### PR TITLE
rough start on implementing rule schemes

### DIFF
--- a/src/redprl.cm
+++ b/src/redprl.cm
@@ -6,6 +6,7 @@ Library
   structure RedPrlLog
   structure RedPrlError
   structure RedPrlLrVals
+  structure RedPrlAbt
 is
   $/basis.cm
   $/ml-yacc-lib.cm

--- a/src/redprl.cm
+++ b/src/redprl.cm
@@ -25,6 +25,7 @@ is
 
   debug.cm
 
+  redprl/symbol.sml
   redprl/parameter.sml
   redprl/operator.sml
   redprl/abt.sml

--- a/src/redprl.mlb
+++ b/src/redprl.mlb
@@ -19,6 +19,7 @@ local
 
   debug.mlb
 
+  redprl/symbol.sml
   redprl/parameter.sml
   redprl/operator.sml
   redprl/abt.sml

--- a/src/redprl/abt.sml
+++ b/src/redprl/abt.sml
@@ -1,7 +1,3 @@
-structure Metavar = AbtSymbol ()
-structure Sym = AbtSymbol ()
-structure Var = Sym
-
 local
   structure AbtKit =
   struct

--- a/src/redprl/categorical_judgment.sml
+++ b/src/redprl/categorical_judgment.sml
@@ -72,7 +72,7 @@ struct
        | O.MONO O.JDG_TYPE $ [_ \ a] => TYPE a
        | O.MONO O.JDG_SYNTH $ [_ \ m] => SYNTH m
        | O.MONO O.JDG_CEQ $ [_ \ m, _ \ n] => CEQUIV (m, n)
-       | _ => raise InvalidJudgment
+       | _ => raise Fail ("Invalid judgment: " ^ TermPrinter.toString jdg)
   end
 
   val toString = TermPrinter.toString o toAbt

--- a/src/redprl/error.sml
+++ b/src/redprl/error.sml
@@ -20,6 +20,7 @@ struct
   val rec format =
     fn E frags => ListSpine.pretty fragToString " " frags
      | Pos (_, exn) => format exn
+     | BadSubstMetaenv {description,...} => description
      | exn => exnMessage exn
 
    fun annotate (SOME pos) exn = Pos (pos, exn)

--- a/src/redprl/lcf_model.fun
+++ b/src/redprl/lcf_model.fun
@@ -27,7 +27,7 @@ struct
      | O.MONO O.RULE_WITNESS $ [_ \ tm] => Rules.Truth.Witness tm
      | O.MONO O.RULE_HEAD_EXP $ _ => Rules.Computation.EqHeadExpansion sign
      | O.MONO O.RULE_SYMMETRY $ _ => Rules.Equality.Symmetry
-     | O.MONO O.RULE_CUT $ [_ \ catjdg] => Rules.Cut (RedPrlCategoricalJudgment.fromAbt catjdg)
+     | O.MONO O.RULE_CUT $ [_ \ catjdg] => (Rules.Cut (RedPrlCategoricalJudgment.fromAbt catjdg) handle _ => raise Fail "fuck30")
      | O.MONO (O.RULE_LEMMA _) $ [_ \ thm] => Rules.Lemma thm
      | _ => raise E.error [E.% "Invalid rule", E.! rule]
 

