### PR TITLE
Fix SML/NJ build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
 language: sml
+env:
+  - COMPILER=smlnj PACKAGES="smlnj ml-yacc ml-ulex"
+  - COMPILER=mlton PACKAGES="mlton"
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y --force-yes smlnj mlton
+  - sudo apt-get install -y --force-yes ${PACKAGES}
 install:
   - git submodule init
   - git submodule update --init --recursive
 script:
-  - ./script/test-mlton.sh
+  - ./script/test-${COMPILER}.sh
   - cat 'build.log'
 
 notifications:

--- a/script/smlnj.sh
+++ b/script/smlnj.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+mkdir -p ./bin
 sml script/go-nj.sml
 script/mkexec.sh `which sml` `pwd` redprl
 


### PR DESCRIPTION
Apparently, in SML/NJ it is an error rather than a warning to have redundant cases in pattern matches. I have updated the Travis script to test SML/NJ as well as MLton.

@favonia By the way, this suggests to me that you have been developing RedPRL with MLton, which could be a little frustrating considering how long it takes for MLton to build RedPRL. It may be more fun for you if you use SML/NJ during development, since RedPRL takes only a few seconds to build there. The script `script/smlnj.sh` should get you started.