### PR TITLE
Refactor parser to improve error reporting when start-of-item token is malformed

### DIFF
--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -156,7 +156,7 @@ end
 %verbose
 %pos (string -> Coord.t)
 %start start
-%eop EOF CMD_PRINT DCL_DEF DCL_TAC DCL_THM
+%eop EOF DOT
 %noshift EOF
 %name RedPrl
 %arg (fileName) : string
@@ -408,5 +408,5 @@ rawCmd
 cmd : rawCmd (rawCmd, (Pos.pos (rawCmd1left fileName) (rawCmd1right fileName)))
 
 elt
-  : cmd DOT (Signature.CMD cmd)
-  | decl DOT (Signature.DECL decl)
+  : cmd (Signature.CMD cmd)
+  | decl (Signature.DECL decl)


### PR DESCRIPTION
As @freebroccolo pointed out in the comments of #159, there was an issue caused by the parser using the start-of-item tokens (`Thm`, `Def`, etc.) as terminators for the previous item. 

When these tokens were malformed (eg, `hm` instead of `Thm`), RedPRL would see the item before the malformed token and the item starting with the malformed token as one big messed up item, which caused it not to analyze the first item. This is confusing because it intuitively seems like the first item is well formed and should be processed.

This PR uses the '.' token as the separator, which removes this confusing behavior.

For convenience, this PR depends on #160. So I'll clean up the branch once that's merged.

I've reproduced the old issue on my machine in flycheck/emacs and checked that this fixes it.

@freebroccolo: Could you just double check that this also fixes what you were seeing in vscode, and that there are no further issues of this sort that immediately pop up for you?