### PR TITLE
Fix source position handling in the lexer

### DIFF
--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -8,6 +8,24 @@ type arg = string
 val pos = ref Coord.init
 val eof = fn (fileName : string) => Tokens.EOF (!pos, !pos)
 
+fun incPos n = pos := (Coord.addchar n o (!pos))
+
+fun posTuple n =
+  let
+    val l = !pos
+    val () = incPos n
+    val r = !pos
+  in
+    (l, r)
+  end
+
+fun posTupleWith n x =
+  let
+    val (l, r) = posTuple n
+  in
+    (x, l, r)
+  end
+
 exception LexerError of pos
 
 %%
@@ -20,95 +38,95 @@ whitespace = [\ \t];
 %%
 
 \n                 => (pos := (Coord.nextline o (!pos)); continue ());
-{whitespace}+      => (pos := (Coord.addchar (size yytext) o (!pos)); continue ());
-{digit}+           => (Tokens.NUMERAL (valOf (Int.fromString yytext), !pos, Coord.addchar (size yytext) o (!pos)));
+{whitespace}+      => (incPos (size yytext); continue ());
+{digit}+           => (Tokens.NUMERAL (posTupleWith (size yytext) (valOf (Int.fromString yytext))));
 "//"[^\n]*         => (continue ());
 
 
-"<|"               => (Tokens.LANGLE_PIPE (!pos, Coord.addchar (size yytext) o (!pos)));
-"|>"               => (Tokens.RANGLE_PIPE (!pos, Coord.addchar (size yytext) o (!pos)));
-"("                => (Tokens.LPAREN (!pos, Coord.nextchar o (!pos)));
-")"                => (Tokens.RPAREN (!pos, Coord.nextchar o (!pos)));
-"<"                => (Tokens.LANGLE (!pos, Coord.nextchar o (!pos)));
-">"                => (Tokens.RANGLE (!pos, Coord.nextchar o (!pos)));
-"{"                => (Tokens.LBRACKET (!pos, Coord.nextchar o (!pos)));
-"}"                => (Tokens.RBRACKET (!pos, Coord.nextchar o (!pos)));
-"["                => (Tokens.LSQUARE (!pos, Coord.nextchar o (!pos)));
-"]"                => (Tokens.RSQUARE (!pos, Coord.nextchar o (!pos)));
-"."                => (Tokens.DOT (!pos, Coord.nextchar o (!pos)));
-","                => (Tokens.COMMA (!pos, Coord.nextchar o (!pos)));
-":"                => (Tokens.COLON (!pos, Coord.nextchar o (!pos)));
-";"                => (Tokens.SEMI (!pos, Coord.nextchar o (!pos)));
-"#"                => (Tokens.HASH (!pos, Coord.nextchar o (!pos)));
-"="                => (Tokens.EQUALS (!pos, Coord.nextchar o (!pos)));
-"\'"               => (Tokens.APOSTROPHE (!pos, Coord.nextchar o (!pos)));
-"~"                => (Tokens.SQUIGGLE (!pos, Coord.nextchar o (!pos)));
-"~>"               => (Tokens.SQUIGGLE_ARROW (!pos, Coord.addchar 2 o (!pos)));
-"->"               => (Tokens.RIGHT_ARROW (!pos, Coord.addchar 2 o (!pos)));
-"=>"               => (Tokens.DOUBLE_RIGHT_ARROW (!pos, Coord.addchar 2 o (!pos)));
-"<-"               => (Tokens.LEFT_ARROW (!pos, Coord.addchar 2 o (!pos)));
-"`"                => (Tokens.BACK_TICK (!pos, Coord.nextchar o (!pos)));
-"*"                => (Tokens.TIMES (!pos, Coord.nextchar o (!pos)));
-"@"                => (Tokens.AT_SIGN (!pos, Coord.nextchar o (!pos)));
-"||"               => (Tokens.DOUBLE_PIPE (!pos, Coord.addchar 2 o (!pos)));
-"|"                => (Tokens.PIPE (!pos, Coord.nextchar o (!pos)));
-"%"                => (Tokens.PERCENT (!pos, Coord.nextchar o (!pos)));
+"<|"               => (Tokens.LANGLE_PIPE (posTuple (size yytext)));
+"|>"               => (Tokens.RANGLE_PIPE (posTuple (size yytext)));
+"("                => (Tokens.LPAREN (posTuple (size yytext)));
+")"                => (Tokens.RPAREN (posTuple (size yytext)));
+"<"                => (Tokens.LANGLE (posTuple (size yytext)));
+">"                => (Tokens.RANGLE (posTuple (size yytext)));
+"{"                => (Tokens.LBRACKET (posTuple (size yytext)));
+"}"                => (Tokens.RBRACKET (posTuple (size yytext)));
+"["                => (Tokens.LSQUARE (posTuple (size yytext)));
+"]"                => (Tokens.RSQUARE (posTuple (size yytext)));
+"."                => (Tokens.DOT (posTuple (size yytext)));
+","                => (Tokens.COMMA (posTuple (size yytext)));
+":"                => (Tokens.COLON (posTuple (size yytext)));
+";"                => (Tokens.SEMI (posTuple (size yytext)));
+"#"                => (Tokens.HASH (posTuple (size yytext)));
+"="                => (Tokens.EQUALS (posTuple (size yytext)));
+"\'"               => (Tokens.APOSTROPHE (posTuple (size yytext)));
+"~"                => (Tokens.SQUIGGLE (posTuple (size yytext)));
+"~>"               => (Tokens.SQUIGGLE_ARROW (posTuple (size yytext)));
+"->"               => (Tokens.RIGHT_ARROW (posTuple (size yytext)));
+"=>"               => (Tokens.DOUBLE_RIGHT_ARROW (posTuple (size yytext)));
+"<-"               => (Tokens.LEFT_ARROW (posTuple (size yytext)));
+"`"                => (Tokens.BACK_TICK (posTuple (size yytext)));
+"*"                => (Tokens.TIMES (posTuple (size yytext)));
+"@"                => (Tokens.AT_SIGN (posTuple (size yytext)));
+"||"               => (Tokens.DOUBLE_PIPE (posTuple (size yytext)));
+"|"                => (Tokens.PIPE (posTuple (size yytext)));
+"%"                => (Tokens.PERCENT (posTuple (size yytext)));
 
