### PR TITLE
Revamp records; don't use dep-isect as primitive representation

### DIFF
--- a/src/refiner/refiner.sml
+++ b/src/refiner/refiner.sml
@@ -52,7 +52,7 @@ struct
           | Syn.ENSEMBLE _ => EnsembleRules.IsType alpha goal
           | Syn.DEP_ISECT _ => DepIsectRules.IsType alpha goal
           | Syn.CEQUIV _ => CEquivRules.IsType alpha goal
-          | Syn.RCD_SINGL _ => RecordRules.IsType alpha goal
+          | Syn.RECORD_TY _ => RecordRules.IsType alpha goal
           | Syn.UNIV _ => UnivRules.IsType alpha goal
           | Syn.EQ _ => EqRules.IsType alpha goal
           | _ => raise Match)
@@ -77,10 +77,9 @@ struct
           | Syn.ENSEMBLE _ => EnsembleRules.Intro alpha goal
           | Syn.DFUN _ => PiRules.Intro alpha goal
           | Syn.EQ _ => EqRules.Intro alpha goal
-          | Syn.RCD_SINGL _ => RecordRules.IntroSingl alpha goal
-          | Syn.RECORD_TY _ => RecordRules.IntroRecord alpha goal
-          | _ => raise Match
-          )
+          | Syn.RECORD_TY _ => RecordRules.Intro alpha goal
+          | Syn.TOP SortData.EXP => TopRules.IntroTrivial alpha goal
+          | _ => raise Match)
       | Intro alpha (goal as H >> MEM _) = MemRules.Intro alpha goal
       | Intro _ _ = raise Match
 
@@ -99,8 +98,8 @@ struct
         | (Syn.APP (Syn.SQUASH _), _, _) => SquashRules.TypeEq alpha goal
         | (Syn.APP (Syn.ENSEMBLE _), _, _) => EnsembleRules.TypeEq alpha goal
         | (_, _, Syn.ENSEMBLE _) => EnsembleRules.MemberEq alpha goal
-        | (Syn.APP (Syn.RCD_SINGL _), _, _) => RecordRules.TypeEq alpha goal
-        | (_, _, Syn.RCD_SINGL _) => RecordRules.MemberEq alpha goal
+        | (Syn.APP (Syn.RECORD_TY _), _, _) => RecordRules.TypeEq alpha goal
+        | (_, _, Syn.RECORD_TY _) => RecordRules.MemberEq alpha goal
         | (Syn.APP (Syn.ATOM _), _, _) => AtomRules.TypeEq alpha goal
         | (_, _, Syn.ATOM _) => AtomRules.MemberEq alpha goal
         | (Syn.APP (Syn.IF_EQ _), _, _) => AtomRules.TestEq alpha goal

--- a/src/refiner/refiner_kit.sml
+++ b/src/refiner/refiner_kit.sml
@@ -110,8 +110,8 @@ struct
     fun makeEqSequent H args =
       H >> EQ_MEM args
 
-    fun makeMemberSequent H (m, a) =
-      H >> TRUE (Syn.into (Syn.MEMBER (getAtomicSort m, m, a)), EXP)
+    fun makeMemberSequent H args =
+      H >> MEM args
 
     fun makeLevelSequent (H : Sequent.context) =
       let

--- a/src/refiner/rules/record.sig
+++ b/src/refiner/rules/record.sig
@@ -3,7 +3,6 @@ sig
   val IsType : RefinerKit.ntactic
   val TypeEq : RefinerKit.ntactic
   val MemberEq : RefinerKit.ntactic
-  val IntroRecord : RefinerKit.ntactic
-  val IntroSingl : RefinerKit.ntactic
+  val Intro : RefinerKit.ntactic
   val ProjSynth : RefinerKit.ntactic
 end

--- a/src/refiner/rules/record.sml
+++ b/src/refiner/rules/record.sml
@@ -7,35 +7,38 @@ struct
   infix 3 >>
   infix 2 |>
 
