### PR TITLE
Build under sml-nj

### DIFF
--- a/script/go-nj.sml
+++ b/script/go-nj.sml
@@ -1,0 +1,3 @@
+CM.make "src/frontend.cm";
+SMLofNJ.exportFn ("bin/.heapimg", Main.main);
+

--- a/script/mkexec.sh
+++ b/script/mkexec.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# Batch File Creator
+#
+# Arguments:
+# $1 = SMLNJ runtime
+# $2 = Directory of binaries and heap image
+# $3 = Name of executable (e.g. celf)
+cat > "$2/bin/$3" <<EOF
+#! /bin/sh
+exec "$1" @SMLcmdname=\$0 @SMLload="$2/bin/.heapimg" "\$@"
+EOF
+chmod a+x "$2/bin/$3"

--- a/script/smlnj.sh
+++ b/script/smlnj.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+sml script/go-nj.sml
+script/mkexec.sh `which sml` `pwd` redprl
+

--- a/src/frontend.mlb
+++ b/src/frontend.mlb
@@ -4,7 +4,9 @@ local
   debug.mlb
   frontend/frontend.sml
   frontend/main.sml
+  frontend/main-mlton.sml
 in
   structure Frontend
   structure Main
+  structure MainMLton
 end

--- a/src/frontend/main-mlton.sml
+++ b/src/frontend/main-mlton.sml
@@ -1,0 +1,8 @@
+structure MainMLton =
+struct
+  val _ =
+    OS.Process.exit
+      (Main.main
+        (CommandLine.name (),
+         CommandLine.arguments ()))
+end

--- a/src/frontend/main.sml
+++ b/src/frontend/main.sml
@@ -59,11 +59,4 @@ struct
     handle E =>
       (print (RedPrlError.format E);
        OS.Process.failure)
-
-(*  val _ =
-    OS.Process.exit
-      (main
-        (CommandLine.name (),
-         CommandLine.arguments ())) *)
-
 end

--- a/src/frontend/main.sml
+++ b/src/frontend/main.sml
@@ -60,10 +60,10 @@ struct
       (print (RedPrlError.format E);
        OS.Process.failure)
 
-  val _ =
+(*  val _ =
     OS.Process.exit
       (main
         (CommandLine.name (),
-         CommandLine.arguments ()))
+         CommandLine.arguments ())) *)
 
 end


### PR DESCRIPTION
Fixes #172.

WIP: this works by commenting out the binding mentioned in #172, which is not a long term solution. In particular, the exit code should be set, and the command line arguments passed in. And this should be done in a way that is compatible with SML-NJ and MLton.