### PR TITLE
Print out build.log in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
   - git submodule update --init --recursive
 script:
   - ./script/test.sh
+  - cat 'build.log'
 
 notifications:
   email: false


### PR DESCRIPTION
MLton warnings are useful for debugging and I want to see them. I will keep git-rebasing till travis is happy. You have been warned.