### PR TITLE
Fix two issues related to goal `bool * bool = bool * bool type`

### DIFF
--- a/src/redprl/categorical_judgment.sml
+++ b/src/redprl/categorical_judgment.sml
@@ -68,6 +68,7 @@ struct
          O.MONO O.JDG_EQ $ [_ \ m, _\ n, _ \ a] => EQ ((m, n), a)
        | O.MONO O.JDG_MEM $ [_ \ m, _ \ a] => MEM (m, a)
        | O.MONO O.JDG_TRUE $ [_ \ a] => TRUE a
+       | O.MONO O.JDG_EQ_TYPE $ [_ \ m, _\ n] => EQ_TYPE (m, n)
        | O.MONO O.JDG_TYPE $ [_ \ a] => TYPE a
        | O.MONO O.JDG_SYNTH $ [_ \ m] => SYNTH m
        | O.MONO O.JDG_CEQ $ [_ \ m, _ \ n] => CEQUIV (m, n)

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -328,7 +328,7 @@ struct
         val (goal1, _) = makeGoal @@ H >> CJ.EQ_TYPE (a0, a1)
         val (goal2, _) = makeGoal @@ H @> (z, CJ.TRUE a0) >> CJ.EQ_TYPE (b0z, b1z)
       in
-        T.empty >: goal1 >: goal1
+        T.empty >: goal1 >: goal2
           #> trivial
       end
       handle Bind =>

--- a/test/success/bool-pair-test.prl
+++ b/test/success/bool-pair-test.prl
@@ -1,0 +1,3 @@
+Thm test : [ (x : bool) * bool = (y : bool) * bool type ] by [
+  auto
+].


### PR DESCRIPTION
I discovered two unrelated issues with RedPRL's handling of type level equalities. 

First, conversion `fromAbt` did not match type-level equalities, meaning that they could not even be stated.

Second, the sigma type's equality rule had a small typo in it.