### PR TITLE
[parser] give function applications source pos

### DIFF
--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -86,10 +86,12 @@ end
 %nonterm
    start of Signature.sign
 
-   (* a type-theoretic term, excluding function application *)
- | rawTerm of ast
    (* a type-theoretic term, including function application *)
+ | rawTerm of ast
+   (* a type-theoretic term, excluding function application *)
  | atomicRawTerm of ast
+   (* ... annotated with source position*)
+ | atomicTerm of ast
 
    (* a type-theoretic term, annotated with source position *)
  | term of ast
@@ -281,9 +283,11 @@ atomicRawTerm
   | LANGLE IDENT RANGLE term (Ast.$$ (O.MONO O.ID_ABS, [\ (([IDENT],[]), term)]))
   | term AT_SIGN param %prec AT_SIGN (Ast.$$ (O.POLY (O.ID_AP param), [\ (([],[]), term)]))
 
+atomicTerm : atomicRawTerm (annotate (Pos.pos (atomicRawTerm1left fileName) (atomicRawTerm1right fileName)) atomicRawTerm)
+
 rawTerm
-  : term atomicRawTerm %prec FUN_APP (Ast.$$ (O.MONO O.AP, [\ (([],[]), term), \ (([],[]), atomicRawTerm)]))
-  | atomicRawTerm (atomicRawTerm)
+  : term atomicTerm %prec FUN_APP (Ast.$$ (O.MONO O.AP, [\ (([],[]), term), \ (([],[]), atomicTerm)]))
+  | atomicTerm (atomicTerm)
 
 rawJudgment
   : term JDG_TRUE (Ast.$$ (O.MONO O.JDG_TRUE, [\ (([],[]), term)]))


### PR DESCRIPTION
The nonterminal atomicRawTerm does not do annotation, and expects the
parent to do so. However, rawTerm directly called atomicRawTerm,
breaking this expectation.

The fix is to introduce another intermediate nonterminal, called
atomicTerm, which sits between atomicRawTerm and rawTerm. The naming
convention here is that "raw" means "potentially unannotated".