-"bool"             => (Tokens.BOOL (!pos, Coord.addchar (size yytext) o (!pos)));
-"sbool"            => (Tokens.S_BOOL (!pos, Coord.addchar (size yytext) o (!pos)));
-"tt"               => (Tokens.TT (!pos, Coord.addchar (size yytext) o (!pos)));
-"ff"               => (Tokens.FF (!pos, Coord.addchar (size yytext) o (!pos)));
-"if"               => (Tokens.IF (!pos, Coord.addchar (size yytext) o (!pos)));
-"if/s"             => (Tokens.S_IF (!pos, Coord.addchar (size yytext) o (!pos)));
-"paths"            => (Tokens.PATHS (!pos, Coord.addchar (size yytext) o (!pos)));
-"S1"               => (Tokens.S1 (!pos, Coord.addchar (size yytext) o (!pos)));
-"lam"              => (Tokens.LAMBDA (!pos, Coord.addchar 3 o (!pos)));
-"hcom"             => (Tokens.HCOM (!pos, Coord.addchar 4 o (!pos)));
-"coe"              => (Tokens.COE (!pos, Coord.addchar 3 o (!pos)));
-"univ"             => (Tokens.UNIV (!pos, Coord.addchar 4 o (!pos)));
-"loop"             => (Tokens.LOOP (!pos, Coord.addchar (size yytext) o (!pos)));
-"base"             => (Tokens.BASE (!pos, Coord.addchar (size yytext) o (!pos)));
-"fst"              => (Tokens.FST (!pos, Coord.addchar (size yytext) o (!pos)));
-"snd"              => (Tokens.SND (!pos, Coord.addchar (size yytext) o (!pos)));
+"bool"             => (Tokens.BOOL (posTuple (size yytext)));
+"sbool"            => (Tokens.S_BOOL (posTuple (size yytext)));
+"tt"               => (Tokens.TT (posTuple (size yytext)));
+"ff"               => (Tokens.FF (posTuple (size yytext)));
+"if"               => (Tokens.IF (posTuple (size yytext)));
+"if/s"             => (Tokens.S_IF (posTuple (size yytext)));
+"paths"            => (Tokens.PATHS (posTuple (size yytext)));
+"S1"               => (Tokens.S1 (posTuple (size yytext)));
+"lam"              => (Tokens.LAMBDA (posTuple (size yytext)));
+"hcom"             => (Tokens.HCOM (posTuple (size yytext)));
+"coe"              => (Tokens.COE (posTuple (size yytext)));
+"univ"             => (Tokens.UNIV (posTuple (size yytext)));
+"loop"             => (Tokens.LOOP (posTuple (size yytext)));
+"base"             => (Tokens.BASE (posTuple (size yytext)));
+"fst"              => (Tokens.FST (posTuple (size yytext)));
+"snd"              => (Tokens.SND (posTuple (size yytext)));
 
