### PR TITLE
use exit code correctly in the test script

### DIFF
--- a/script/test.sh
+++ b/script/test.sh
@@ -27,3 +27,5 @@ done
 if [ $PROBLEM -eq 0 ] ; then
     echo "All tests ran as expected!"
 fi
+
+exit $PROBLEM


### PR DESCRIPTION
As noted in #167, the test script did not report failures correctly.