### PR TITLE
Add a separate equality judgment (resolve #77)

### DIFF
--- a/src/refiner.cm
+++ b/src/refiner.cm
@@ -46,4 +46,6 @@ is
   refiner/rules/dep_isect.sml
   refiner/rules/void.sig
   refiner/rules/void.sml
+  refiner/rules/eq.sig
+  refiner/rules/eq.sml
   refiner/refiner.sml

--- a/src/refiner.mlb
+++ b/src/refiner.mlb
@@ -39,6 +39,8 @@ local
   refiner/rules/dep_isect.sml
   refiner/rules/void.sig
   refiner/rules/void.sml
+  refiner/rules/eq.sig
+  refiner/rules/eq.sml
   refiner/refiner.sig
   refiner/refiner.sml
 in

--- a/src/refiner/refiner.sml
+++ b/src/refiner/refiner.sml
@@ -24,10 +24,10 @@ struct
         ORELSE EnsembleRules.Intro alpha
         ORELSE PiRules.Intro alpha
         ORELSE TypeRules.Intro alpha
+        ORELSE EqRules.Intro alpha
 
-    fun HypEq alpha (G |> H >> TRUE (P, _)) =
+    fun HypEq alpha (G |> H >> EQ_MEM (m, n, a)) =
       let
-        val (_, m, n, a) = destEq P
         val x = destVar m
         val y = destVar n
         val _ = if Variable.eq (x, y) then () else raise Match
@@ -39,32 +39,29 @@ struct
       end
       | HypEq _ _ = raise Match
 
-    fun Eq r alpha (jdg as _ |> _ >> TRUE (P, _)) =
-      (case out P of
-           CTT (EQ _) $ _ =>
-             (UnivRules.Eq alpha
-               ORELSE BaseRules.TypeEq alpha
-               ORELSE BaseRules.MemberEq alpha
-               ORELSE TopRules.TypeEq alpha
-               ORELSE TopRules.MemberEq alpha
-               ORELSE CEquivRules.TypeEq alpha
-               ORELSE CEquivRules.MemberEq alpha
-               ORELSE SquashRules.TypeEq alpha
-               ORELSE EnsembleRules.TypeEq alpha
-               ORELSE EnsembleRules.MemberEq alpha
-               ORELSE RecordRules.TypeEq alpha
-               ORELSE RecordRules.MemberEq alpha
-               ORELSE AtomRules.TypeEq alpha
-               ORELSE AtomRules.MemberEq alpha
-               ORELSE AtomRules.TestEq alpha
-               ORELSE PiRules.TypeEq alpha
-               ORELSE PiRules.MemberEq alpha
-               ORELSE PiRules.ElimEq alpha
-               ORELSE DepIsectRules.TypeEq alpha
-               ORELSE DepIsectRules.MemberEq alpha
-               ORELSE VoidRules.TypeEq alpha
-               ORELSE HypEq alpha) jdg
-         | _ => raise Fail "Eq not applicable")
+    fun Eq r alpha (jdg as _ |> _ >> EQ_MEM _) =
+          (UnivRules.Eq alpha
+            ORELSE BaseRules.TypeEq alpha
+            ORELSE BaseRules.MemberEq alpha
+            ORELSE TopRules.TypeEq alpha
+            ORELSE TopRules.MemberEq alpha
+            ORELSE CEquivRules.TypeEq alpha
+            ORELSE CEquivRules.MemberEq alpha
+            ORELSE SquashRules.TypeEq alpha
+            ORELSE EnsembleRules.TypeEq alpha
+            ORELSE EnsembleRules.MemberEq alpha
+            ORELSE RecordRules.TypeEq alpha
+            ORELSE RecordRules.MemberEq alpha
+            ORELSE AtomRules.TypeEq alpha
+            ORELSE AtomRules.MemberEq alpha
+            ORELSE AtomRules.TestEq alpha
+            ORELSE PiRules.TypeEq alpha
+            ORELSE PiRules.MemberEq alpha
+            ORELSE PiRules.ElimEq alpha
+            ORELSE DepIsectRules.TypeEq alpha
+            ORELSE DepIsectRules.MemberEq alpha
+            ORELSE VoidRules.TypeEq alpha
+            ORELSE HypEq alpha) jdg
       | Eq _ _ _ = raise Match
 
     fun Ext alpha (jdg as _ |> _ >> TRUE (P, _)) =

--- a/src/refiner/refiner_kit.sml
+++ b/src/refiner/refiner_kit.sml
@@ -163,9 +163,8 @@ struct
         (CTT (UNIV EXP) $ [([],[]) \ lvl],
          EXP)
 
-
     fun makeEqSequent H args =
-      H >> TRUE (makeEq (getMetas H) args, EXP)
+      H >> EQ_MEM args
 
     fun makeMemberSequent H args =
       H >> TRUE (makeMember (getMetas H) args, EXP)

--- a/src/refiner/rules/atom.sml
+++ b/src/refiner/rules/atom.sml
@@ -34,9 +34,8 @@ struct
               ^ DebugShowAbt.toString m
 
 
-  fun TypeEq _ (G |> H >> TRUE (P, _)) =
+  fun TypeEq _ (G |> H >> EQ_MEM (atm1, atm2, univ)) =
     let
-      val (_, atm1, atm2, univ) = destEq P
       val (sigma, lvl) = destUniv univ
       val tau1 = destAtom atm1
       val tau2 = destAtom atm2
@@ -47,9 +46,8 @@ struct
     end
     | TypeEq _ _ = raise Match
 
-  fun MemberEq _ (G |> H >> TRUE (P, _)) =
+  fun MemberEq _ (G |> H >> EQ_MEM (tok1, tok2, atm)) =
     let
-      val (_,tok1,tok2,atm) = destEq P
       val tau = destAtom atm
       val (u1,tau1) = destToken tok1
       val (u2,tau2) = destToken tok2
@@ -64,9 +62,8 @@ struct
     end
     | MemberEq _ _ = raise Match
 
-  fun TestEq alpha (G |> H >> TRUE (P, _)) =
+  fun TestEq alpha (G |> H >> EQ_MEM (test1, test2, a)) =
     let
-      val (_, test1, test2, a) = destEq P
       val (sigma, tau, t1, t2, yes, no) = destTest test1
       val (sigma', tau', t1', t2', yes', no') = destTest test2
 

--- a/src/refiner/rules/base.sml
+++ b/src/refiner/rules/base.sml
@@ -14,9 +14,8 @@ struct
              @@ "Expected Base but got "
               ^ DebugShowAbt.toString m
 
-  fun TypeEq alpha (G |> H >> TRUE (P, _)) =
+  fun TypeEq alpha (G |> H >> EQ_MEM (m, n, a)) =
     let
-      val (tau, m,n,a) = destEq P
       val (tau1, tau2) = (destBase m, destBase n)
       val i = destUniv a
     in
@@ -25,10 +24,8 @@ struct
     end
     | TypeEq _ _ = raise Match
 
-  fun MemberEq alpha (G |> H >> TRUE (P, _)) =
+  fun MemberEq alpha (G |> H >> EQ_MEM (m, n, a)) =
     let
-      val (tau, m,n,a) = destEq P
-
       val tau = destBase a
       val subgoals =
         VarCtx.foldl

--- a/src/refiner/rules/cequiv.sml
+++ b/src/refiner/rules/cequiv.sml
@@ -5,9 +5,8 @@ struct
   infix 4 >>
   infix 3 |>
 
-  fun TypeEq _ (G |> H >> TRUE (P, _)) =
+  fun TypeEq _ (G |> H >> EQ_MEM (ceq1, ceq2, univ)) =
     let
-      val (_, ceq1, ceq2, univ) = destEq P
       val i = destUniv univ
       val (tau1, m1, n1) = destCEquiv ceq1
       val (tau2, m2, n2) = destCEquiv ceq2
@@ -28,9 +27,8 @@ struct
     end
     | TypeEq _ _ = raise Match
 
-  fun MemberEq _ (G |> H >> TRUE (P, _)) =
+  fun MemberEq _ (G |> H >> EQ_MEM (m, n, ty)) =
     let
-      val (_, m, n, ty) = destEq P
       val _ = destCEquiv ty
       val _ = destAx m
       val _ = destAx n

--- a/src/refiner/rules/dep_isect.sml
+++ b/src/refiner/rules/dep_isect.sml
@@ -13,9 +13,8 @@ struct
   val TypeEq =
     QuantifierKit.TypeEq (CTT DEP_ISECT)
 
-  fun MemberEq alpha (G |> H >> TRUE (P, _)) =
+  fun MemberEq alpha (G |> H >> EQ_MEM (m1, m2, ty)) =
     let
-      val (_, m1, m2, ty) = destEq P
       val (a, x, bx) = destDepIsect ty
       val bm1 = subst (m1, x) bx
 

--- a/src/refiner/rules/ensemble.sml
+++ b/src/refiner/rules/ensemble.sml
@@ -14,9 +14,8 @@ struct
              @@ "Expected Ensemble but got "
               ^ DebugShowAbt.toString m
 
-  fun TypeEq alpha (goal as (G |> H >> TRUE (P, _))) =
+  fun TypeEq alpha (goal as (G |> H >> EQ_MEM (s1, s2, univ))) =
     let
-      val (_,s1,s2,univ) = destEq P
       val (sigma1, tau1, a1, x1, b1) = destEnsemble s1
       val (sigma1, tau1, a2, x2, b2) = destEnsemble s2
     in
@@ -24,9 +23,8 @@ struct
     end
     | TypeEq _ _ = raise Match
 
-  fun MemberEq alpha (G |> H >> TRUE (P, _)) =
+  fun MemberEq alpha (G |> H >> EQ_MEM (m1, m2, ensemble)) =
     let
-      val (_, m1, m2, ensemble) = destEq P
       val (tau1, tau2, a, x, b) = destEnsemble ensemble
 
       val (tyGoal, _, H) =

--- a/src/refiner/rules/eq.sig
+++ b/src/refiner/rules/eq.sig
@@ -1,0 +1,4 @@
+signature EQ_RULES =
+sig
+  val Intro : RefinerKit.ntactic
+end

--- a/src/refiner/rules/eq.sml
+++ b/src/refiner/rules/eq.sml
@@ -1,0 +1,22 @@
+structure EqRules : EQ_RULES =
+struct
+  open RefinerKit OperatorData CttOperatorData SortData
+  infix @@ $ \ @>
+  infix 2 //
+  infix 4 >>
+  infix 3 |>
+
+  fun Intro alpha (G |> H >> TRUE (P, _)) =
+    let
+      val (_, m, n, a) = destEq P
+      val (goal, _, _) =
+        makeGoal @@
+          G |> H >> EQ_MEM (m, n, a)
+      val psi = T.empty @> goal
+    in
+      (psi, fn rho =>
+         T.lookup rho (#1 goal))
+    end
+    | Intro _ _ = raise Match
+
+end

--- a/src/refiner/rules/pi.sml
+++ b/src/refiner/rules/pi.sml
@@ -33,9 +33,8 @@ struct
 
   val TypeEq = QuantifierKit.TypeEq (CTT DFUN)
 
-  fun MemberEq alpha (G |> H >> TRUE (P, _)) =
+  fun MemberEq alpha (G |> H >> EQ_MEM (lam1, lam2, dfun)) =
     let
-      val (_, lam1, lam2, dfun) = destEq P
       val (a, x, bx) = destDFun dfun
       val (y1, m1) = destLam lam1
       val (y2, m2) = destLam lam2
@@ -64,9 +63,8 @@ struct
     end
     | MemberEq _ _ = raise Match
 
-  fun ElimEq alpha (G |> H >> TRUE (P, _)) =
+  fun ElimEq alpha (G |> H >> EQ_MEM (ap1, ap2, c)) =
     let
-      val (_, ap1, ap2, c) = destEq P
       val (m1, n1) = destAp ap1
       val (m2, n2) = destAp ap2
 
@@ -194,9 +192,8 @@ struct
     end
     | Elim _ _ _ = raise Match
 
-  fun Ext alpha (jdg as G |> H >> TRUE (P, _)) =
+  fun Ext alpha (jdg as G |> H >> EQ_MEM (f, g, dfun)) =
     let
-      val (_, f, g, dfun) = destEq P
       val (a, x, bx) = destDFun dfun
 
       val z = alpha 0

--- a/src/refiner/rules/quantifier_kit.sml
+++ b/src/refiner/rules/quantifier_kit.sml
@@ -25,9 +25,8 @@ struct
            ^ DebugShowAbt.toString m
   end
 
-  fun TypeEq theta alpha (G |> H >> TRUE (P, _)) =
+  fun TypeEq theta alpha (G |> H >> EQ_MEM (quant1, quant2, univ)) =
     let
-      val (_, quant1, quant2, univ) = destEq P
       val _ = destUniv univ
       val (a1, x, b1x) = destQuantifier theta quant1
       val (a2, y, b2y) = destQuantifier theta quant2

--- a/src/refiner/rules/record.sml
+++ b/src/refiner/rules/record.sml
@@ -27,9 +27,8 @@ struct
       (metactx m)
       (RCD (PROJ lbl) $ [([],[]) \ m], EXP)
 
-  fun TypeEq alpha (G |> H >> TRUE (P, _)) =
+  fun TypeEq alpha (G |> H >> EQ_MEM (ty1, ty2, univ)) =
     let
-      val (_,ty1,ty2,univ) = destEq P
       val (tau, lvl) = destUniv univ
       val _ = if Sort.eq (tau, EXP) then () else raise Match
 
@@ -58,9 +57,8 @@ struct
     end
     | TypeEq _ _ = raise Match
 
-  fun MemberEq alpha (G |> H >> TRUE (P, _)) =
+  fun MemberEq alpha (G |> H >> EQ_MEM (rcd1, rcd2, ty)) =
     let
-      val (_, rcd1, rcd2, ty) = destEq P
       val (lbl, a, x, bx) = destRecord ty
 
       val proj1 = makeProj lbl rcd1
@@ -82,9 +80,8 @@ struct
     end
     | MemberEq _ _ = raise Match
 
-  fun ProjEq alpha (G |> H >> TRUE (P, _)) =
+  fun ProjEq alpha (G |> H >> EQ_MEM (p1, p2, ty)) =
     let
-      val (_, p1, p2, ty) = destEq P
       val (lbl1, rcd1) = destProj p1
       val (lbl2, rcd2) = destProj p2
       val _ = if Symbol.eq (lbl1, lbl2) then () else raise Match

--- a/src/refiner/rules/squash.sml
+++ b/src/refiner/rules/squash.sml
@@ -14,12 +14,11 @@ struct
              @@ "Expected Squash but got "
               ^ DebugShowAbt.toString m
 
-  fun TypeEq _ (G |> H >> TRUE (P, _)) =
+  fun TypeEq _ (G |> H >> EQ_MEM (a,b,univ)) =
     let
-      val (tau,a,b,univ) = destEq P
       val (_, a') = destSquash a
       val (_, b') = destSquash b
-      val _ = destUniv univ
+      val (tau, _) = destUniv univ
       val eq =
         check
           (getMetas H)
@@ -47,16 +46,15 @@ struct
     end
     | Intro _ _ = raise Match
 
-  fun Unhide h _ (G |> H >> TRUE (P, tau)) =
+  fun Unhide h _ (G |> H >> EQ_MEM (m, n, a)) =
     let
-      val _ = destEq P
       val (Q, sigma) = Ctx.lookup (getHyps H) h
       val (tau', Q') = destSquash Q
       val H' = updateHyps (Ctx.modify h (fn _ => (Q', tau'))) H
 
       val (goal, _, _) =
         makeGoal @@
-          [] |> H' >> TRUE (P, tau)
+          [] |> H' >> EQ_MEM (m, n, a)
 
       val psi = T.empty @> goal
     in

--- a/src/refiner/rules/top.sml
+++ b/src/refiner/rules/top.sml
@@ -14,9 +14,8 @@ struct
              @@ "Expected Top but got "
               ^ DebugShowAbt.toString m
 
-  fun TypeEq alpha (G |> H >> TRUE (P, _)) =
+  fun TypeEq alpha (G |> H >> EQ_MEM (m, n, a)) =
     let
-      val (tau, m,n,a) = destEq P
       val (tau1, tau2) = (destTop m, destTop n)
       val i = destUniv a
     in
@@ -25,9 +24,8 @@ struct
     end
     | TypeEq _ _ = raise Match
 
-  fun MemberEq alpha (G |> H >> TRUE (P, _)) =
+  fun MemberEq alpha (G |> H >> EQ_MEM (_, _, a)) =
     let
-      val (_,_,_,a) = destEq P
       val _ = destTop a
     in
       (T.empty, fn rho =>

--- a/src/refiner/rules/univ.sml
+++ b/src/refiner/rules/univ.sml
@@ -83,10 +83,8 @@ struct
               ^ " < "
               ^ DebugShowAbt.toString j
 
-  fun Eq alpha (G |> H >> TRUE (P, _)) =
+  fun Eq alpha (G |> H >> EQ_MEM (m, n, a)) =
     let
-      val (tau, m, n, a) = destEq P
-      val () = if tau = EXP then () else raise Fail "Expected exp"
       val ((tau1, i), (tau2, j), (tau3, k)) = (destUniv m, destUniv n, destUniv a)
       val () = if tau1 = tau2 andalso tau2 = tau3 then () else raise Fail "Sort mismatch"
       val () = assertLevelEq (i, j)
@@ -97,10 +95,8 @@ struct
     end
     | Eq _ _ = raise Match
 
-  fun Cum alpha (G |> H >> TRUE (P, _)) =
+  fun Cum alpha (G |> H >> EQ_MEM (m, n, a)) =
     let
-      val (tau, m, n, a) = destEq P
-      val () = if tau = EXP then () else raise Fail "Expected exp"
       val (tau, i) = destUniv a
       val j = destLSucc i
       val univ =

--- a/src/refiner/rules/void.sml
+++ b/src/refiner/rules/void.sml
@@ -13,9 +13,8 @@ struct
              @@ "Expected Void but got "
               ^ DebugShowAbt.toString m
 
-  fun TypeEq _ (G |> H >> TRUE (P, _)) =
+  fun TypeEq _ (G |> H >> EQ_MEM (void1, void2, univ)) =
     let
-      val (_, void1, void2, univ) = destEq P
       val _ = destUniv univ
       val _ = destVoid void1
       val _ = destVoid void2

--- a/src/refiner/target.sml
+++ b/src/refiner/target.sml
@@ -14,6 +14,7 @@ struct
   fun mapConcl f =
     fn TRUE (p, tau) => TRUE (f p, tau)
      | TYPE (p, tau) => TYPE (f p, tau)
+     | EQ_MEM (m, n, a) => EQ_MEM (f m, f n, f a)
 
   fun targetRewrite f target (G |> H >> concl) =
     case target of

--- a/src/syntax/sequent.sig
+++ b/src/syntax/sequent.sig
@@ -1,6 +1,7 @@
 signature SEQUENT =
 sig
   type prop
+  type expr
   type sort
   type var
 
@@ -22,6 +23,7 @@ sig
   datatype concl =
       TRUE of prop * sort
     | TYPE of prop * sort
+    | EQ_MEM of expr * expr * prop
 
   datatype sequent =
       >> of context * concl

--- a/src/syntax/sequent.sml
+++ b/src/syntax/sequent.sml
@@ -1,4 +1,5 @@
 structure Sequent :> SEQUENT
+  where type expr = Abt.abt
   where type prop = Abt.abt
   where type sort = Abt.sort
   where type var = Abt.variable
@@ -7,6 +8,7 @@ structure Sequent :> SEQUENT
   where type hypctx = (Abt.abt * Abt.sort) SymbolTelescope.telescope =
 struct
   type prop = Abt.abt
+  type expr = Abt.abt
   type sort = Abt.sort
   type var = Abt.variable
 
@@ -61,6 +63,7 @@ struct
   datatype concl =
       TRUE of prop * sort
     | TYPE of prop * sort
+    | EQ_MEM of expr * expr * prop
 
   (* The meaning of the sequent with respect to its context of metavariables is
    * essentially the following: If the metavariables are replaced by closed abstractions
@@ -75,8 +78,9 @@ struct
   infix 3 |>
 
   val conclToString =
-    fn TRUE (P, tau) => ShowAbt.toString P ^ " true"
-     | TYPE (P, tau) => ShowAbt.toString P ^ " type"
+    fn TRUE (a, tau) => ShowAbt.toString a ^ " true"
+     | TYPE (a, tau) => ShowAbt.toString a ^ " type"
+     | EQ_MEM (m, n, a) => ShowAbt.toString m ^ " = " ^ ShowAbt.toString n ^ " : " ^ ShowAbt.toString a
 
   fun hypothesesToString H =
     let

--- a/testsuite/tests/example.prl
+++ b/testsuite/tests/example.prl
@@ -58,12 +58,12 @@ Thm extractTest[z:exp] : [~(extract(example[z]); Ax)] by [
 ].
 
 Thm univTest(i : lvl) : [=(Univ(i); Univ(i); Univ(lsuc(i)))] by [
-  eq
+  bang
 ].
 
 
 Thm baseTypeEq(i : lvl) : [=(Base; Base; Univ(i))] by [
-  eq
+  bang
 ].
 
 Tac crefl = [
@@ -71,7 +71,7 @@ Tac crefl = [
 ].
 
 Thm baseMemberEq : [=(Ax; Ax; Base)] by [
-  eq; crefl
+  bang
 ].
 
 // Ensembles, or subtype comprehensions, are types that restrict the inhabitants of
@@ -83,7 +83,7 @@ Def ensembleExample : exp = [
 ].
 
 Thm ensembleTest : [member(Ax; {x : Base | ~(x; Ax) })] by [
-  repeat(auto)
+  bang
 ].
 
 Thm demo : [{x : Base | ~(x; Ax)}] by [
@@ -114,12 +114,12 @@ Thm lamTest : [fun(Atom; Atom)] by [
 
 Thm apEqTest : [member(ap(lam([x].x); 'mysym); Atom)] by [
   auto;
-  l <- eq;
+  l <- intro; eq;
   [ witness{lvl} [lbase]
   , witness [Atom]
   , witness [Atom]
   ];
-  repeat(auto)
+  bang
 ].
 
 Sym foo : lbl.
@@ -164,8 +164,7 @@ Def Monoid(i : lvl) : exp = [
 ].
 
 Thm MonoidStructWf(i : lvl) : [member(MonoidStruct(i); Univ(lsuc(i)))] by [
-  bang;
-  cum; auto
+  bang; cum; auto
 ].
 
 


### PR DESCRIPTION
This is nice, because we extend the judgment, but the propositional equality is defined all at once in terms of the judgmental equality (as it should be!). "propositional equality defined at each type" is such nonsense!