-"then"             => (Tokens.THEN (!pos, Coord.addchar (size yytext) o (!pos)));
-"else"             => (Tokens.ELSE (!pos, Coord.addchar (size yytext) o (!pos)));
-"let"              => (Tokens.LET (!pos, Coord.addchar (size yytext) o (!pos)));
-"with"             => (Tokens.WITH (!pos, Coord.addchar (size yytext) o (!pos)));
-"case"             => (Tokens.CASE (!pos, Coord.addchar (size yytext) o (!pos)));
-"of"               => (Tokens.OF (!pos, Coord.addchar (size yytext) o (!pos)));
+"then"             => (Tokens.THEN (posTuple (size yytext)));
+"else"             => (Tokens.ELSE (posTuple (size yytext)));
+"let"              => (Tokens.LET (posTuple (size yytext)));
+"with"             => (Tokens.WITH (posTuple (size yytext)));
+"case"             => (Tokens.CASE (posTuple (size yytext)));
+"of"               => (Tokens.OF (posTuple (size yytext)));
 
-"dim"              => (Tokens.DIM (!pos, Coord.addchar 3 o (!pos)));
-"exn"              => (Tokens.EXN (!pos, Coord.addchar 3 o (!pos)));
-"lbl"              => (Tokens.LBL (!pos, Coord.addchar 3 o (!pos)));
+"dim"              => (Tokens.DIM (posTuple (size yytext)));
+"exn"              => (Tokens.EXN (posTuple (size yytext)));
+"lbl"              => (Tokens.LBL (posTuple (size yytext)));
 
-"exp"              => (Tokens.EXP (!pos, Coord.addchar 3 o (!pos)));
-"tac"              => (Tokens.TAC (!pos, Coord.addchar 3 o (!pos)));
-"lvl"              => (Tokens.LVL (!pos, Coord.addchar 3 o (!pos)));
+"exp"              => (Tokens.EXP (posTuple (size yytext)));
+"tac"              => (Tokens.TAC (posTuple (size yytext)));
+"lvl"              => (Tokens.LVL (posTuple (size yytext)));
 
-"Print"            => (Tokens.CMD_PRINT (!pos, Coord.addchar (size yytext) o (!pos)));
-"Def"              => (Tokens.DCL_DEF (!pos, Coord.addchar 3 o (!pos)));
-"Tac"              => (Tokens.DCL_TAC (!pos, Coord.addchar 3 o (!pos)));
-"Thm"              => (Tokens.DCL_THM (!pos, Coord.addchar 3 o (!pos)));
-"by"               => (Tokens.BY (!pos, Coord.addchar 2 o (!pos)));
-"in"               => (Tokens.IN (!pos, Coord.addchar 2 o (!pos)));
+"Print"            => (Tokens.CMD_PRINT (posTuple (size yytext)));
+"Def"              => (Tokens.DCL_DEF (posTuple (size yytext)));
+"Tac"              => (Tokens.DCL_TAC (posTuple (size yytext)));
+"Thm"              => (Tokens.DCL_THM (posTuple (size yytext)));
+"by"               => (Tokens.BY (posTuple (size yytext)));
+"in"               => (Tokens.IN (posTuple (size yytext)));
 
