### PR TITLE
Add proof rules for hcom

### DIFF
--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1136,6 +1136,7 @@ struct
 
   structure Computation =
   struct
+    exception UnsafeStep
 
     local
       open Machine.S.Cl infix <: $
@@ -1149,7 +1150,7 @@ struct
           case out m of
              th $ _ =>
                if List.exists (fn (_, sigma) => sigma = P.DIM) @@ Abt.O.support th then
-                 NONE
+                 raise UnsafeStep
                else
                  Machine.next sign st
            | _ => NONE

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1141,6 +1141,27 @@ struct
                                                     (tubeCapGoals H ty r0 cap0 group0)))
         #> trivial
       end
+
+    fun CapEq alpha jdg =
+      let
+        val _ = RedPrlLog.trace "HCom.CapEq"
+        val H >> CJ.EQ ((lhs, rhs), ty) = jdg
+        val Syn.HCOM (exts, (r, r'), ty0, cap, tubes) = Syn.out lhs
+        val () = assertParamEq "HCom.CapEq source and target of direction" (r, r')
+        val () = assertAlphaEq (ty0, ty)
+        val () = assertAlphaEq (cap, rhs)
+        val group = groupTubes exts tubes
+
+        val (goalTy, _) = makeGoal @@ H >> CJ.TYPE ty
+        val (goalCap, _) = makeGoal @@ H >> CJ.MEM (cap, ty)
+
+        val w = alpha 0
+      in
+        T.append (T.empty >: goalTy >: goalCap)
+                 (T.append (intraTubeGoals H w ty group)
+                           (tubeCapGoals H ty r cap group))
+        #> trivial
+      end
   end
 
 

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1166,7 +1166,6 @@ struct
         val _ = RedPrlLog.trace "Computation.EqHeadExpansion"
         val H >> CJ.EQ ((m, n), ty) = jdg
         val Abt.$ (theta, _) = Abt.out m
-        val hasFreeDims = List.exists (fn (_, sigma) => sigma = P.DIM) @@ Abt.O.support theta
         val m' = Machine.unload sign (safeEval sign (Machine.load m))
         val (goal, _) = makeGoal @@ H >> CJ.EQ ((m', n), ty)
       in
@@ -1179,7 +1178,6 @@ struct
         val _ = RedPrlLog.trace "Computation.EqTypeHeadExpansion"
         val H >> CJ.EQ_TYPE (ty1, ty2) = jdg
         val Abt.$ (theta, _) = Abt.out ty1
-        val hasFreeDims = List.exists (fn (_, sigma) => sigma = P.DIM) @@ Abt.O.support theta
         val ty1' = Machine.unload sign (safeEval sign (Machine.load ty1))
         val (goal, _) = makeGoal @@ H >> CJ.EQ_TYPE (ty1', ty2)
         in

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1162,6 +1162,35 @@ struct
                            (tubeCapGoals H ty r cap group))
         #> trivial
       end
+
+    fun TubeEq i alpha jdg =
+      let
+        val _ = RedPrlLog.trace "HCom.TubeEq"
+        val H >> CJ.EQ ((lhs, rhs), ty) = jdg
+        val Syn.HCOM (exts, (r, r'), ty0, cap, tubes) = Syn.out lhs
+        val () = assertAlphaEq (ty0, ty)
+        val j =
+          case List.nth (exts, i) of
+             P.APP P.DIM0 => 0
+           | P.APP P.DIM1 => 1
+           | _ => raise Fail "HCom.TubeEq extent"
+
+        val (u, tube) = List.nth (tubes, 2 * i + j)
+
+        val () = assertAlphaEq (substSymbol (r', u) tube, rhs)
+
+        val group = groupTubes exts tubes
+
+        val (goalTy, _) = makeGoal @@ H >> CJ.TYPE ty
+        val (goalCap, _) = makeGoal @@ H >> CJ.MEM (cap, ty)
+
+        val w = alpha 0
+      in
+        T.append (T.empty >: goalTy >: goalCap)
+                 (T.append (intraTubeGoals H w ty group)
+                           (tubeCapGoals H ty r cap group))
+        #> trivial
+      end
   end
 
 

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1150,15 +1150,15 @@ struct
         val Syn.HCOM (exts, (r, r'), ty0, cap, tubes) = Syn.out lhs
         val () = assertParamEq "HCom.CapEq source and target of direction" (r, r')
         val () = assertAlphaEq (ty0, ty)
-        val () = assertAlphaEq (cap, rhs)
         val group = groupTubes exts tubes
 
         val (goalTy, _) = makeGoal @@ H >> CJ.TYPE ty
         val (goalCap, _) = makeGoal @@ H >> CJ.MEM (cap, ty)
+        val (goalEq, _) = makeGoal @@ H >> CJ.EQ ((cap, rhs), ty)
 
         val w = alpha 0
       in
-        T.append (T.empty >: goalTy >: goalCap)
+        T.append (T.empty >: goalTy >: goalCap >: goalEq)
                  (T.append (intraTubeGoals H w ty group)
                            (tubeCapGoals H ty r cap group))
         #> trivial
@@ -1178,16 +1178,15 @@ struct
 
         val (u, tube) = List.nth (tubes, 2 * i + j)
 
-        val () = assertAlphaEq (substSymbol (r', u) tube, rhs)
-
         val group = groupTubes exts tubes
 
         val (goalTy, _) = makeGoal @@ H >> CJ.TYPE ty
         val (goalCap, _) = makeGoal @@ H >> CJ.MEM (cap, ty)
+        val (goalEq, _) = makeGoal @@ H >> CJ.EQ ((substSymbol (r', u) tube, rhs), ty)
 
         val w = alpha 0
       in
-        T.append (T.empty >: goalTy >: goalCap)
+        T.append (T.empty >: goalTy >: goalCap >: goalEq)
                  (T.append (intraTubeGoals H w ty group)
                            (tubeCapGoals H ty r cap group))
         #> trivial

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1105,6 +1105,7 @@ struct
             (ext, P.APP P.DIM0, tube0) ::
             (ext, P.APP P.DIM1, tube1) ::
             groupTubes exts tubes
+          | groupTubes _ _ = raise Fail "groupTubes"
 
         fun listToTel' acc [] = acc
           | listToTel' acc (g :: l) = listToTel' (acc >: g) l

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1023,14 +1023,17 @@ struct
        directed" on the restriction being performed.
      *)
 
-    fun neqDims (P.APP P.DIM0, P.APP DIM1) = true
-      | neqDims (P.APP P.DIM1, P.APP DIM0) = true
-      | neqDims _ = false
+    (* Return whether given dimensions are different constants, which
+       is a contradiction, allowing the restriction judgment to conclude
+       anything. *)
+    fun dimsContradictory (P.APP P.DIM0, P.APP DIM1) = true
+      | dimsContradictory (P.APP P.DIM1, P.APP DIM0) = true
+      | dimsContradictory _ = false
 
     (* Restrict a judgement by a single equation `ext = eps`. *)
     fun One (jdg : abt jdg) (ext : param) (eps : param) =
       if P.eq Sym.eq (ext, eps) then [jdg] (* combining rules in first row *)
-      else if neqDims (ext, eps) then [] (* second row, left rule *)
+      else if dimsContradictory (ext, eps) then [] (* second row, left rule *)
       else
         let
           val (P.VAR v, P.APP eps) = (ext, eps)
@@ -1042,8 +1045,8 @@ struct
     fun Two (jdg : abt jdg) (ext0 : param) (eps0 : param) (ext1 : param) (eps1 : param) =
       if P.eq Sym.eq (ext0, eps0) then One jdg ext1 eps1 (* top right rule *)
       else if P.eq Sym.eq (ext1, eps1) then One jdg ext0 eps0 (* top right rule *)
-      else if neqDims (ext0, eps0) then [] (* second row, left rule *)
-      else if neqDims (ext1, eps1) then [] (* second row, left rule *)
+      else if dimsContradictory (ext0, eps0) then [] (* second row, left rule *)
+      else if dimsContradictory (ext1, eps1) then [] (* second row, left rule *)
       else
         let
           val (P.VAR u, P.APP _) = (ext0, eps0)

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -74,11 +74,9 @@ struct
         val Syn.S1 = Syn.out ty
         val Syn.LOOP r1 = Syn.out m
         val Syn.LOOP r2 = Syn.out n
+        val () = assertParamEq "S1.EqLoop" (r1, r2)
       in
-        if P.eq Sym.eq (r1, r2) then
-          T.empty #> trivial
-        else
-          raise E.error [E.% "Expected loops in same dimension"]
+        T.empty #> trivial
       end
 
     fun Elim z alpha jdg =
@@ -678,7 +676,7 @@ struct
         val H >> CJ.EQ ((ap0, ap1), ty) = jdg
         val Syn.ID_AP (m0, r0) = Syn.out ap0
         val Syn.ID_AP (m1, r1) = Syn.out ap1
-        val true = P.eq Sym.eq (r0, r1)
+        val () = assertParamEq "Path.ApEq" (r0, r1)
         val (goalSynth, holeSynth) = makeGoal @@ H >> CJ.SYNTH m0
         val (goalMem, _) = makeGoal @@ H >> CJ.EQ ((m0, m1), holeSynth [] [])
         val (goalLine, holeLine) = makeGoal @@ MATCH (O.MONO O.ID_TY, 0, holeSynth [] [])

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1155,12 +1155,11 @@ struct
         val group = groupTubes exts tubes
 
         val (goalTy, _) = makeGoal @@ H >> CJ.TYPE ty
-        val (goalCap, _) = makeGoal @@ H >> CJ.MEM (cap, ty)
         val (goalEq, _) = makeGoal @@ H >> CJ.EQ ((cap, rhs), ty)
 
         val w = alpha 0
       in
-        T.append (T.empty >: goalTy >: goalCap >: goalEq)
+        T.append (T.empty >: goalTy >: goalEq)
                  (T.append (intraTubeGoals H w ty group)
                            (tubeCapGoals H ty r cap group))
         #> trivial

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1282,7 +1282,10 @@ struct
         case (Machine.canonicity sign m, Machine.canonicity sign n) of
            (Machine.CANONICAL, Machine.CANONICAL) => StepEqVal ((m, n), ty)
          | (Machine.NEUTRAL x, Machine.NEUTRAL y) => StepEqNeu (x, y) ((m, n), ty)
-         | (Machine.REDEX, _) => Computation.EqHeadExpansion sign
+         | (Machine.REDEX, _) => (fn a =>
+           (* this is a horrible hack to get the hcom rule to be called sometimes *)
+           Lcf.orelse_ (HCom.Eq a,
+                        Computation.EqHeadExpansion sign a))
          | (_, Machine.REDEX) => Equality.Symmetry
          | (Machine.NEUTRAL (Machine.VAR x), Machine.CANONICAL) => StepEqEta ty
          | (Machine.CANONICAL, Machine.NEUTRAL _) => Equality.Symmetry

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1126,16 +1126,6 @@ struct
 
         val w = alpha 0
 
-        fun interTube ext eps (u, tube0) (v, tube1) =
-          let
-            val tube0 = substSymbol (P.ret w, u) tube0
-            val tube1 = substSymbol (P.ret w, v) tube1
-            val J = H >> CJ.EQ ((tube0,tube1), ty)
-          in
-            List.map (fn j => #1 (makeGoal (([(w, P.DIM)], []) |> j)))
-                     (Restriction.One J ext eps)
-          end
-
         val group0 = groupTubes exts0 tubes0
         val group1 = groupTubes exts1 tubes1
 
@@ -1145,10 +1135,22 @@ struct
                N_i^eps = P_i^eps in A [Psi, y | r_i = eps]
          *)
         val interTubeGoals =
-          listToTel
-            (ListMonad.bind
-               (fn ((ext, eps, tube0), (_, _, tube1)) => interTube ext eps tube0 tube1)
-               (ListPair.zipEq (group0, group1)))
+          let
+            fun interTube ext eps (u, tube0) (v, tube1) =
+              let
+                val tube0 = substSymbol (P.ret w, u) tube0
+                val tube1 = substSymbol (P.ret w, v) tube1
+                val J = H >> CJ.EQ ((tube0,tube1), ty)
+              in
+                List.map (fn j => #1 (makeGoal (([(w, P.DIM)], []) |> j)))
+                         (Restriction.One J ext eps)
+              end
+          in
+            listToTel
+              (ListMonad.bind
+                 (fn ((ext, eps, tube0), (_, _, tube1)) => interTube ext eps tube0 tube1)
+                 (ListPair.zipEq (group0, group1)))
+          end
       in
         T.append (T.empty >: goalTy >: goalCap)
                  (T.append interTubeGoals (T.append (intraTubeGoals H w ty group0)

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1072,7 +1072,10 @@ struct
 
     fun listToTel l = List.foldl (fn (g, l) => l >: g) T.empty l
 
-    (* Produce the list of goals requiring that tube aspects agree with each other. *)
+    (* Produce the list of goals requiring that tube aspects agree with each other.
+         forall i, j, eps, eps'.
+           N_i^eps = N_j^eps' in A [Psi, y | r_i = eps, r_j = eps']
+     *)
     fun intraTubeGoals H w ty group =
       let
         fun intraTube (ext0, eps0, (u, tube0)) (ext1, eps1, (v, tube1)) =
@@ -1091,7 +1094,10 @@ struct
              group)
       end
 
-    (* Produce the list of goals requiring that tube aspects agree with the cap. *)
+    (* Produce the list of goals requiring that tube aspects agree with the cap.
+         forall i, eps.
+           N_i^eps<r/y> = M in A [Psi | r_i = eps]
+     *)
     fun tubeCapGoals H ty r cap group =
       let
         fun tubeCap (ext, eps, (u, tube)) =
@@ -1133,6 +1139,11 @@ struct
         val group0 = groupTubes exts0 tubes0
         val group1 = groupTubes exts1 tubes1
 
+        (* The list of goals requiring that corresponding tube aspects
+           from the left and right side agree.
+             forall i, eps.
+               N_i^eps = P_i^eps in A [Psi, y | r_i = eps]
+         *)
         val interTubeGoals =
           listToTel
             (ListMonad.bind

--- a/src/redprl/refiner_kit.fun
+++ b/src/redprl/refiner_kit.fun
@@ -119,6 +119,12 @@ struct
     else
       raise E.error [E.% "Expected", E.! m, E.% "to be alpha-equivalent to", E.! n]
 
+  fun assertParamEq msg (r1, r2) =
+    if P.eq Sym.eq (r1, r2) then
+      ()
+    else
+      raise E.error [E.% (msg ^ ":"), E.% "Expected parameter", E.% (P.toString Sym.toString r1), E.% "to be equal to", E.% (P.toString Sym.toString r2)]
+
   fun assertVarEq (x, y) =
     if Var.eq (x, y) then
       ()

--- a/test/failure/bad-hcom-step.prl
+++ b/test/failure/bad-hcom-step.prl
@@ -1,0 +1,8 @@
+Thm BoolSym : [
+  (a : bool) -> (b : bool) ->
+  paths({_}.bool; a; b) ->
+  paths({_}.bool; b; a) true
+] by [
+  { lam a. lam b. lam p. <i> 'hcom{i; 0 ~> 1}(bool; ,a; {j}. ,p @ j; {_}. ,a)};
+  [auto-step; head-expand]
+].

--- a/test/success/bool-hcom.prl
+++ b/test/success/bool-hcom.prl
@@ -1,0 +1,12 @@
+Thm BasicHcom : [
+  (a : bool) -> (b : bool) -> (c : bool) -> (d : bool) ->
+  paths({_}.bool; a; b) ->
+  paths({_}.bool; a; c) ->
+  paths({_}.bool; b; d) ->
+  paths({_}.bool; c; d) true
+] by [
+  { lam a. lam b. lam c. lam d.
+    lam pab. lam pac. lam pbd.
+    <i> 'hcom{i; 0 ~> 1}(bool; ,pab @ i; {j}. ,pac @ j; {j}. ,pbd @ j)
+  }; auto
+].

--- a/test/success/bool-hcom.prl
+++ b/test/success/bool-hcom.prl
@@ -10,3 +10,11 @@ Thm BasicHcom : [
     <i> 'hcom{i; 0 ~> 1}(bool; ,pab @ i; {j}. ,pac @ j; {j}. ,pbd @ j)
   }; auto
 ].
+
+Thm Cap{i : dim} : [ hcom{i; 0 ~> 0}(bool; tt; {_}. tt; {_}. tt) = tt : bool ] by [
+  auto
+].
+
+Thm Tube : [ hcom{0; 0 ~> 1}(bool; tt; {_}. tt; {_}. tt) = tt : bool ] by [
+  auto
+].

--- a/test/success/bool-sym.prl
+++ b/test/success/bool-sym.prl
@@ -1,0 +1,8 @@
+Thm BoolSym : [
+  (a : bool) -> (b : bool) ->
+  paths({_}.bool; a; b) ->
+  paths({_}.bool; b; a) true
+] by [
+  { lam a. lam b. lam p. <i> 'hcom{i; 0 ~> 1}(bool; ,a; {j}. ,p @ j; {_}. ,a)};
+  auto
+].


### PR DESCRIPTION
This is a work in progress on adding hcom rules to RedPRL's proof theory. These are summarized on pg 46 of "Dependent cubical realizability".

- [x] Add hcoms to the syntax view
- [x] Structural equality rule for hcoms
- [x] "Cap" rule
- [x] "Tube" rule
- [x] Figure out a better way of getting HCom.Eq rule to be called by auto
- [x] Add test for Cap rule
- [x] Add test for Tube rule