### PR TITLE
Incorporate annotations in elaborator's wrap

### DIFF
--- a/src/redprl/elab_monad.sml
+++ b/src/redprl/elab_monad.sml
@@ -102,7 +102,10 @@ struct
 
   fun wrap (pos, f) =
     Debug.wrap (fn _ => ret (f ()))
-    handle exn => fail (pos, RedPrlError.format exn)
+    handle exn => fail (case RedPrlError.annotation exn of
+                          NONE => pos
+                        | SOME pos' => SOME pos',
+                        RedPrlError.format exn)
 
   fun delay f =
     bind f (ret ())


### PR DESCRIPTION
The RedPRL error reporting facility allows the code throwing the error to specify a position, but such positions would be ignored everywhere, as far as I can tell.

This PR makes the elaborator's `wrap` function check to see whether the thrown exception contains a position. If so, it uses it; otherwise, it falls back on the position passed in as an argument. 

This is useful, for example, when wrapping a function that traverses a term. If an error occurs during the traversal, we may have more precise position information than "somewhere in the tree".