--- a/src/redprl/machine.sml
+++ b/src/redprl/machine.sml
@@ -181,7 +181,7 @@ struct
 
      | O.MONO O.AX `$ _ <: _ => S.VAL
 
-     | O.MONO (O.REFINE _) `$ _ <: _ => S.VAL
+     | O.POLY (O.REFINE _) `$ _ <: _ => S.VAL
      | O.MONO (O.EXTRACT tau) `$ [_ \ thm] <: env =>
          S.CUT
            @@ (O.MONO (O.EXTRACT tau) `$ [([],[]) \ S.HOLE], thm)
@@ -372,9 +372,10 @@ struct
      | (O.MONO O.FST `$ [_ \ S.HOLE], _ \ O.MONO O.PAIR `$ [_ \ m, _ \ n] <: env) => m <: env
      | (O.MONO O.SND `$ [_ \ S.HOLE], _ \ O.MONO O.PAIR `$ [_ \ m, _ \ n] <: env) => n <: env
 
-     | (O.MONO (O.EXTRACT _) `$ [_ \ S.HOLE], _ \ O.MONO (O.REFINE (true, _)) `$ [_, _, _ \ m] <: env) => m <: env
-     | (O.MONO (O.RULE_LEMMA (_, tau)) `$ [_ \ S.HOLE], _ \ O.MONO (O.REFINE (true, tau')) `$ [goal, script, evd] <: env) =>
-         O.MONO (O.RULE_LEMMA (true, tau)) $$ [([],[]) \ O.MONO (O.REFINE (true, tau')) $$ [goal, script, evd]] <: env
+     | (O.MONO (O.EXTRACT _) `$ [_ \ S.HOLE], _ \ O.POLY (O.REFINE ([], _)) `$ [_, _, _ \ m] <: env) => m <: env
+     | (O.MONO (O.RULE_LEMMA (_, tau)) `$ [_ \ S.HOLE], _ \ O.POLY (O.REFINE (vls, tau')) `$ (goal :: script :: rest) <: env) =>
+         O.MONO (O.RULE_LEMMA (true, tau)) $$ [([],[]) \ O.POLY (O.REFINE (vls, tau')) $$ (goal :: script :: rest)] <: env
+
      | (O.MONO O.IF `$ [_, _ \ S.HOLE, _ \ S.% cl, _], _ \ O.MONO O.TRUE `$ _ <: _) => cl
      | (O.MONO O.IF `$ [_, _ \ S.HOLE, _, _ \ S.% cl], _ \ O.MONO O.FALSE `$ _ <: _) => cl
      | (O.MONO O.IF `$ [(_,[x]) \ S.% cx, _ \ S.HOLE, _ \ S.% t, _ \ S.% f], _ \ O.POLY (O.HCOM (O.TAG_BOOL, exts, dir)) `$ (_ \ cap) :: tubes <: env) =>

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -8,6 +8,7 @@ struct
    | JDG
    | TRIV
    | SEQ
+   | GJDG (* generic judgments *)
 end
 
 structure RedPrlSort : ABT_SORT =
@@ -25,6 +26,7 @@ struct
      | JDG => "jdg"
      | TRIV => "triv"
      | SEQ => "seq"
+     | GJDG => "gjdg"
 end
 
 structure RedPrlArity = ListAbtArity (structure PS = RedPrlParamSort and S = RedPrlSort)
@@ -63,6 +65,7 @@ struct
    | JDG_EQ | JDG_CEQ | JDG_MEM | JDG_TRUE | JDG_TYPE | JDG_EQ_TYPE | JDG_SYNTH
 
    | SEQ_CONCL | SEQ_CONS of sort
+   | GJDG_FORM of psort list * sort list (* generic judgment form *)
 
   (* We end up having separate hcom operator for the different types. This
    * corresponds to the fact that there are two stages of computation for a kan
@@ -196,6 +199,7 @@ struct
 
      | SEQ_CONCL => [[] * [] <> JDG] ->> SEQ
      | SEQ_CONS tau => [[] * [] <> JDG, [] * [tau] <> SEQ] ->> SEQ
+     | GJDG_FORM (sigmas, taus) => [sigmas * taus <> SEQ] ->> GJDG
 
   local
     val typeArgsForTag =
@@ -393,6 +397,7 @@ struct
      | JDG_SYNTH => "synth"
      | SEQ_CONCL => "seq-concl"
      | SEQ_CONS _ => "seq-cons"
+     | GJDG_FORM _ => "generic"
 
   local
     fun spanToString f (r, r') =

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -98,7 +98,7 @@ end
  | EXP | TAC
 
  | CMD_PRINT
- | DCL_DEF | DCL_TAC | DCL_THM
+ | DCL_DEF | DCL_TAC | DCL_THM | DCL_RULE
  | BY | IN
 
  | MTAC_REC | MTAC_PROGRESS | MTAC_REPEAT | MTAC_AUTO
@@ -485,6 +485,8 @@ rawDecl
       (OPNAME, Signature.TAC {arguments = declArgumentsParens, params = declParamsBrackets, script = tactic})
   | DCL_THM OPNAME declParamsBrackets declArgumentsParens COLON LSQUARE sequent RSQUARE BY LSQUARE tactic RSQUARE
       (OPNAME, Signature.THM {arguments = declArgumentsParens, params = declParamsBrackets, goal = sequent, script = tactic})
+  (*| DCL_RULE OPNAME declParamsBrackets declArgumentsParens COLON LSQUARE sequent RSQURE BY LSQURE tactic RSQUARE*)
+      (*(OPNAME, Signature.RULE {arguments = declArgumentsParens, params = declParamsBrackets, goal = sequent, script = tactic})*)
 
 decl : rawDecl (#1 rawDecl, #2 rawDecl, Pos.pos (rawDecl1left fileName) (rawDecl1right fileName))
 

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -88,6 +88,7 @@ end
  | BACK_TICK | AT_SIGN | PIPE | DOUBLE_PIPE | PERCENT
  | TIMES
  | DOUBLE_RANGLE
+ | DASHES
 
  | HCOM | COE | UNIV | BOOL | S_BOOL | TT | FF | IF | S_IF | PATHS | LOOP | BASE | S1 | FST | SND
  | THEN | ELSE | LET | WITH | CASE | OF
@@ -171,6 +172,11 @@ end
 
  | rawSequent of ast
  | sequent of ast
+ | genericJdg of ast
+ | rulePremise of ast
+ | rulePremises of ast list
+ | ruleConcl of ast
+ | ruleSpec of ast list * ast
 
  | rawTactic of ast
  | tactic of ast
@@ -378,6 +384,24 @@ rawSequent
 
 sequent : rawSequent (annotate (Pos.pos (rawSequent1left fileName) (rawSequent1right fileName)) rawSequent)
 
+(* TODO *)
+genericJdg
+  : sequent (Ast.$$ (O.MONO (O.GJDG_FORM ([],[])), [\ (([],[]), sequent)]))
+
+rulePremise
+  : LBRACKET genericJdg RBRACKET (genericJdg)
+
+rulePremises
+  : ([])
+  | rulePremise ([rulePremise])
+  | rulePremise COMMA rulePremises (rulePremise :: rulePremises)
+
+ruleConcl
+  : LBRACKET sequent RBRACKET (sequent)
+
+ruleSpec
+  : rulePremises DASHES ruleConcl (rulePremises, ruleConcl)
+
 atomicRawTac
   : RULE_ID (Ast.$$ (O.MONO O.RULE_ID, []))
   | RULE_AUTO_STEP (Ast.$$ (O.MONO O.RULE_AUTO_STEP, []))
@@ -485,8 +509,8 @@ rawDecl
       (OPNAME, Signature.TAC {arguments = declArgumentsParens, params = declParamsBrackets, script = tactic})
   | DCL_THM OPNAME declParamsBrackets declArgumentsParens COLON LSQUARE sequent RSQUARE BY LSQUARE tactic RSQUARE
       (OPNAME, Signature.THM {arguments = declArgumentsParens, params = declParamsBrackets, goal = sequent, script = tactic})
-  (*| DCL_RULE OPNAME declParamsBrackets declArgumentsParens COLON LSQUARE sequent RSQURE BY LSQURE tactic RSQUARE*)
-      (*(OPNAME, Signature.RULE {arguments = declArgumentsParens, params = declParamsBrackets, goal = sequent, script = tactic})*)
+  | DCL_RULE OPNAME declParamsBrackets declArgumentsParens COLON LSQUARE ruleSpec RSQUARE BY LSQUARE tactic RSQUARE
+      (OPNAME, Signature.RULE {arguments = declArgumentsParens, params = declParamsBrackets, premises = (#1 ruleSpec), concl = (#2 ruleSpec), script = tactic})
 
 decl : rawDecl (#1 rawDecl, #2 rawDecl, Pos.pos (rawDecl1left fileName) (rawDecl1right fileName))
 

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -109,6 +109,7 @@ whitespace = [\ \t];
 "Def"              => (Tokens.DCL_DEF (posTuple (size yytext)));
 "Tac"              => (Tokens.DCL_TAC (posTuple (size yytext)));
 "Thm"              => (Tokens.DCL_THM (posTuple (size yytext)));
+"Rule"             => (Tokens.DCL_RULE (posTuple (size yytext)));
 "by"               => (Tokens.BY (posTuple (size yytext)));
 "in"               => (Tokens.IN (posTuple (size yytext)));
 

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -34,11 +34,13 @@ lower = [a-z];
 digit = [0-9];
 identChr = [a-zA-Z0-9\'/-];
 whitespace = [\ \t];
+dashes = [\-\-\-][\-]*;
 %%
 
 \n                 => (pos := (Coord.nextline o (!pos)); continue ());
 {whitespace}+      => (incPos (size yytext); continue ());
 {digit}+           => (Tokens.NUMERAL (posTupleWith (size yytext) (valOf (Int.fromString yytext))));
+{dashes}           => (Tokens.DASHES (posTuple (size yytext)));
 "//"[^\n]*         => (continue ());
 
 

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1253,7 +1253,7 @@ struct
       val _ = RedPrlLog.trace "Lemma"
 
       val Abt.$ (O.POLY (O.REFINE (metas, _)), (_ \ goal) :: (_ \ script) :: (_ \ evidence) :: rest) = Abt.out thm
-      val true = Abt.eq (goal, RedPrlSequent.toAbt jdg)
+      val _ = if Abt.eq (goal, RedPrlSequent.toAbt jdg) then () else raise E.error [E.% "Lemma", E.! goal, E.% "did not match goal"]
 
       fun goalFromSeqTm tm = 
        #1 o makeGoal @@ Lcf.genericFromAbt (SOME alpha) tm

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1235,18 +1235,17 @@ struct
         #> hole1 [] [hole2 [] []]
     end
 
-  fun Lemma thm alpha jdg =
+  fun Lemma thm (alpha : int -> sym) jdg =
     let
       val _ = RedPrlLog.trace "Lemma"
 
       val Abt.$ (O.POLY (O.REFINE (vls, _)), (_ \ goal) :: (_ \ script) :: (_ \ evidence) :: rest) = Abt.out thm
 
-      (*val seq' = RedPrlSequent.fromAbt goal*)
       val true = Abt.eq (goal, RedPrlSequent.toAbt jdg) handle _ => raise Fail "fuck1244"
       fun goalFromTerm ((_, ((sigmas, taus), _)), (xs, us) \ seq) = 
         makeGoal 
           @@ (ListPair.zip (us, sigmas), ListPair.zip (xs, taus)) 
-          || (RedPrlSequent.fromAbt seq handle _ => raise Fail "fuck1248")
+          || (RedPrlSequent.fromAbtUsingNames (SOME alpha) seq handle _ => raise Fail "fuck1248")
           handle _ => raise Fail "fuck1249"
 
       val subgoalsList = ListPair.map goalFromTerm (vls, rest) handle _ => raise Fail "Fuck1251"

--- a/src/redprl/refiner.sig
+++ b/src/redprl/refiner.sig
@@ -6,7 +6,7 @@ sig
   type rule
   type hyp
 
-  val Lemma : abt -> 'n -> Lcf.jdg Lcf.tactic
+  val Lemma : abt -> (int -> hyp) -> Lcf.jdg Lcf.tactic
   val Cut : catjdg -> rule
   val Elim : sign -> hyp -> rule
   val AutoStep : sign -> rule

--- a/src/redprl/sequent.sig
+++ b/src/redprl/sequent.sig
@@ -25,6 +25,7 @@ sig
 
   val eq : CJ.Tm.abt jdg * CJ.Tm.abt jdg -> bool
 
+  val fromAbtUsingNames : (int -> sym) option -> abt -> abt jdg
   val fromAbt : abt -> abt jdg
   val toAbt : abt jdg -> abt
 end

--- a/src/redprl/sequent.sig
+++ b/src/redprl/sequent.sig
@@ -26,4 +26,5 @@ sig
   val eq : CJ.Tm.abt jdg * CJ.Tm.abt jdg -> bool
 
   val fromAbt : abt -> abt jdg
+  val toAbt : abt jdg -> abt
 end

--- a/src/redprl/signature.sig
+++ b/src/redprl/signature.sig
@@ -27,6 +27,7 @@ sig
   datatype src_decl =
      DEF of {arguments : string arguments, params : string params, sort : sort, definiens : ast}
    | THM of {arguments : string arguments, params : string params, goal : ast, script : ast}
+   | RULE of {arguments : string arguments, params : string params, premises : ast list, concl : ast, script : ast}
    | TAC of {arguments : string arguments, params : string params, script : ast}
 
   datatype 'opid cmd =

--- a/src/redprl/symbol.sml
+++ b/src/redprl/symbol.sml
@@ -1,0 +1,3 @@
+structure Sym = AbtSymbol ()
+structure Var = Sym
+structure Metavar = Sym

--- a/test/success/rule-scheme.prl
+++ b/test/success/rule-scheme.prl
@@ -1,12 +1,14 @@
-Thm RuleScheme : [x : bool true >> bool true] by [
-  
+Rule RuleScheme : [
+  {x : bool true >> bool true}
+  ---------------
+  {z : bool true >> bool true}
+] by [
 ].
 
 Print RuleScheme.
 
 Thm Lemma : [ y : bool true >> bool true] by [
-  z <- lemma{RuleScheme{y}():exp};
-  hyp{z}
+  lemma{RuleScheme():exp}
 ].
 
 Print Lemma.

--- a/test/success/rule-scheme.prl
+++ b/test/success/rule-scheme.prl
@@ -1,0 +1,9 @@
+Thm RuleScheme : [x : bool true >> bool true] by [
+  
+].
+
+// Print RuleScheme.
+
+Thm Lemma : [ y : bool true >> bool true] by [
+  lemma{RuleScheme{y}():exp}
+].

--- a/test/success/rule-scheme.prl
+++ b/test/success/rule-scheme.prl
@@ -5,5 +5,6 @@ Thm RuleScheme : [x : bool true >> bool true] by [
 // Print RuleScheme.
 
 Thm Lemma : [ y : bool true >> bool true] by [
-  lemma{RuleScheme{y}():exp}
+  z <- lemma{RuleScheme{y}():exp};
+  
 ].

--- a/test/success/rule-scheme.prl
+++ b/test/success/rule-scheme.prl
@@ -2,9 +2,11 @@ Thm RuleScheme : [x : bool true >> bool true] by [
   
 ].
 
-// Print RuleScheme.
+Print RuleScheme.
 
 Thm Lemma : [ y : bool true >> bool true] by [
   z <- lemma{RuleScheme{y}():exp};
-  
+  hyp{z}
 ].
+
+Print Lemma.


### PR DESCRIPTION
#37 [very rough, don't look at this code (lol!)]

The basic idea is that a rule is just like a theorem, except you can close it without completing all the subgoals. Then, when you use a rule as a lemma, it "restores" the appropriate missing subgoals into the current state. This is a very simple idea, whose technical realization is a bit more involved.

When I add a declaration form for rules (right now I'm just piggy-backing on theorems), this could include a specification of the 'final' subgoal telescope by the user, so that the definitions succeeds only if this specification unifies with the actual state of affairs.

One sucky fact is that we really need a *second-order binder* in the syntax of theorem objects / extractions, to account for the fact that a piece of evidence now can have holes in it. Currently we just fake the binding, which is sad. If we can move to a higher-order logical framework, this would be resolved.