### PR TITLE
nominal-lcf cleanup; start basing everything on multitactics

### DIFF
--- a/src/redprl/lcf_model.fun
+++ b/src/redprl/lcf_model.fun
@@ -7,8 +7,7 @@ struct
   type 'a nominal = Syn.atom Spr.point -> 'a
   type tactic = Lcf.jdg Lcf.tactic nominal
   type multitactic = Lcf.jdg Lcf.multitactic nominal
-  type env = tactic Syn.VarCtx.dict
-  type menv = multitactic Syn.VarCtx.dict
+  type env = multitactic Syn.VarCtx.dict
   exception InvalidRule
 
   open RedPrlAbt
@@ -19,8 +18,7 @@ struct
   structure O = RedPrlOpData
   fun interpret (sign, env) rule =
     case out rule of
-       `x => Var.Ctx.lookup env x
-     | O.MONO O.RULE_ID $ _ => (fn _ => Lcf.idn)
+       O.MONO O.RULE_ID $ _ => (fn _ => Lcf.idn)
      | O.MONO O.RULE_EVAL_GOAL $ _ => Rules.Lift (Rules.CEquiv.EvalGoal sign)
      | O.MONO O.RULE_CEQUIV_REFL $ _ => Rules.Lift (Rules.CEquiv.Refl)
      | O.MONO O.RULE_AUTO_STEP $ _ => Rules.Lift (Rules.AutoStep sign)

--- a/src/redprl/lcf_syntax.fun
+++ b/src/redprl/lcf_syntax.fun
@@ -73,7 +73,6 @@ struct
          O.MONO O.MTAC_ALL $ [_ \ t] => ALL t
        | O.MONO (O.MTAC_EACH _) $ ts => EACH (List.map (fn _ \ t => t) ts)
        | O.MONO (O.MTAC_FOCUS i) $ [_ \ t] => FOCUS (i, t)
-       | O.MONO O.MTAC_REPEAT $ [_ \ mt] => REPEAT mt
        | O.MONO O.MTAC_PROGRESS $ [_ \ mt] => PROGRESS mt
        | O.MONO O.MTAC_REC $ [(_,[x]) \ mtx] => REC (x, mtx)
        | O.MONO (O.MTAC_SEQ _) $ [_ \ mt1, (us,_) \ mt2] => SEQ (us, mt1, mt2)

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -45,9 +45,10 @@ struct
    | REFINE of bool * sort | EXTRACT of sort
 
    (* primitive tacticals and multitacticals *)
-   | TAC_SEQ of psort list | TAC_ORELSE | TAC_REC | TAC_PROGRESS
+   | MTAC_SEQ of psort list | MTAC_ORELSE | MTAC_REC
    | MTAC_ALL | MTAC_EACH of int | MTAC_FOCUS of int | MTAC_REPEAT
    | MTAC_AUTO | MTAC_PROGRESS
+   | TAC_MTAC
 
    (* primitive rules *)
    | RULE_ID | RULE_EVAL_GOAL | RULE_CEQUIV_REFL | RULE_AUTO_STEP | RULE_SYMMETRY | RULE_WITNESS | RULE_HEAD_EXP
@@ -150,10 +151,10 @@ struct
      | REFINE (true, tau) => [[] * [] <> JDG, [] * [] <> TAC, [] * [] <> tau] ->> THM tau
      | REFINE (false, tau) => [[] * [] <> JDG, [] * [] <> TAC] ->> THM tau
      | EXTRACT tau => [[] * [] <> THM tau] ->> tau
-     | TAC_SEQ psorts => [[] * [] <> MTAC, psorts * [] <> TAC] ->> TAC
-     | TAC_ORELSE => [[] * [] <> TAC, [] * [] <> TAC] ->> TAC
-     | TAC_REC => [[] * [TAC] <> TAC] ->> TAC
-     | TAC_PROGRESS => [[] * [] <> TAC] ->> TAC
+     | MTAC_SEQ psorts => [[] * [] <> MTAC, psorts * [] <> MTAC] ->> MTAC
+     | MTAC_ORELSE => [[] * [] <> MTAC, [] * [] <> MTAC] ->> MTAC
+     | MTAC_REC => [[] * [MTAC] <> MTAC] ->> MTAC
+     | TAC_MTAC => [[] * [] <> MTAC] ->> TAC
      | MTAC_REPEAT => [[] * [] <> MTAC] ->> MTAC
      | RULE_ID => [] ->> TAC
      | MTAC_AUTO => [] ->> MTAC
@@ -346,10 +347,10 @@ struct
      | ID_ABS => "abs"
      | REFINE _ => "refine"
      | EXTRACT _ => "extract"
-     | TAC_SEQ _ => "seq"
-     | TAC_ORELSE => "orelse"
-     | TAC_REC => "rec"
-     | TAC_PROGRESS => "progress"
+     | MTAC_SEQ _ => "seq"
+     | MTAC_ORELSE => "orelse"
+     | MTAC_REC => "rec"
+     | TAC_MTAC => "mtac"
      | MTAC_REPEAT => "repeat"
      | RULE_ID => "id"
      | MTAC_AUTO => "auto"

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -17,23 +17,16 @@ struct
   type binding = (string * P.param_sort) list * ast
   infix $$ $ \
 
-  fun makeSeq mt (us : (string * P.param_sort) list) t =
+
+  fun makeSeq mt (us : (string * P.param_sort) list) mt' =
     let
       val (syms, sorts) = ListPair.unzip us
     in
-      O.MONO (O.TAC_SEQ sorts) $$ [([],[]) \ mt, (syms,[]) \ t]
+      O.MONO (O.MTAC_SEQ sorts) $$ [([],[]) \ mt, (syms,[]) \ mt']
     end
 
   fun multitacToTac tm =
-    case out tm of
-       O.MONO O.MTAC_ALL $ [_ \ t] => t
-     | _ => makeSeq tm [] (O.MONO O.RULE_ID $$ [])
-
-  val rec compileScript =
-    fn [] => O.MONO O.RULE_ID $$ []
-     | [([], tac)] => multitacToTac tac
-     | [(us, tac)] => makeSeq tac us (O.MONO O.RULE_ID $$ [])
-     | (us, tac) :: ts => makeSeq tac us (compileScript ts)
+    O.MONO O.TAC_MTAC $$ [([],[]) \ tm]
 end
 
 %%
@@ -45,6 +38,7 @@ end
  | NUMERAL of int
  | COLON
  | LANGLE | RANGLE
+ | LANGLE_PIPE | RANGLE_PIPE
  | LPAREN | RPAREN
  | RBRACKET | LBRACKET
  | LSQUARE | RSQUARE
@@ -73,7 +67,7 @@ end
  | DCL_DEF | DCL_TAC | DCL_THM
  | BY | IN
 
- | TAC_REC | TAC_PROGRESS | MTAC_REPEAT | MTAC_AUTO
+ | MTAC_REC | MTAC_PROGRESS | MTAC_REPEAT | MTAC_AUTO
  | RULE_ID | RULE_AUTO_STEP | RULE_SYMMETRY | RULE_EVAL_GOAL | RULE_CEQUIV_REFL | RULE_HYP | RULE_ELIM | RULE_HEAD_EXP | RULE_LEMMA
 
  | JDG_TRUE | JDG_TYPE | JDG_SYNTH
@@ -129,8 +123,6 @@ end
  | rawTactic of ast
  | tactic of ast
  | tactics of ast list
- | tacticBinding of Tac.binding
- | tacticBindings of Tac.binding list
  | hypBindings of (string * P.param_sort) list
  | rawMultitac of ast
  | multitac of ast
@@ -308,11 +300,9 @@ atomicRawTac
   | RULE_ELIM LBRACKET IDENT RBRACKET (Ast.$$ (O.POLY (O.RULE_ELIM IDENT), []))
   | APOSTROPHE term (Ast.$$ (O.MONO O.RULE_WITNESS, [\ (([],[]), term)]))
   | RULE_HEAD_EXP (Ast.$$ (O.MONO O.RULE_HEAD_EXP, []))
-  | LBRACKET tactic RBRACKET tactic (tactic)
-  | tactic DOUBLE_PIPE tactic %prec DOUBLE_PIPE (Ast.$$ (O.MONO O.TAC_ORELSE, [\ (([],[]), tactic1), \ (([],[]), tactic2)]))
-  | TAC_REC IDENT IN LBRACKET tactic RBRACKET (Ast.$$ (O.MONO O.TAC_REC, [\ (([],[IDENT]), tactic)]))
-  | TAC_PROGRESS LBRACKET tactic RBRACKET (Ast.$$ (O.MONO O.TAC_PROGRESS, [\ (([], []), tactic)]))
   | RULE_LEMMA LBRACKET term COLON sort RBRACKET (Ast.$$ (O.MONO (O.RULE_LEMMA (false, sort)), [\ (([],[]), term)]))
+
+  | LANGLE_PIPE multitac RANGLE_PIPE (Tac.multitacToTac multitac)
 
   | LAMBDA IDENT DOT tactic (Ast.$$ (O.MONO O.DEV_FUN_INTRO, [\ (([IDENT], []), tactic)]))
   | LANGLE IDENT RANGLE tactic (Ast.$$ (O.MONO O.DEV_PATH_INTRO, [\ (([IDENT], []), tactic)]))
@@ -341,7 +331,14 @@ rawMultitac
   | HASH NUMERAL LBRACKET tactic RBRACKET (Ast.$$ (O.MONO (O.MTAC_FOCUS NUMERAL), [\ (([],[]), tactic)]))
   | MTAC_REPEAT LBRACKET multitac RBRACKET (Ast.$$ (O.MONO O.MTAC_REPEAT, [\ (([], []), multitac)]))
   | MTAC_AUTO (Ast.$$ (O.MONO O.MTAC_AUTO, []))
+  | MTAC_PROGRESS LBRACKET multitac RBRACKET (Ast.$$ (O.MONO O.MTAC_PROGRESS, [\ (([], []), multitac)]))
+  | MTAC_REC IDENT IN LBRACKET multitac RBRACKET (Ast.$$ (O.MONO O.MTAC_REC, [\ (([],[IDENT]), multitac)]))
+  | LBRACKET multitac RBRACKET (multitac)
+  | hypBindings LEFT_ARROW multitac SEMI multitac %prec LEFT_ARROW (Tac.makeSeq multitac1 hypBindings multitac2)
+  | multitac SEMI multitac %prec LEFT_ARROW (Tac.makeSeq multitac1 [] multitac2)
   | atomicTac (Ast.$$ (O.MONO O.MTAC_ALL, [\ (([],[]), atomicTac)]))
+  | multitac DOUBLE_PIPE multitac %prec DOUBLE_PIPE (Ast.$$ (O.MONO O.MTAC_ORELSE, [\ (([],[]), multitac1), \ (([],[]), multitac2)]))
+  | (Ast.$$ (O.MONO O.MTAC_ALL, [\ (([],[]), Ast.$$ (O.MONO O.RULE_ID, []))]))
 
 multitac : rawMultitac (annotate (Pos.pos (rawMultitac1left fileName) (rawMultitac1right fileName)) rawMultitac)
 
@@ -350,19 +347,11 @@ hypBindings
   : IDENT ([(IDENT, P.HYP)])
   | IDENT COMMA hypBindings ((IDENT, P.HYP) :: hypBindings)
 
-tacticBinding
-  : hypBindings LEFT_ARROW multitac %prec LEFT_ARROW (hypBindings, multitac)
-  | multitac ([], multitac)
-
-tacticBindings
-  : tacticBinding ([tacticBinding])
-  | tacticBinding SEMI tacticBindings (tacticBinding :: tacticBindings)
-  | ([])
-
 rawTactic
-  : tacticBindings (Tac.compileScript tacticBindings)
+  : multitac (Tac.multitacToTac multitac)
 
-tactic : rawTactic (annotate (Pos.pos (rawTactic1left fileName) (rawTactic1right fileName)) rawTactic)
+tactic
+  : rawTactic (annotate (Pos.pos (rawTactic1left fileName) (rawTactic1right fileName)) rawTactic)
 
 tactics
   : ([])

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -25,8 +25,14 @@ struct
       O.MONO (O.MTAC_SEQ sorts) $$ [([],[]) \ mt, (syms,[]) \ mt']
     end
 
-  fun multitacToTac tm =
-    O.MONO O.TAC_MTAC $$ [([],[]) \ tm]
+  fun multitacToTac mt =
+    O.MONO O.TAC_MTAC $$ [([],[]) \ mt]
+
+  fun tacToMulitac t =
+    O.MONO O.MTAC_ALL $$ [([],[]) \ t]
+
+  fun orElse (t1, t2) =
+    multitacToTac (O.MONO O.MTAC_ORELSE $$ [([],[]) \ tacToMulitac t1, ([],[]) \ tacToMulitac t2])
 end
 
 %%
@@ -302,6 +308,7 @@ atomicRawTac
   | RULE_HEAD_EXP (Ast.$$ (O.MONO O.RULE_HEAD_EXP, []))
   | RULE_LEMMA LBRACKET term COLON sort RBRACKET (Ast.$$ (O.MONO (O.RULE_LEMMA (false, sort)), [\ (([],[]), term)]))
 
+  | tactic DOUBLE_PIPE tactic %prec DOUBLE_PIPE (Tac.orElse (tactic1, tactic2))
   | LANGLE_PIPE multitac RANGLE_PIPE (Tac.multitacToTac multitac)
 
   | LAMBDA IDENT DOT tactic (Ast.$$ (O.MONO O.DEV_FUN_INTRO, [\ (([IDENT], []), tactic)]))
@@ -337,7 +344,6 @@ rawMultitac
   | hypBindings LEFT_ARROW multitac SEMI multitac %prec LEFT_ARROW (Tac.makeSeq multitac1 hypBindings multitac2)
   | multitac SEMI multitac %prec LEFT_ARROW (Tac.makeSeq multitac1 [] multitac2)
   | atomicTac (Ast.$$ (O.MONO O.MTAC_ALL, [\ (([],[]), atomicTac)]))
-  | multitac DOUBLE_PIPE multitac %prec DOUBLE_PIPE (Ast.$$ (O.MONO O.MTAC_ORELSE, [\ (([],[]), multitac1), \ (([],[]), multitac2)]))
   | (Ast.$$ (O.MONO O.MTAC_ALL, [\ (([],[]), Ast.$$ (O.MONO O.RULE_ID, []))]))
 
 multitac : rawMultitac (annotate (Pos.pos (rawMultitac1left fileName) (rawMultitac1right fileName)) rawMultitac)

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -25,6 +25,8 @@ whitespace = [\ \t];
 "//"[^\n]*         => (continue ());
 
 
+"<|"               => (Tokens.LANGLE_PIPE (!pos, Coord.addchar (size yytext) o (!pos)));
+"|>"               => (Tokens.RANGLE_PIPE (!pos, Coord.addchar (size yytext) o (!pos)));
 "("                => (Tokens.LPAREN (!pos, Coord.nextchar o (!pos)));
 ")"                => (Tokens.RPAREN (!pos, Coord.nextchar o (!pos)));
 "<"                => (Tokens.LANGLE (!pos, Coord.nextchar o (!pos)));
@@ -91,9 +93,9 @@ whitespace = [\ \t];
 "by"               => (Tokens.BY (!pos, Coord.addchar 2 o (!pos)));
 "in"               => (Tokens.IN (!pos, Coord.addchar 2 o (!pos)));
 
-"rec"              => (Tokens.TAC_REC (!pos, Coord.addchar (size yytext) o (!pos)));
+"rec"              => (Tokens.MTAC_REC (!pos, Coord.addchar (size yytext) o (!pos)));
 "repeat"           => (Tokens.MTAC_REPEAT (!pos, Coord.addchar (size yytext) o (!pos)));
-"progress"         => (Tokens.TAC_PROGRESS (!pos, Coord.addchar (size yytext) o (!pos)));
+"progress"         => (Tokens.MTAC_PROGRESS (!pos, Coord.addchar (size yytext) o (!pos)));
 "id"               => (Tokens.RULE_ID (!pos, Coord.addchar 2 o (!pos)));
 "eval-goal"        => (Tokens.RULE_EVAL_GOAL (!pos, Coord.addchar (size yytext) o (!pos)));
 "ceq/refl"         => (Tokens.RULE_CEQUIV_REFL (!pos, Coord.addchar (size yytext) o (!pos)));


### PR DESCRIPTION
This is based on the thought that I mentioned in https://github.com/RedPRL/sml-dependent-lcf/issues/17.

The idea is that both Dependent LCF and Nominal LCF behave best when you do most of the hacking at the level of multitactics; for instance, with "repeat" you want to repeatedly run a tactic on the whole proof state, as opposed to running a tactic repeatedly on each subgoal in a proof state.

So, I've changed most tacticals to be multitacticals. You may wonder, do we lose anything? I believe that we can recover the old behavior using a "vertical application" tactical, which takes a multitactic and runs it on *each* subgoal—this is essentially just precomposing with the unit and postcomposing with multiplication. This is written `<| mt |>` in RedPRL's concrete notation.

- [x] TODO: we will probably want `ORELSE` to apply "vertically" by default, since this is what is usually desired by a user.