-  fun IsType alpha (goal as (H >> TYPE (ty, EXP))) =
+  val IsType =
+    QuantifierKit.IsType (fn ty =>
+      let
+        val Syn.RECORD_TY (lbl, a, x, bx) = Syn.out ty
+      in
+        (a, x, bx)
+      end)
+
+  fun TypeEq alpha (H >> EQ_MEM (rcd1, rcd2, univ)) =
     let
-      val Syn.RCD_SINGL (lbl, a) = Syn.out ty
+      val Syn.UNIV _ = Syn.out univ
+      val Syn.RECORD_TY (lbl1, a1, x, b1x) = Syn.out rcd1
+      val Syn.RECORD_TY (lbl2, a2, y, b2y) = Syn.out rcd2
 
-      val (goalA, holeA, H') =
-        makeGoal @@
-          H >> TYPE (a, EXP)
-
-      val psi = T.empty @> goalA
-    in
-      (psi, fn rho =>
-          T.lookup rho (#1 goalA))
-    end
-    | IsType _ _ = raise Match
-
-  fun TypeEq alpha (H >> EQ_MEM (ty1, ty2, univ)) =
-    let
-      val Syn.UNIV (tau, lvl) = Syn.out univ
-      val _ = if tau = EXP then () else raise Match
-
-      val Syn.RCD_SINGL (lbl1, a1) = Syn.out ty1
-      val Syn.RCD_SINGL (lbl2, a2) = Syn.out ty2
       val _ = if Symbol.eq (lbl1, lbl2) then () else raise Match
 
-      val (goal, _, _) =
+      val (goal1, _, H) =
         makeGoal @@
-          makeEqSequent H (a1, a2, Syn.into @@ Syn.UNIV (EXP, lvl))
+          makeEqSequent H (a1,a2,univ)
 
-      val psi = T.empty @> goal
+      val z = alpha 0
+      val ztm = check (`z, RS.EXP SortData.EXP)
+      val b1z = subst (ztm, x) b1x
+      val b2z = subst (ztm, y) b2y
+
+      val H' = updateHyps (fn xs => Ctx.snoc xs z (a1, SortData.EXP)) H
+
+      val (goal2, _, H') =
+        makeGoal @@
+          [(z, SortData.EXP)] |> makeEqSequent H' (b1z, b2z, univ)
+
+      val psi = T.empty @> goal1 @> goal2
     in
       (psi, fn rho =>
         abtToAbs @@ Syn.into Syn.AX)
@@ -44,98 +47,55 @@ struct
 
   fun MemberEq alpha (H >> EQ_MEM (rcd1, rcd2, ty)) =
     let
-      val Syn.RCD_SINGL (lbl, a) = Syn.out ty
-
+      val Syn.RECORD_TY (lbl, a, x, bx) = Syn.out ty
       val proj1 = Syn.into @@ Syn.RCD_PROJ (lbl, rcd1)
       val proj2 = Syn.into @@ Syn.RCD_PROJ (lbl, rcd2)
 
-      val (goal, _, _) =
+      val (goal1, _, _) =
         makeGoal @@
           makeEqSequent H (proj1, proj2, a)
 
-      val psi = T.empty @> goal
+      val (goal2, _, _) =
+        makeGoal @@
+          makeEqSequent H (rcd1, rcd2, subst (proj1, x) bx)
+
+      val psi = T.empty @> goal1 @> goal2
     in
       (psi, fn rho =>
-        abtToAbs @@ Syn.into Syn.AX)
+         abtToAbs @@ Syn.into Syn.AX)
     end
-    | MemberEq _ _ = raise Match
+  | MemberEq _ _ = raise Match
 
-
-  fun accumulateRecordGoals H ty =
-    case Syn.out ty of
-       Syn.RECORD_TY (lbl, a, x, bx) =>
-         let
-           val singl = Syn.into @@ Syn.RCD_SINGL (lbl, a)
-           val ((goalName, goal), goalHole, H') = makeGoal @@ H >> TRUE (singl, EXP)
-           val proj = Syn.into @@ Syn.RCD_PROJ (lbl, goalHole [] [])
-           val b' = subst (proj, x) bx
-         in
-           (goalName, (lbl, goal)) <@ accumulateRecordGoals H' b'
-         end
-     | Syn.TOP _ => T.empty
-     | _ => raise Fail "Could not match record type"
-
-  fun IntroRecord alpha (H >> TRUE (ty, _)) =
+  fun Intro alpha (H >> TRUE (ty, EXP)) =
     let
-      val psi = accumulateRecordGoals H ty
-    in
-      (T.map #2 psi, fn rho =>
-        let
-          fun go t =
-            let
-              open T.ConsView
-            in
-              case out t of
-                 EMPTY => Syn.into Syn.AX
-               | CONS (x, (lbl, _), t) =>
-                   let
-                     val m = T.lookup rho x // ([],[])
-                     val proj = Syn.into @@ Syn.RCD_PROJ (lbl, m)
-                   in
-                     Syn.into @@ Syn.RCD_CONS (lbl, proj, go t)
-                   end
-            end
-        in
-          abtToAbs @@ go psi
-        end)
-    end
-    | IntroRecord _ _ = raise Match
+      val Syn.RECORD_TY (lbl, a, x, bx) = Syn.out ty
+      val (goalA, holeA, H') = makeGoal @@ H >> TRUE (a, EXP)
+      val b' = subst (holeA [] [], x) bx
 
-  fun IntroSingl alpha (H >> TRUE (ty, tau)) =
-    let
-      val Syn.RCD_SINGL (lbl, a) = Syn.out ty
-      val (goal, _, _) = makeGoal @@ H >> TRUE (a, tau)
-      val psi = T.empty @> goal
+      val (goalB, _, _) = makeGoal @@ H' >> TRUE (b', EXP)
+      val psi = T.empty @> goalA @> goalB
     in
       (psi, fn rho =>
          let
-           val m = T.lookup rho (#1 goal) // ([],[])
+           val hd = T.lookup rho (#1 goalA) // ([],[])
+           val tl = T.lookup rho (#1 goalB) // ([],[])
          in
-           abtToAbs @@ Syn.into @@ Syn.RCD_CONS (lbl, m, Syn.into Syn.AX)
+           abtToAbs @@ Syn.into @@ Syn.RCD_CONS (lbl, hd, tl)
          end)
     end
-    | IntroSingl _ _ = raise Match
+    | Intro _ _ = raise Match
 
-  (* TODO: account for case where R synth ~> rs, with rs some not-necessarily-singleton record type. *)
-
-  (* H >> R.lbl synth ~> A
-   *   H >> R synth ~> singl[lbl](A)
-   *)
-  fun ProjSynth alpha (H >> SYN p) =
+  fun ProjSynth alpha (H >> SYN proj) =
     let
-      val Syn.RCD_PROJ (lbl, rcd) = Syn.out p
-
-      val (tyGoal, tyHole, H') =
-        makeGoal @@
-          H >> SYN rcd
-
+      val Syn.RCD_PROJ (lbl, rcd) = Syn.out proj
+      val (tyGoal, tyHole, H') = makeGoal @@ H >> SYN rcd
       val psi = T.empty @> tyGoal
     in
       (psi, fn rho =>
         let
           val ty = T.lookup rho (#1 tyGoal) // ([],[])
         in
-          abtToAbs @@ Syn.into @@ Syn.SINGL_GET_TY ty
+          abtToAbs @@ Syn.into @@ Syn.RCD_PROJ_TY (lbl, ty, rcd)
         end)
     end
     | ProjSynth _ _ = raise Match

--- a/src/refiner/rules/top.sig
+++ b/src/refiner/rules/top.sig
@@ -3,4 +3,6 @@ sig
   val IsType : RefinerKit.ntactic
   val TypeEq : RefinerKit.ntactic
   val MemberEq : RefinerKit.ntactic
+
+  val IntroTrivial : RefinerKit.ntactic
 end

--- a/src/refiner/rules/top.sml
+++ b/src/refiner/rules/top.sml
@@ -35,4 +35,13 @@ struct
         abtToAbs @@ Syn.into Syn.AX)
     end
     | MemberEq _ _ = raise Match
+
+  fun IntroTrivial alpha (H >> TRUE (ty, EXP)) =
+    let
+      val Syn.TOP EXP = Syn.out ty
+    in
+      (T.empty, fn rho =>
+         abtToAbs @@ Syn.into Syn.AX)
+    end
+    | IntroTrivial _ _ = raise Match
 end

--- a/src/syntax/operator/record.sml
+++ b/src/syntax/operator/record.sml
@@ -2,14 +2,15 @@ structure RecordOperators =
 struct
   datatype 'i rcd_val =
      CONS of 'i
-   | SINGL of 'i
+   | RECORD of 'i
 
   datatype 'i rcd_cont =
      PROJ of 'i
-   | SINGL_GET_TY
+   | PROJ_TY of 'i
 
   datatype 'i rcd_def =
-     RECORD of 'i
+     SINGL of 'i
+
 end
 
 structure RecordV : JSON_ABT_OPERATOR =
@@ -23,34 +24,34 @@ struct
 
   val arity =
     fn CONS lbl => [[] * [] <> EXP, [] * [] <> EXP] ->> EXP
-     | SINGL lbl => [[] * [] <> EXP] ->> EXP
+     | RECORD lbl => [[] * [] <> EXP, [] * [EXP] <> EXP] ->> EXP
 
   val support =
     fn CONS lbl => [(lbl, RCD_LBL)]
-     | SINGL lbl => [(lbl, RCD_LBL)]
+     | RECORD lbl => [(lbl, RCD_LBL)]
 
   fun eq f =
     fn (CONS l1, CONS l2) => f (l1, l2)
-     | (SINGL l1, SINGL l2) => f (l1, l2)
+     | (RECORD l1, RECORD l2) => f (l1, l2)
      | _ => false
 
   fun toString f =
     fn CONS lbl => "rcons[" ^ f lbl ^ "]"
-     | SINGL lbl => "rsing[" ^ f lbl ^ "]"
+     | RECORD lbl => "rcd[" ^ f lbl ^ "]"
 
   fun map f =
     fn CONS lbl => CONS (f lbl)
-     | SINGL lbl => SINGL (f lbl)
+     | RECORD lbl => RECORD (f lbl)
 
   structure J = Json and S = RedPrlAtomicSortJson
 
   fun encode f =
     fn CONS lbl => J.Obj [("cons", f lbl)]
-     | SINGL lbl => J.Obj [("singl", f lbl)]
+     | RECORD lbl => J.Obj [("rcd", f lbl)]
 
   fun decode f =
     fn J.Obj [("cons", lbl)] => Option.map CONS (f lbl)
-     | J.Obj [("singl", lbl)] => Option.map SINGL (f lbl)
+     | J.Obj [("rcd", lbl)] => Option.map RECORD (f lbl)
      | _ => NONE
 end
 
@@ -70,38 +71,39 @@ struct
 
   val arity =
     fn PROJ lbl => [] ->> EXP
-     | SINGL_GET_TY => [] ->> EXP
+     | PROJ_TY lbl => [[] * [] <> EXP] ->> EXP
 
   val input =
     fn PROJ _ => EXP
-     | SINGL_GET_TY => EXP
+     | PROJ_TY _ => EXP
 
   val support =
     fn PROJ lbl => [(lbl, RCD_LBL)]
-     | SINGL_GET_TY => []
+     | PROJ_TY lbl => [(lbl, RCD_LBL)]
 
   fun eq f =
     fn (PROJ l1, PROJ l2) => f (l1, l2)
-     | (SINGL_GET_TY, SINGL_GET_TY) => true
+     | (PROJ_TY l1, PROJ_TY l2) => f (l1, l2)
      | _ => false
+
 
   fun toString f =
     fn PROJ lbl => "rproj[" ^ f lbl ^ "]"
-     | SINGL_GET_TY => "singl-get-ty"
+     | PROJ_TY lbl => "rproj-ty[" ^ f lbl ^ "]"
 
   fun map f =
     fn PROJ lbl => PROJ (f lbl)
-     | SINGL_GET_TY => SINGL_GET_TY
+     | PROJ_TY lbl => PROJ_TY (f lbl)
 
   structure J = Json and S = RedPrlAtomicSortJson
 
   fun encode f =
     fn PROJ lbl => J.Obj [("proj", f lbl)]
-     | SINGL_GET_TY => J.String "singl_get_ty"
+     | PROJ_TY lbl => J.Obj [("proj-ty", f lbl)]
 
   fun decode f =
     fn J.Obj [("proj", lbl)] => Option.map PROJ (f lbl)
-     | J.String "singl_get_ty" => SOME SINGL_GET_TY
+     | J.Obj [("proj-ty", lbl)] => Option.map PROJ_TY (f lbl)
      | _ => NONE
 end
 
@@ -114,28 +116,25 @@ struct
 
   infix <> ->>
 
-  fun arity (RECORD lbl) =
-    [[] * [] <> EXP,
-     [] * [EXP] <> EXP]
-       ->> EXP
+  fun arity (SINGL lbl) = [[] * [] <> EXP] ->> EXP
 
-  fun support (RECORD lbl) =
+  fun support (SINGL lbl) =
     [(lbl, RCD_LBL)]
 
   fun eq  _ _ = true
 
-  fun toString f (RECORD lbl) =
-    "rcd[" ^ f lbl ^ "]"
+  fun toString f (SINGL lbl) =
+    "singl[" ^ f lbl ^ "]"
 
-  fun map f (RECORD lbl) =
-    RECORD (f lbl)
+  fun map f (SINGL lbl) =
+    SINGL (f lbl)
 
   structure J = Json and S = RedPrlAtomicSortJson
 
-  fun encode f (RECORD lbl) =
-    J.Obj [("record", f lbl)]
+  fun encode f (SINGL lbl) =
+    J.Obj [("singl", f lbl)]
 
   fun decode f =
-    fn J.Obj [("record", lbl)] => Option.map RECORD (f lbl)
+    fn J.Obj [("singl", lbl)] => Option.map SINGL (f lbl)
      | _ => NONE
 end

--- a/src/syntax/syntax.fun
+++ b/src/syntax/syntax.fun
@@ -21,6 +21,8 @@ sig
   val $$ : symbol operator * term bview spine -> term
   val out : term -> term view
 
+  val variable : string -> variable
+
   val debugToString : term -> string
 end
 
@@ -33,6 +35,7 @@ struct
 
   structure Show = DebugShowAbt (Abt)
   val debugToString = Show.toString
+  val variable = Var.named
 end
 
 functor AstSyntaxView (Ast : AST where type 'a spine = 'a list) : SYNTAX_VIEW =
@@ -45,6 +48,8 @@ struct
   type 'a spine = 'a Ast.spine
 
   type term = Ast.ast
+
+  fun variable x = x
 
   datatype 'a bview =
      \ of (symbol spine * variable spine) * 'a
@@ -117,7 +122,7 @@ struct
    | RCD_SINGL of symbol * 'a
    | RECORD_TY of symbol * 'a * variable * 'a
    | RCD_PROJ of symbol * 'a
-   | SINGL_GET_TY of 'a
+   | RCD_PROJ_TY of symbol * 'a * 'a
 
    | REFINE_SCRIPT of RS.sort * 'a * 'a * 'a
    | EXTRACT_WITNESS of RS.sort * 'a
@@ -221,10 +226,11 @@ struct
        | IF_EQ (sigma, tau, t1, t2, m, n) => cutAtm (RS.EXP, tau) (AtomOperators.TEST0 (sigma, tau)) [([],[]) \ t2, ([],[]) \ m, ([],[]) \ n] t1
 
        | RCD_CONS (u, m, n) => intoRcdV (RecordOperators.CONS u) [([],[]) \ m, ([],[]) \ n]
-       | RCD_SINGL (u, m) => intoRcdV (RecordOperators.SINGL u) [([],[]) \ m]
-       | RECORD_TY (u, a, x, bx) => intoRcdD (RecordOperators.RECORD u) [([],[]) \ a, ([],[x]) \ bx]
+       | RCD_SINGL (u, a) => intoRcdD (RecordOperators.SINGL u) [([],[]) \ a]
+
+       | RECORD_TY (u, a, x, bx) => intoRcdV (RecordOperators.RECORD u) [([],[]) \ a, ([],[x]) \ bx]
        | RCD_PROJ (u, m) => cutRcd (RecordOperators.PROJ u) [] m
-       | SINGL_GET_TY a => cutRcd RecordOperators.SINGL_GET_TY [] a
+       | RCD_PROJ_TY (u, a, m) => cutRcd (RecordOperators.PROJ_TY u) [([],[]) \ m] a
 
        | REFINE_SCRIPT (tau, m, s, e) => ret (RS.THM tau) @@ O.V (REFINE tau) $$ [([],[]) \ m, ([],[]) \ s, ([],[]) \ e]
        | EXTRACT_WITNESS (tau, m) => O.CUT (RS.THM tau, tau) $$ [([],[]) \ O.K (EXTRACT tau) $$ [], ([],[]) \ m]
@@ -294,7 +300,7 @@ struct
          | O.V (ATM_V (AtomOperators.TOKEN (u, tau))) $ _ => TOKEN (u, tau)
 
          | O.V (RCD_V (RecordOperators.CONS u)) $ [_ \ m, _ \ n] => RCD_CONS (u, m, n)
-         | O.V (RCD_V (RecordOperators.SINGL u)) $ [_ \ a] =>  RCD_SINGL (u, a)
+         | O.V (RCD_V (RecordOperators.RECORD u)) $ [_ \ a, (_,[x]) \ bx] => RECORD_TY (u, a, x, bx)
 
          | O.V (VEC_LIT (tau, _)) $ es => VEC_LITERAL (tau, List.map (fn _ \ m => m) es)
          | O.V (STR_LIT str) $ _ => STR_LITERAL str
@@ -350,7 +356,7 @@ struct
          | O.K (ATM_K (AtomOperators.TEST0 (sigma, tau))) $ [_ \ t2, _ \ l, _ \ r] => IF_EQ (sigma, tau, m, t2, l, r)
          | O.K (ATM_K (AtomOperators.TEST1 ((u, sigma), tau))) $ [_ \ l, _ \ r] => IF_EQ (sigma, tau, into (TOKEN (u, sigma)), m, l, r)
          | O.K (RCD_K (RecordOperators.PROJ u)) $ [] => RCD_PROJ (u, m)
-         | O.K (RCD_K RecordOperators.SINGL_GET_TY) $ [] => SINGL_GET_TY m
+         | O.K (RCD_K (RecordOperators.PROJ_TY u)) $ [_ \ rcd] => RCD_PROJ_TY (u, m, rcd)
          | O.K (EXTRACT tau) $ [_ \ m] => EXTRACT_WITNESS (tau, m)
          | O.K (CATCH a) $ [(_,[x]) \ nx] => TRY (a, m, x, nx)
          | O.K THROW $ _ => RAISE m
@@ -361,10 +367,10 @@ struct
            (CTT_D CttOperators.FUN, [_ \ a, _ \ b]) => FUN (a, b)
          | (CTT_D CttOperators.NOT, [_ \ a]) => NOT a
          | (CTT_D (CttOperators.MEMBER tau), [_ \ m, _ \ a]) => MEMBER (tau, m, a)
-         | (RCD_D (RecordOperators.RECORD u), [_ \ a, (_,[x]) \ bx]) => RECORD_TY (u, a, x, bx)
+         | (RCD_D (RecordOperators.SINGL u), [_ \ a]) => RCD_SINGL (u, a)
          | _ => raise Fail "outDef expected definitional extension"
 
-      and out m  =
+      and out m =
         case View.out m of
            O.RET _ $ [_ \ v] => outVal v
          | O.CUT _ $ [_ \ k, _ \ m] => outCut k m
@@ -413,7 +419,6 @@ struct
        | CEQUIV (_, m, n) => infix' (Non, 0, "~") (unparse m, unparse n)
        | AX => atom "Ax"
        | RCD_CONS (lbl, a, b) => infix' (Right, 5, "\226\136\183") (infix' (Non, 5, "=") (atom (Symbol.toString lbl), unparse a), unparse b)
-       | RCD_SINGL (lbl, a) => atom @@ "{" ^ parens (done (infix' (Non, 0, ":") (atom (Symbol.toString lbl), unparse a))) ^ "}"
        | RCD_PROJ (lbl, m) => postfix (4, ". " ^ Symbol.toString lbl) (unparse m)
        | RECORD_TY (lbl, a, x, bx) =>
            let

--- a/src/syntax/syntax.fun
+++ b/src/syntax/syntax.fun
@@ -21,8 +21,6 @@ sig
   val $$ : symbol operator * term bview spine -> term
   val out : term -> term view
 
-  val variable : string -> variable
-
   val debugToString : term -> string
 end
 
@@ -35,7 +33,6 @@ struct
 
   structure Show = DebugShowAbt (Abt)
   val debugToString = Show.toString
-  val variable = Var.named
 end
 
 functor AstSyntaxView (Ast : AST where type 'a spine = 'a list) : SYNTAX_VIEW =
@@ -48,8 +45,6 @@ struct
   type 'a spine = 'a Ast.spine
 
   type term = Ast.ast
-
-  fun variable x = x
 
   datatype 'a bview =
      \ of (symbol spine * variable spine) * 'a

--- a/testsuite/tests/example.prl
+++ b/testsuite/tests/example.prl
@@ -45,9 +45,8 @@ Def Monoid(i : lvl) : exp = [
   { M : MonoidStruct(i) | MonoidLaws(M) }
 ].
 
-Thm MonoidStructWf(i : lvl) : [member(MonoidStruct(i); Univ(lsuc(i)))] by [
-  bang; cumulativity;
-  chk-inf; bang
+Thm MonoidStructWf : [member(MonoidStruct(lbase); Univ(lsuc(lbase)))] by [
+  bang; cumulativity; bang
 ].
 
 
@@ -64,10 +63,10 @@ Record Sg(A : exp, B : [exp].exp) = {
 
 Thm SigmaTest : [Sg(Base; [x]. ~(x; Ax))] by [
   unfold Sg;
-  repeat(intro);
-  #0 { witness [Ax] };
+  intro; [ witness [Ax] ];
   bang
 ].
+
 
 Thm symgenTest : [~(nu{lbl}({l}. {l = Unit}.l); Unit)] by [
   bang


### PR DESCRIPTION
I know I've gone back and forth on this a lot, but I've found that
dep-isect is really detrimental to automation. The new record type is
*extensionally* equivalent to the dep-isect representation, and we could
add a rule to that effect if we wanted.

This commit moves us back to rules like those in
http://homepages.inf.ed.ac.uk/rpollack/export/TLCA03extended.pdf

(resolves #91)