### PR TITLE
Parse signatures element-by-element

### DIFF
--- a/src/frontend/frontend.sml
+++ b/src/frontend/frontend.sml
@@ -25,17 +25,87 @@ struct
             (RedPrlError.error [E.% s])
   end
 
-  fun parseSig fileName =
-    let
-      val input = TextIO.inputAll (TextIO.openIn fileName)
-      val lexer = RedPrlParser.makeLexer (stringreader input) fileName
-      val (sign, _) = RedPrlParser.parse (1, lexer, error fileName, fileName)
-    in
-      sign
-    end
+  fun parseElt fileName lexer =
+    RedPrlParser.parse (0, lexer, error fileName, fileName)
+
+  local
+    open Signature
+  in
+    fun processElt sign (DECL (nm, d, pos)) = Signature.insert sign nm (d, SOME pos)
+      | processElt sign (CMD c) = Signature.command sign c
+  end
+
+  fun logExn exn =
+    RedPrlLog.print RedPrlLog.FAIL (RedPrlError.annotation exn, RedPrlError.format exn)
+
+  local
+    val EOF = RedPrlLrVals.Tokens.EOF (Coord.init, Coord.init)
+    val DEF = RedPrlLrVals.Tokens.DCL_DEF (Coord.init, Coord.init)
+    val THM = RedPrlLrVals.Tokens.DCL_THM (Coord.init, Coord.init)
+    val TAC = RedPrlLrVals.Tokens.DCL_TAC (Coord.init, Coord.init)
+    val PRINT = RedPrlLrVals.Tokens.CMD_PRINT (Coord.init, Coord.init)
+
+    fun isBeginElt tok =
+      RedPrlParser.Token.sameToken (tok, THM) orelse
+      RedPrlParser.Token.sameToken (tok, DEF) orelse
+      RedPrlParser.Token.sameToken (tok, TAC) orelse
+      RedPrlParser.Token.sameToken (tok, PRINT)
+
+    fun isEof tok =
+      RedPrlParser.Token.sameToken (tok, EOF)
+
+    fun skipToBeginElt lexer =
+      let
+        val (next_tok, lexer') = RedPrlParser.Stream.get lexer
+      in
+        if isEof next_tok orelse isBeginElt next_tok
+        then lexer
+        else skipToBeginElt lexer'
+      end
+
+    fun recover lexer =
+      let
+        val (_, lexer) = RedPrlParser.Stream.get lexer
+      in
+        skipToBeginElt lexer
+      end
+
+    fun doElt fileName lexer sign =
+      let
+        val (elt, lexer) = parseElt fileName lexer
+      in
+        (true, processElt sign elt, lexer)
+      end
+      handle exn => (logExn exn; (false, sign, recover lexer))
+  in
+    fun parseSig fileName =
+      let
+        fun loop acc lexer sign =
+          let
+            val (next_tok, _) = RedPrlParser.Stream.get lexer
+          in
+            if RedPrlParser.Token.sameToken (next_tok, EOF)
+            then (acc, sign)
+            else
+              let
+                val (err, sign, lexer) = doElt fileName lexer sign
+              in
+                loop (acc andalso err) lexer sign
+              end
+          end
+
+        val input = TextIO.inputAll (TextIO.openIn fileName)
+        val lexer = RedPrlParser.makeLexer (stringreader input) fileName
+      in
+        loop true lexer Signature.empty
+      end
+  end
 
   fun processFile fileName =
-    Signature.check (parseSig fileName)
-    handle exn => (RedPrlLog.print RedPrlLog.FAIL (RedPrlError.annotation exn, RedPrlError.format exn); false)
-
+    let
+      val (noParseErrors, sign) = parseSig fileName
+    in
+      Signature.check sign andalso noParseErrors
+    end
+    handle exn => (logExn exn; false)
 end

--- a/src/frontend/frontend.sml
+++ b/src/frontend/frontend.sml
@@ -22,14 +22,17 @@ struct
   fun error fileName (s, pos, pos') : unit =
     raise ParseError (Pos.pos (pos fileName) (pos' fileName), s)
 
-  fun processFile fileName =
+  fun parseSig fileName =
     let
       val input = TextIO.inputAll (TextIO.openIn fileName)
       val lexer = RedPrlParser.makeLexer (stringreader input) fileName
       val (sign, _) = RedPrlParser.parse (1, lexer, error fileName, fileName)
     in
-      Signature.check sign
+      sign
     end
+
+  fun processFile fileName =
+    Signature.check (parseSig fileName)
     handle ParseError (pos, msg) => (RedPrlLog.print RedPrlLog.FAIL (SOME pos, msg); false)
          | exn => (RedPrlLog.print RedPrlLog.FAIL (SOME (Pos.pos (Coord.init fileName) (Coord.init fileName)), RedPrlError.format exn); false)
 end

--- a/src/frontend/frontend.sml
+++ b/src/frontend/frontend.sml
@@ -17,10 +17,13 @@ struct
         end
     end
 
-  exception ParseError of Pos.t * string
-
-  fun error fileName (s, pos, pos') : unit =
-    raise ParseError (Pos.pos (pos fileName) (pos' fileName), s)
+  local
+    structure E = RedPrlError
+  in
+    fun error fileName (s, pos, pos') : unit =
+      raise E.annotate (SOME (Pos.pos (pos fileName) (pos' fileName)))
+            (RedPrlError.error [E.% s])
+  end
 
   fun parseSig fileName =
     let
@@ -33,6 +36,6 @@ struct
 
   fun processFile fileName =
     Signature.check (parseSig fileName)
-    handle ParseError (pos, msg) => (RedPrlLog.print RedPrlLog.FAIL (SOME pos, msg); false)
-         | exn => (RedPrlLog.print RedPrlLog.FAIL (SOME (Pos.pos (Coord.init fileName) (Coord.init fileName)), RedPrlError.format exn); false)
+    handle exn => (RedPrlLog.print RedPrlLog.FAIL (RedPrlError.annotation exn, RedPrlError.format exn); false)
+
 end

--- a/src/redprl.cm
+++ b/src/redprl.cm
@@ -5,6 +5,7 @@ Library
   structure Signature
   structure RedPrlLog
   structure RedPrlError
+  structure RedPrlLrVals
 is
   $/basis.cm
   $/ml-yacc-lib.cm

--- a/src/redprl.mlb
+++ b/src/redprl.mlb
@@ -70,4 +70,5 @@ in
   structure Signature
   structure RedPrlLog
   structure RedPrlError
+  structure RedPrlLrVals
 end

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -84,7 +84,7 @@ end
 
 
 %nonterm
-   start of Signature.sign
+   start of Signature.src_elt
 
    (* a type-theoretic term, including function application *)
  | rawTerm of ast
@@ -147,22 +147,22 @@ end
    (* a declaration in a RedPRL signature *)
  | rawDecl of string * Signature.src_decl
    (* a declaration, annotated with source position *)
- | decl of string * (Signature.src_decl * Pos.t option)
+ | decl of string * Signature.src_decl * Pos.t
    (* a RedPRL signature *)
  | rawCmd of Signature.src_cmd
  | cmd of Signature.src_cmd * Pos.t
- | sign of Signature.sign
+ | elt of Signature.src_elt
 
 %verbose
 %pos (string -> Coord.t)
 %start start
-%eop EOF
+%eop EOF CMD_PRINT DCL_DEF DCL_TAC DCL_THM
 %noshift EOF
 %name RedPrl
 %arg (fileName) : string
 %%
 
-start : sign (sign)
+start : elt (elt)
 
 psort
   : DIM (P.DIM)
@@ -400,14 +400,13 @@ rawDecl
   | DCL_THM IDENT declParamsBrackets declArgumentsParens COLON LSQUARE judgment RSQUARE BY LSQUARE tactic RSQUARE
       (IDENT, Signature.THM {arguments = declArgumentsParens, params = declParamsBrackets, goal = judgment, script = tactic})
 
-decl : rawDecl (#1 rawDecl, (#2 rawDecl, SOME (Pos.pos (rawDecl1left fileName) (rawDecl1right fileName))))
+decl : rawDecl (#1 rawDecl, #2 rawDecl, Pos.pos (rawDecl1left fileName) (rawDecl1right fileName))
 
 rawCmd
   : CMD_PRINT IDENT (Signature.PRINT IDENT)
 
 cmd : rawCmd (rawCmd, (Pos.pos (rawCmd1left fileName) (rawCmd1right fileName)))
 
-sign
-  : (Signature.empty)
-  | sign decl DOT (Signature.insert sign (#1 decl) (#2 decl))
-  | sign cmd DOT (Signature.command sign cmd)
+elt
+  : cmd DOT (Signature.CMD cmd)
+  | decl DOT (Signature.DECL decl)

--- a/src/redprl/signature.sig
+++ b/src/redprl/signature.sig
@@ -34,6 +34,10 @@ sig
 
   type src_cmd = src_opid cmd
 
+  datatype src_elt =
+     DECL of string * src_decl * Pos.t
+   | CMD of src_cmd * Pos.t
+
   val empty : sign
   val insert : sign -> src_opid -> src_decl * Pos.t option -> sign
   val command : sign -> src_opid cmd * Pos.t -> sign

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -36,6 +36,10 @@ struct
 
     type src_cmd = src_opid cmd
 
+    datatype src_elt =
+       DECL of string * src_decl * Pos.t
+     | CMD of src_cmd * Pos.t
+
     (* elaborated declarations *)
     datatype elab_decl =
        EDEF of entry

--- a/test/failure/incremental-parse.prl
+++ b/test/failure/incremental-parse.prl
@@ -1,0 +1,11 @@
+// Two copies of the same theorem. The first one has a syntax error
+// (curlys instead of squares around the proof), but the second one is
+// just fine, and should be processed by RedPRL despite the earlier error.
+
+Thm foo : [tt = tt : bool ] by {
+  auto
+}.
+
+Thm bar : [ tt = tt : bool ] by [
+  auto
+].

--- a/test/failure/incremental-parse.prl
+++ b/test/failure/incremental-parse.prl
@@ -1,11 +1,16 @@
-// Two copies of the same theorem. The first one has a syntax error
-// (curlys instead of squares around the proof), but the second one is
-// just fine, and should be processed by RedPRL despite the earlier error.
+// Three copies of the same theorem. The second one has a syntax error
+// (curlys instead of squares around the proof), but the first and
+// last ones are just fine, and should be processed by RedPRL despite
+// the error in the middle.
 
-Thm foo : [tt = tt : bool ] by {
+Thm foo : [ tt = tt : bool ] by [
+  auto
+].
+
+Thm bar : [ tt = tt : bool ] by {
   auto
 }.
 
-Thm bar : [ tt = tt : bool ] by [
+Thm baz : [ tt = tt : bool ] by [
   auto
 ].

--- a/test/success/empty.prl
+++ b/test/success/empty.prl
@@ -1,0 +1,1 @@
+// This is an empty signature


### PR DESCRIPTION
Fixes #147.

In order to support better recovery from syntax errors, this PR changes the parser to parse signature *elements*. (An element is defined to be either a command or a declaration.) A signature is parsed "by hand" by calling the element parser in a loop.

When encountering a syntax error, the loop scans the token stream until it sees a token that is the beginning of some element, and then tries to parse another element starting there. So a signature with syntax errors can have most of its parts checked.

If any parse errors are encountered while processing a signature, the signature is considered to have failed to check.

The test `test/failure/incremental-parsing.prl` shows a signature consisting of a syntax-correct theorem, then a theorem with a syntax error, and then another syntax-correct one. The changes in this PR allow RedPRL to check the two syntax-correct theorems while printing an error for the one with a problem.

I put most of the "by hand" parser in `src/frontend/frontend.sml`, but it might make more sense to move it somewhere in `src/redprl/`, where the rest of the parsing infrastructure lives. Suggestions welcome.