### PR TITLE
Improve handling of lexical errors

### DIFF
--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -26,8 +26,6 @@ fun posTupleWith n x =
     (x, l, r)
   end
 
-exception LexerError of pos
-
 %%
 %arg (fileName : string);
 %header (functor RedPrlLexFun (structure Tokens : RedPrl_TOKENS));
@@ -130,3 +128,5 @@ whitespace = [\ \t];
 "synth"            => (Tokens.JDG_SYNTH (posTuple (size yytext)));
 
 {alpha}{identChr}* => (Tokens.IDENT (posTupleWith (size yytext) yytext));
+
+.                  => (RedPrlLog.print RedPrlLog.FAIL (SOME (Pos.pos (!pos yyarg) (!pos yyarg)), "lexical error: skipping unrecognized character '" ^ yytext ^ "'"); continue ());

--- a/test/failure/lexical-error.prl
+++ b/test/failure/lexical-error.prl
@@ -1,0 +1,3 @@
+Thm boolTest : [ (_ : bool) -> bool true ] by [
+  { lam _. '_tt }; auto
+].


### PR DESCRIPTION
This PR makes the lexer more idiomatic by matching all possible input. (See Section 7.3 of the [mllex user manual](http://rogerprice.org/ug/ug.pdf).)

The lexer now just skips characters it doesn't recognize, while printing an error. 

This change also means that lexical errors are reported using the normal RedPRL error mechanism, so they show up as expected in IDEs.