### PR TITLE
Handle new BadConversion exception from abt lib

### DIFF
--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -303,7 +303,7 @@ struct
       fun convertToAbt (metactx, symctx, env) ast sort =
         E.wrap (RedPrlAst.getAnnotation ast,
                 fn () => AstToAbt.convertOpen (metactx, metactxToNameEnv metactx) (env, NameEnv.empty) (ast, sort)
-                         handle AstToAbt.FreeMeta (mv, pos) => raise Err.annotate pos (Err.error [Err.% "Unbound metavariable", Err.% mv]))
+                         handle AstToAbt.BadConversion (msg, pos) => raise Err.annotate pos (Err.error [Err.% msg]))
           >>= scopeCheck (metactx, symctx)
     end
 

--- a/test/failure/bad-op.prl
+++ b/test/failure/bad-op.prl
@@ -1,0 +1,4 @@
+Def Foo(#a : exp; #b : exp) : exp = [ (x : #a) -> #b ].
+
+Thm Foo-bool-type : [Foo(bool) type] by [
+].


### PR DESCRIPTION
RedPRL/sml-typed-abts#78 adds a generic conversion error. This PR handles that error in RedPRL. The two PRs should be merged at the same time; neither is backwards compatible.

I also added a test demonstrating the new error message when arities don't match.

```
../../test/failure/bad-op.prl:3.22-3.31 [Error]:
  Arity mismatch for operator foo{}
```