-"rec"              => (Tokens.MTAC_REC (!pos, Coord.addchar (size yytext) o (!pos)));
-"repeat"           => (Tokens.MTAC_REPEAT (!pos, Coord.addchar (size yytext) o (!pos)));
-"progress"         => (Tokens.MTAC_PROGRESS (!pos, Coord.addchar (size yytext) o (!pos)));
-"id"               => (Tokens.RULE_ID (!pos, Coord.addchar 2 o (!pos)));
-"eval-goal"        => (Tokens.RULE_EVAL_GOAL (!pos, Coord.addchar (size yytext) o (!pos)));
-"ceq/refl"         => (Tokens.RULE_CEQUIV_REFL (!pos, Coord.addchar (size yytext) o (!pos)));
-"symmetry"         => (Tokens.RULE_SYMMETRY (!pos, Coord.addchar (size yytext) o (!pos)));
-"auto-step"        => (Tokens.RULE_AUTO_STEP (!pos, Coord.addchar (size yytext) o (!pos)));
-"auto"             => (Tokens.MTAC_AUTO (!pos, Coord.addchar (size yytext) o (!pos)));
-"hyp"              => (Tokens.RULE_HYP (!pos, Coord.addchar (size yytext) o (!pos)));
-"elim"             => (Tokens.RULE_ELIM (!pos, Coord.addchar (size yytext) o (!pos)));
-"head-expand"      => (Tokens.RULE_HEAD_EXP (!pos, Coord.addchar (size yytext) o (!pos)));
-"lemma"            => (Tokens.RULE_LEMMA (!pos, Coord.addchar (size yytext) o (!pos)));
+"rec"              => (Tokens.MTAC_REC (posTuple (size yytext)));
+"repeat"           => (Tokens.MTAC_REPEAT (posTuple (size yytext)));
+"progress"         => (Tokens.MTAC_PROGRESS (posTuple (size yytext)));
+"id"               => (Tokens.RULE_ID (posTuple (size yytext)));
+"eval-goal"        => (Tokens.RULE_EVAL_GOAL (posTuple (size yytext)));
+"ceq/refl"         => (Tokens.RULE_CEQUIV_REFL (posTuple (size yytext)));
+"symmetry"         => (Tokens.RULE_SYMMETRY (posTuple (size yytext)));
+"auto-step"        => (Tokens.RULE_AUTO_STEP (posTuple (size yytext)));
+"auto"             => (Tokens.MTAC_AUTO (posTuple (size yytext)));
+"hyp"              => (Tokens.RULE_HYP (posTuple (size yytext)));
+"elim"             => (Tokens.RULE_ELIM (posTuple (size yytext)));
+"head-expand"      => (Tokens.RULE_HEAD_EXP (posTuple (size yytext)));
+"lemma"            => (Tokens.RULE_LEMMA (posTuple (size yytext)));
 
-"true"             => (Tokens.JDG_TRUE (!pos, Coord.addchar 4 o (!pos)));
-"type"             => (Tokens.JDG_TYPE (!pos, Coord.addchar 4 o (!pos)));
-"synth"            => (Tokens.JDG_SYNTH (!pos, Coord.addchar 5 o (!pos)));
+"true"             => (Tokens.JDG_TRUE (posTuple (size yytext)));
+"type"             => (Tokens.JDG_TYPE (posTuple (size yytext)));
+"synth"            => (Tokens.JDG_SYNTH (posTuple (size yytext)));
 
-{alpha}{identChr}* => (Tokens.IDENT (yytext, !pos, Coord.addchar (size yytext) o (!pos)));
+{alpha}{identChr}* => (Tokens.IDENT (posTupleWith (size yytext) yytext));


### PR DESCRIPTION
The lexer was previously inconsistent about maintaining the source
position. The position was only being updated on newlines and
whitespace, and not when any real tokens were processed.

This problem was partially masked by the fact that the ending position
of each token was correct relative to the start position, but the end
position was not being written back to the global variable that keeps
track of the current position.

This patch factors out the update logic into a few helper functions.
* `posTuple n` takes the length of the current token as an argument, and
  returns the (start,end) position information while writing the end
  position back to the global variable `pos`.
* `posTuple n x` additionally takes an arbitrary value `x`, and returns
  the tuple `(x, start, end)`. This is useful when the token takes
  additional arguments beyond just the positions.