### PR TITLE
Give nicer error messages (with location info) on unbound variables and symbols

### DIFF
--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -243,15 +243,19 @@ struct
     fun scopeCheck (metactx, symctx) term : Tm.abt E.t =
       let
         val termPos = Tm.getAnnotation term
+        val symOccurrences = Susp.delay (fn _ => Tm.symOccurrences term)
         val checkSyms =
           Tm.Sym.Ctx.foldl
             (fn (u, tau, r) =>
               let
                 val tau' = Tm.Sym.Ctx.find symctx u
                 val ustr = Tm.Sym.toString u
+                val pos = case Tm.Sym.Ctx.find (Susp.force symOccurrences) u of
+                               SOME (pos :: _) => SOME pos
+                             | _ => (print ("couldn't find position for var " ^ ustr); termPos)
               in
-                E.when (tau' = NONE, E.fail (termPos, "Unbound symbol: " ^ ustr))
-                  *> E.when (Option.isSome tau' andalso not (tau' = SOME tau), E.fail (termPos, "Symbol sort mismatch: " ^ ustr))
+                E.when (tau' = NONE, E.fail (pos, "Unbound symbol: " ^ ustr))
+                  *> E.when (Option.isSome tau' andalso not (tau' = SOME tau), E.fail (pos, "Symbol sort mismatch: " ^ ustr))
                   *> r
               end)
             (E.ret ())

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -257,9 +257,17 @@ struct
             (E.ret ())
             (Tm.symctx term)
 
+        val varOccurrences = Susp.delay (fn _ => Tm.varOccurrences term)
         val checkVars =
           Tm.Var.Ctx.foldl
-            (fn (x, tau, r) => E.fail (termPos, "Unbound variable: " ^ Tm.Var.toString x) *> r)
+            (fn (x, tau, r) =>
+               let
+                 val pos = case Tm.Var.Ctx.find (Susp.force varOccurrences) x of
+                               SOME (pos :: _) => SOME pos
+                             | _ => termPos
+               in
+                 E.fail (pos, "Unbound variable: " ^ Tm.Var.toString x) *> r
+               end)
             (E.ret ())
             (Tm.varctx term)
 


### PR DESCRIPTION
~This is a work in progress. Please do not merge yet.~ This is ready to merge after approval.

Addresses #110.

Depends on RedPRL/sml-typed-abts#72.

I have made some progress here. So far, I've just done it for "normal" variables. Any early feedback on that part is welcome.

When trying to take the next step by implementing this for meta variables, I ran into the failure illustrated by the test in the most recent commit. Basically, it looks like ABT conversion fails out if there's a free metavariable, so we have no chance in checkScope to give a nice error message. Any ideas on what to do here?