### PR TITLE
Support reading input from stdin

### DIFF
--- a/src/frontend/frontend.sml
+++ b/src/frontend/frontend.sml
@@ -78,7 +78,7 @@ struct
       end
       handle exn => (logExn exn; (false, sign, recover lexer))
   in
-    fun parseSig fileName =
+    fun parseSig fileName buf =
       let
         fun loop acc lexer sign =
           let
@@ -94,18 +94,27 @@ struct
               end
           end
 
-        val input = TextIO.inputAll (TextIO.openIn fileName)
-        val lexer = RedPrlParser.makeLexer (stringreader input) fileName
+        val lexer = RedPrlParser.makeLexer (stringreader buf) fileName
       in
         loop true lexer Signature.empty
       end
   end
 
-  fun processFile fileName =
+  fun processBuffer fileName buf =
     let
-      val (noParseErrors, sign) = parseSig fileName
+      val (noParseErrors, sign) = parseSig fileName buf
     in
       Signature.check sign andalso noParseErrors
     end
     handle exn => (logExn exn; false)
+
+  fun processStream fileName stream =
+    let
+      val input = TextIO.inputAll stream
+    in
+      processBuffer fileName input
+    end
+
+  fun processFile fileName =
+    processStream fileName (TextIO.openIn fileName)
 end


### PR DESCRIPTION
Fixes #146. Makes progress on freebroccolo/vscode-redprl#2.

Depends on #159. ~I'll clean up this branch after that PR is merged.~ EDIT: Done.

This PR adds a command line option `--from-stdin` to RedPRL. From the help message:
```
--from-stdin[=filename]   Read signature from stdin with optional diagnostic filename
```
The `=` syntax made it easier to work with in the (lack of a 😛 ) command line argument parsing library in RedPRL. I hope it isn't too hard for users or tools to adapt to. 