### PR TITLE
Immortal pretty printer and sexpr-style concrete notation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "lib/sml-wpp"]
 	path = lib/sml-wpp
 	url = https://github.com/RedPRL/sml-wpp.git
+[submodule "lib/sml-final-pretty-printer"]
+	path = lib/sml-final-pretty-printer
+	url = https://github.com/RedPRL/sml-final-pretty-printer

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "lib/sml-dependent-lcf"]
 	path = lib/sml-dependent-lcf
 	url = https://github.com/JonPRL/sml-dependent-lcf.git
-[submodule "lib/sml-unparse"]
-	path = lib/sml-unparse
-	url = https://github.com/RedPRL/sml-unparse.git
 [submodule "lib/sml-json"]
 	path = lib/sml-json
 	url = https://github.com/RedPRL/sml-json.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "lib/sml-cats"]
 	path = lib/sml-cats
 	url = https://github.com/RedPRL/sml-cats.git
-[submodule "lib/sml-wpp"]
-	path = lib/sml-wpp
-	url = https://github.com/RedPRL/sml-wpp.git
 [submodule "lib/sml-final-pretty-printer"]
 	path = lib/sml-final-pretty-printer
 	url = https://github.com/RedPRL/sml-final-pretty-printer

--- a/src/frontend.cm
+++ b/src/frontend.cm
@@ -1,5 +1,6 @@
 Group is
   $/basis.cm
+  ../lib/sml-final-pretty-printer/final-pretty-printer.cm
   redprl.cm (bind:(anchor:libs value:../lib/))
   debug.cm
   frontend/frontend.sml

--- a/src/frontend.mlb
+++ b/src/frontend.mlb
@@ -1,5 +1,6 @@
 local
-  $(SML_LIB)/basis/basis.mlb
+  $(SML_LIB)/basis/basis.ml
+  ../lib/sml-final-pretty-printer/final-pretty-printer.mlb
   redprl.mlb
   debug.mlb
   frontend/frontend.sml

--- a/src/frontend.mlb
+++ b/src/frontend.mlb
@@ -1,5 +1,5 @@
 local
-  $(SML_LIB)/basis/basis.ml
+  $(SML_LIB)/basis/basis.mlb
   ../lib/sml-final-pretty-printer/final-pretty-printer.mlb
   redprl.mlb
   debug.mlb

--- a/src/frontend/main.sml
+++ b/src/frontend/main.sml
@@ -57,6 +57,6 @@ struct
            | HELP => (print helpMessage; OS.Process.success)
       end)
     handle E =>
-      (print (RedPrlError.format E);
+      (FppRenderPlainText.render TextIO.stdErr (FinalPrinter.execPP (RedPrlError.format E));
        OS.Process.failure)
 end

--- a/src/redprl.cm
+++ b/src/redprl.cm
@@ -6,6 +6,7 @@ Library
   structure RedPrlLog
   structure RedPrlError
   structure RedPrlLrVals
+  structure FinalPrinter
 is
   $/basis.cm
   $/ml-yacc-lib.cm

--- a/src/redprl.cm
+++ b/src/redprl.cm
@@ -19,7 +19,6 @@ is
   $libs/sml-dependent-lcf/dependent_lcf.cm
   $libs/sml-dependent-lcf/lcf_abt.cm
   $libs/sml-dependent-lcf/nominal_lcf.cm
-  $libs/sml-wpp/wpp.cm
   $libs/sml-final-pretty-printer/final-pretty-printer.cm
 
   debug.cm

--- a/src/redprl.cm
+++ b/src/redprl.cm
@@ -12,16 +12,15 @@ is
 
   cmlib.cm
   $libs/sml-cats/cats.cm
-  $libs/sml-unparse/unparse.cm
   $libs/sml-telescopes/telescopes.cm
   $libs/sml-typed-abts/abt.cm
-  $libs/sml-typed-abts/abt-unparser.cm
   $libs/sml-typed-abts/abt-machine.cm
   $libs/sml-typed-abts/basis/basis.cm
   $libs/sml-dependent-lcf/dependent_lcf.cm
   $libs/sml-dependent-lcf/lcf_abt.cm
   $libs/sml-dependent-lcf/nominal_lcf.cm
   $libs/sml-wpp/wpp.cm
+  $libs/sml-final-pretty-printer/final-pretty-printer.cm
 
   debug.cm
 

--- a/src/redprl.mlb
+++ b/src/redprl.mlb
@@ -12,7 +12,6 @@ local
   $(LIBS)/sml-dependent-lcf/dependent_lcf.mlb
   $(LIBS)/sml-dependent-lcf/lcf_abt.mlb
   $(LIBS)/sml-dependent-lcf/nominal_lcf.mlb
-  $(LIBS)/sml-wpp/wpp.mlb
   $(LIBS)/sml-final-pretty-printer/final-pretty-printer.mlb
 
 

--- a/src/redprl.mlb
+++ b/src/redprl.mlb
@@ -36,7 +36,7 @@ local
 
   redprl/elab_monad.sig
   redprl/elab_monad.sml
-  
+
   redprl/lcf.sml
 
   redprl/signature.sig

--- a/src/redprl.mlb
+++ b/src/redprl.mlb
@@ -19,9 +19,10 @@ local
 
   redprl/operator.sml
   redprl/abt.sml
-  redprl/error.sig
 
   redprl/pretty.sml
+
+  redprl/error.sig
   redprl/error.sml
   redprl/syntax.sml
 
@@ -65,6 +66,7 @@ local
   redprl/redprl_parser.sml
 
 in
+  structure FinalPrinter
   structure RedPrlParser
   structure Coord
   structure Pos

--- a/src/redprl.mlb
+++ b/src/redprl.mlb
@@ -6,15 +6,14 @@ local
 
   $(LIBS)/sml-cats/cats.mlb
   $(LIBS)/sml-telescopes/telescopes.mlb
-  $(LIBS)/sml-unparse/unparse.mlb
   $(LIBS)/sml-typed-abts/abt.mlb
-  $(LIBS)/sml-typed-abts/abt-unparser.mlb
   $(LIBS)/sml-typed-abts/abt-machine.mlb
   $(LIBS)/sml-typed-abts/basis/basis.mlb
   $(LIBS)/sml-dependent-lcf/dependent_lcf.mlb
   $(LIBS)/sml-dependent-lcf/lcf_abt.mlb
   $(LIBS)/sml-dependent-lcf/nominal_lcf.mlb
   $(LIBS)/sml-wpp/wpp.mlb
+  $(LIBS)/sml-final-pretty-printer/final-pretty-printer.mlb
 
 
   debug.mlb

--- a/src/redprl/categorical_judgment.sig
+++ b/src/redprl/categorical_judgment.sig
@@ -19,7 +19,7 @@ sig
 
   val eq : abt jdg * abt jdg -> bool
 
-  val pretty : ('a -> FinalPrinter.doc) -> 'a jdg -> FinalPrinter.doc
+  val pretty : ('a -> Fpp.doc) -> 'a jdg -> Fpp.doc
 
   exception InvalidJudgment
 end

--- a/src/redprl/categorical_judgment.sig
+++ b/src/redprl/categorical_judgment.sig
@@ -19,7 +19,7 @@ sig
 
   val eq : abt jdg * abt jdg -> bool
 
-  val pretty : ('a -> string) -> 'a jdg -> FinalPrinter.doc
+  val pretty : ('a -> FinalPrinter.doc) -> 'a jdg -> FinalPrinter.doc
 
   exception InvalidJudgment
 end

--- a/src/redprl/categorical_judgment.sig
+++ b/src/redprl/categorical_judgment.sig
@@ -14,14 +14,12 @@ sig
   val toAbt : abt jdg -> abt
   val fromAbt : abt -> abt jdg
 
-  val toString : abt jdg -> string
-
   val metactx : abt jdg -> Tm.metactx
   val unify : abt jdg * abt jdg -> Tm.Unify.renaming
 
   val eq : abt jdg * abt jdg -> bool
 
-  val pretty : ('a -> string) -> 'a jdg -> PP.doc
+  val pretty : ('a -> string) -> 'a jdg -> FinalPrinter.doc
 
   exception InvalidJudgment
 end

--- a/src/redprl/categorical_judgment.sml
+++ b/src/redprl/categorical_judgment.sml
@@ -69,11 +69,11 @@ struct
   val toString = TermPrinter.toString o toAbt
   val metactx = RedPrlAbt.metactx o toAbt
 
-  fun pretty f = raise Fail "TODO!"
-    (*fn EQ ((m, n), a) => PP.concat [PP.text (f m), PP.text " = ", PP.text (f n), PP.text " in ", PP.text (f a)]
-     | TRUE a => PP.concat [PP.text (f a), PP.text " true"]
-     | EQ_TYPE (a, b) => PP.concat [PP.text (f a), PP.text " = ", PP.text (f b), PP.text " type"]
-     | SYNTH m => PP.concat [PP.text (f m), PP.text " synth"]*)
+  fun pretty f =
+    fn EQ ((m, n), a) => Fpp.hsep [f m, Fpp.Atomic.equals, f n, Fpp.text "in", f a]
+     | TRUE a => Fpp.hsep [f a, Fpp.text "true"]
+     | EQ_TYPE (a, b) => Fpp.hsep [f a, Fpp.Atomic.equals, f b, Fpp.text "type"]
+     | SYNTH m => Fpp.hsep [f m, Fpp.text "synth"]
 
   fun unify (j1, j2) =
     RedPrlAbt.Unify.unify (toAbt j1, toAbt j2)

--- a/src/redprl/categorical_judgment.sml
+++ b/src/redprl/categorical_judgment.sml
@@ -18,10 +18,10 @@ struct
    | EQ_TYPE of 'a * 'a
    | SYNTH of 'a
 
-  fun MEM (m, a) = 
+  fun MEM (m, a) =
     EQ ((m, m), a)
 
-  fun TYPE a = 
+  fun TYPE a =
     EQ_TYPE (a, a)
 
   type 'a jdg = 'a redprl_jdg

--- a/src/redprl/categorical_judgment.sml
+++ b/src/redprl/categorical_judgment.sml
@@ -71,7 +71,7 @@ struct
 
   fun pretty f =
     fn EQ ((m, n), a) => Fpp.hsep [f m, Fpp.Atomic.equals, f n, Fpp.text "in", f a]
-     | TRUE a => Fpp.hsep [f a, Fpp.text "true"]
+     | TRUE a => f a
      | EQ_TYPE (a, b) => Fpp.hsep [f a, Fpp.Atomic.equals, f b, Fpp.text "type"]
      | SYNTH m => Fpp.hsep [f m, Fpp.text "synth"]
 

--- a/src/redprl/categorical_judgment.sml
+++ b/src/redprl/categorical_judgment.sml
@@ -66,7 +66,6 @@ struct
        | _ => raise InvalidJudgment
   end
 
-  val toString = TermPrinter.toString o toAbt
   val metactx = RedPrlAbt.metactx o toAbt
 
   fun pretty f =

--- a/src/redprl/categorical_judgment.sml
+++ b/src/redprl/categorical_judgment.sml
@@ -69,11 +69,11 @@ struct
   val toString = TermPrinter.toString o toAbt
   val metactx = RedPrlAbt.metactx o toAbt
 
-  fun pretty f =
-    fn EQ ((m, n), a) => PP.concat [PP.text (f m), PP.text " = ", PP.text (f n), PP.text " in ", PP.text (f a)]
+  fun pretty f = raise Fail "TODO!"
+    (*fn EQ ((m, n), a) => PP.concat [PP.text (f m), PP.text " = ", PP.text (f n), PP.text " in ", PP.text (f a)]
      | TRUE a => PP.concat [PP.text (f a), PP.text " true"]
      | EQ_TYPE (a, b) => PP.concat [PP.text (f a), PP.text " = ", PP.text (f b), PP.text " type"]
-     | SYNTH m => PP.concat [PP.text (f m), PP.text " synth"]
+     | SYNTH m => PP.concat [PP.text (f m), PP.text " synth"]*)
 
   fun unify (j1, j2) =
     RedPrlAbt.Unify.unify (toAbt j1, toAbt j2)

--- a/src/redprl/elab_monad.sig
+++ b/src/redprl/elab_monad.sig
@@ -8,17 +8,17 @@ sig
   val wrap : (unit -> 'a) ann -> 'a t
 
   val hush : 'a t -> 'a t
-  val warn : FinalPrinter.doc ann -> unit t
-  val dump : FinalPrinter.doc ann -> unit t
-  val info : FinalPrinter.doc ann -> unit t
-  val fail : FinalPrinter.doc ann -> 'a t
+  val warn : Fpp.doc ann -> unit t
+  val dump : Fpp.doc ann -> unit t
+  val info : Fpp.doc ann -> unit t
+  val fail : Fpp.doc ann -> 'a t
 
   type ('a, 'b) alg =
-    {warn : FinalPrinter.doc ann * 'b -> 'b,
-     dump : FinalPrinter.doc ann * 'b -> 'b,
-     info : FinalPrinter.doc ann * 'b -> 'b,
+    {warn : Fpp.doc ann * 'b -> 'b,
+     dump : Fpp.doc ann * 'b -> 'b,
+     info : Fpp.doc ann * 'b -> 'b,
      init : 'b,
-     fail : FinalPrinter.doc ann * 'b -> 'b,
+     fail : Fpp.doc ann * 'b -> 'b,
      succeed : 'a * 'b -> 'b}
 
   val fold : ('a, 'b) alg -> 'a t -> 'b

--- a/src/redprl/elab_monad.sig
+++ b/src/redprl/elab_monad.sig
@@ -8,17 +8,17 @@ sig
   val wrap : (unit -> 'a) ann -> 'a t
 
   val hush : 'a t -> 'a t
-  val warn : string ann -> unit t
-  val dump : string ann -> unit t
-  val info : string ann -> unit t
-  val fail : string ann -> 'a t
+  val warn : FinalPrinter.doc ann -> unit t
+  val dump : FinalPrinter.doc ann -> unit t
+  val info : FinalPrinter.doc ann -> unit t
+  val fail : FinalPrinter.doc ann -> 'a t
 
   type ('a, 'b) alg =
-    {warn : string ann * 'b -> 'b,
-     dump : string ann * 'b -> 'b,
-     info : string ann * 'b -> 'b,
+    {warn : FinalPrinter.doc ann * 'b -> 'b,
+     dump : FinalPrinter.doc ann * 'b -> 'b,
+     info : FinalPrinter.doc ann * 'b -> 'b,
      init : 'b,
-     fail : string ann * 'b -> 'b,
+     fail : FinalPrinter.doc ann * 'b -> 'b,
      succeed : 'a * 'b -> 'b}
 
   val fold : ('a, 'b) alg -> 'a t -> 'b

--- a/src/redprl/elab_monad.sml
+++ b/src/redprl/elab_monad.sml
@@ -34,7 +34,6 @@ struct
   fun force susp =
     Debug.wrap (fn _ => Susp.force susp)
     handle exn =>
-      (* TODO: fix *)
       {result = FAILURE (RedPrlError.annotation exn, RedPrlError.format exn),
        messages = DList.empty}
 

--- a/src/redprl/elab_monad.sml
+++ b/src/redprl/elab_monad.sml
@@ -17,13 +17,13 @@ struct
   end
 
   datatype msg =
-     DUMP of string ann
-   | INFO of string ann
-   | WARN of string ann
+     DUMP of FinalPrinter.doc ann
+   | INFO of FinalPrinter.doc ann
+   | WARN of FinalPrinter.doc ann
 
   datatype 'a res =
      SUCCESS of 'a
-   | FAILURE of string ann
+   | FAILURE of FinalPrinter.doc ann
 
   type 'a state =
     {result : 'a res,
@@ -34,6 +34,7 @@ struct
   fun force susp =
     Debug.wrap (fn _ => Susp.force susp)
     handle exn =>
+      (* TODO: fix *)
       {result = FAILURE (RedPrlError.annotation exn, RedPrlError.format exn),
        messages = DList.empty}
 
@@ -107,10 +108,10 @@ struct
     bind f (ret ())
 
   type ('a, 'b) alg =
-    {warn : string ann * 'b -> 'b,
-     dump : string ann * 'b -> 'b,
-     info : string ann * 'b -> 'b,
-     fail : string ann * 'b -> 'b,
+    {warn : FinalPrinter.doc ann * 'b -> 'b,
+     dump : FinalPrinter.doc ann * 'b -> 'b,
+     info : FinalPrinter.doc ann * 'b -> 'b,
+     fail : FinalPrinter.doc ann * 'b -> 'b,
      init : 'b,
      succeed : 'a * 'b -> 'b}
 

--- a/src/redprl/elab_monad.sml
+++ b/src/redprl/elab_monad.sml
@@ -17,13 +17,13 @@ struct
   end
 
   datatype msg =
-     DUMP of FinalPrinter.doc ann
-   | INFO of FinalPrinter.doc ann
-   | WARN of FinalPrinter.doc ann
+     DUMP of Fpp.doc ann
+   | INFO of Fpp.doc ann
+   | WARN of Fpp.doc ann
 
   datatype 'a res =
      SUCCESS of 'a
-   | FAILURE of FinalPrinter.doc ann
+   | FAILURE of Fpp.doc ann
 
   type 'a state =
     {result : 'a res,
@@ -107,10 +107,10 @@ struct
     bind f (ret ())
 
   type ('a, 'b) alg =
-    {warn : FinalPrinter.doc ann * 'b -> 'b,
-     dump : FinalPrinter.doc ann * 'b -> 'b,
-     info : FinalPrinter.doc ann * 'b -> 'b,
-     fail : FinalPrinter.doc ann * 'b -> 'b,
+    {warn : Fpp.doc ann * 'b -> 'b,
+     dump : Fpp.doc ann * 'b -> 'b,
+     info : Fpp.doc ann * 'b -> 'b,
+     fail : Fpp.doc ann * 'b -> 'b,
      init : 'b,
      succeed : 'a * 'b -> 'b}
 

--- a/src/redprl/error.sig
+++ b/src/redprl/error.sig
@@ -7,7 +7,7 @@ sig
   type term
 
   val error : term frag list -> exn
-  val format : exn -> FinalPrinter.doc
+  val format : exn -> Fpp.doc
 
   val annotate : Pos.t option -> exn -> exn
   val annotation : exn -> Pos.t option

--- a/src/redprl/error.sig
+++ b/src/redprl/error.sig
@@ -7,7 +7,7 @@ sig
   type term
 
   val error : term frag list -> exn
-  val format : exn -> string
+  val format : exn -> FinalPrinter.doc
 
   val annotate : Pos.t option -> exn -> exn
   val annotation : exn -> Pos.t option

--- a/src/redprl/error.sml
+++ b/src/redprl/error.sml
@@ -18,10 +18,10 @@ struct
      | ! tm => "`" ^ TermPrinter.toString tm ^ "`"
 
   val rec format =
-    fn E frags => ListSpine.pretty fragToString " " frags
+    fn E frags => Fpp.text (ListSpine.pretty fragToString " " frags)
      | Pos (_, exn) => format exn
-     | BadSubstMetaenv {description,...} => description
-     | exn => exnMessage exn
+     | BadSubstMetaenv {description,...} => Fpp.text description
+     | exn => Fpp.text (exnMessage exn)
 
    fun annotate (SOME pos) exn = Pos (pos, exn)
      | annotate NONE exn = exn

--- a/src/redprl/judgment.fun
+++ b/src/redprl/judgment.fun
@@ -12,7 +12,8 @@ struct
 
   val subst = S.map o Tm.substMetaenv
   val eq = S.eq
-  val toString = S.toString TermPrinter.toString
+  fun toString _ = "TODO"
+  (* S.toString TermPrinter.toString*)
 
   local
     open S
@@ -31,6 +32,6 @@ struct
            end
   end
 end
-
+ 
 structure RedPrlSequent = Sequent (structure CJ = RedPrlCategoricalJudgment)
 structure RedPrlJudgment = SequentJudgment (structure S = RedPrlSequent and TermPrinter = TermPrinter)

--- a/src/redprl/judgment.fun
+++ b/src/redprl/judgment.fun
@@ -1,6 +1,6 @@
 functor SequentJudgment
   (structure S : SEQUENT where type 'a CJ.Tm.O.Ar.Vl.Sp.t = 'a list and type CJ.Tm.Sym.t = Sym.t and type CJ.Tm.Var.t = Sym.t
-   structure TermPrinter : sig type t = S.CJ.Tm.abt val ppTerm : t -> FinalPrinter.doc end) : LCF_JUDGMENT  =
+   structure TermPrinter : sig type t = S.CJ.Tm.abt val ppTerm : t -> Fpp.doc end) : LCF_JUDGMENT  =
 struct
   structure CJ = S.CJ
   structure Tm = CJ.Tm

--- a/src/redprl/judgment.fun
+++ b/src/redprl/judgment.fun
@@ -1,6 +1,6 @@
 functor SequentJudgment
   (structure S : SEQUENT where type 'a CJ.Tm.O.Ar.Vl.Sp.t = 'a list and type CJ.Tm.Sym.t = Sym.t and type CJ.Tm.Var.t = Sym.t
-   structure TermPrinter : SHOW where type t = S.CJ.Tm.abt) : LCF_JUDGMENT  =
+   structure TermPrinter : sig type t = S.CJ.Tm.abt val ppTerm : t -> FinalPrinter.doc end) : LCF_JUDGMENT  =
 struct
   structure CJ = S.CJ
   structure Tm = CJ.Tm
@@ -12,8 +12,7 @@ struct
 
   val subst = S.map o Tm.substMetaenv
   val eq = S.eq
-  fun toString _ = "TODO"
-  (* S.toString TermPrinter.toString*)
+  val toString = FppRenderPlainText.toString o FinalPrinter.execPP o S.pretty TermPrinter.ppTerm
 
   local
     open S

--- a/src/redprl/judgment.fun
+++ b/src/redprl/judgment.fun
@@ -20,7 +20,7 @@ struct
   in
     val rec sort =
       fn (I, H) >> catjdg =>
-           ((List.map #2 I, Hyps.foldr (fn (_, jdg, r) => CJ.synthesis jdg :: r) [] H), 
+           ((List.map #2 I, Hyps.foldr (fn (_, jdg, r) => CJ.synthesis jdg :: r) [] H),
             CJ.synthesis catjdg)
        | MATCH (th, k, _, _, _) =>
            let
@@ -31,6 +31,6 @@ struct
            end
   end
 end
- 
+
 structure RedPrlSequent = Sequent (structure CJ = RedPrlCategoricalJudgment)
 structure RedPrlJudgment = SequentJudgment (structure S = RedPrlSequent and TermPrinter = TermPrinter)

--- a/src/redprl/lcf.sml
+++ b/src/redprl/lcf.sml
@@ -33,7 +33,7 @@ struct
             val jdg' = J.subst env jdg
             val env' = Metavar.Ctx.insert env x (LcfLanguage.var x' (J.sort jdg'))
           in
-            {doc = Fpp.seq [doc, prettyGoal (x, jdg), Fpp.hardLine],
+            {doc = Fpp.seq [doc, prettyGoal (x, jdg), Fpp.newline],
              env = env',
              idx = idx + 1}
           end)

--- a/src/redprl/lcf.sml
+++ b/src/redprl/lcf.sml
@@ -13,14 +13,14 @@ struct
 
   (* TODO: clean up all this stuff with vsep *)
 
+  fun @@ (f, x) = f x
+  infixr 0 @@
+
   fun prettyGoal (x, jdg) =
-    Fpp.seq
-      [Fpp.text "Goal",
-       Fpp.space 1,
-       Fpp.text ".",
-       Fpp.newline,
-       Fpp.nest 2 (RedPrlSequent.pretty TermPrinter.ppTerm jdg),
-       Fpp.hardLine]
+    Fpp.nest 2 @@ 
+      Fpp.vsep 
+        [Fpp.seq [Fpp.hsep [Fpp.text "Goal", Fpp.text (Metavar.toString x)], Fpp.text "."],
+         RedPrlSequent.pretty TermPrinter.ppTerm jdg]
 
   val prettyGoals : jdg Tl.telescope -> {doc : FinalPrinter.doc, env : J.env, idx : int} = 
     let

--- a/src/redprl/lcf.sml
+++ b/src/redprl/lcf.sml
@@ -12,6 +12,8 @@ struct
   infix |> ||
 
   (* TODO: clean up all this stuff with vsep *)
+  (* TODO: also try to extend the printer with "concrete name" environments so that we can print without doing
+     all these renamings. *)
 
   fun @@ (f, x) = f x
   infixr 0 @@

--- a/src/redprl/lcf.sml
+++ b/src/redprl/lcf.sml
@@ -3,7 +3,7 @@ structure LcfLanguage = LcfAbtLanguage (RedPrlAbt)
 structure Lcf :
 sig
   include LCF_UTIL
-  val prettyState : jdg state -> FinalPrinter.doc
+  val prettyState : jdg state -> Fpp.doc
 end =
 struct
   structure Lcf = Lcf (LcfLanguage)
@@ -22,7 +22,7 @@ struct
         [Fpp.seq [Fpp.hsep [Fpp.text "Goal", Fpp.text (Metavar.toString x)], Fpp.text "."],
          RedPrlSequent.pretty TermPrinter.ppTerm jdg]
 
-  val prettyGoals : jdg Tl.telescope -> {doc : FinalPrinter.doc, env : J.env, idx : int} = 
+  val prettyGoals : jdg Tl.telescope -> {doc : Fpp.doc, env : J.env, idx : int} = 
     let
       open RedPrlAbt
     in

--- a/src/redprl/lcf.sml
+++ b/src/redprl/lcf.sml
@@ -11,67 +11,35 @@ struct
   open Def Lcf
   infix |> ||
 
-(*
-  val prettySyms =
-    PP.text o ListSpine.pretty (fn (u, sigma) => Sym.toString u ^ " : " ^ RedPrlAbt.O.Ar.Vl.PS.toString sigma) ", "
-
-  val prettyVars = 
-    PP.text o ListSpine.pretty (fn (x, tau) => Var.toString x ^ " : " ^ RedPrlAbt.O.Ar.Vl.S.toString tau) ", "
+  (* TODO: clean up all this stuff with vsep *)
 
   fun prettyGoal (x, jdg) =
-    PP.concat
-      [PP.text "Goal ",
-        PP.text (RedPrlAbt.Metavar.toString x),
-        PP.text ".",
-        PP.nest 2 (PP.concat [PP.line, RedPrlSequent.pretty TermPrinter.toString jdg]),
-        PP.line]
+    Fpp.seq
+      [Fpp.text "Goal",
+       Fpp.space 1,
+       Fpp.text ".",
+       Fpp.newline,
+       Fpp.nest 2 (RedPrlSequent.pretty TermPrinter.ppTerm jdg),
+       Fpp.hardLine]
 
-
-  val prettyGoals : jdg eff Tl.telescope -> {doc : PP.doc, env : J.env, idx : int} =
+  val prettyGoals : jdg Tl.telescope -> {doc : FinalPrinter.doc, env : J.env, idx : int} = 
     let
       open RedPrlAbt
     in
-      Tl.foldl
+      Tl.foldl 
         (fn (x, jdg, {doc, env, idx}) =>
           let
             val x' = Metavar.named (Int.toString idx)
             val jdg' = J.subst env jdg
             val env' = Metavar.Ctx.insert env x (LcfLanguage.var x' (J.sort jdg'))
           in
-            {doc = PP.concat [doc, prettyGoal (x, jdg), PP.line],
+            {doc = Fpp.seq [doc, prettyGoal (x, jdg), Fpp.hardLine],
              env = env',
              idx = idx + 1}
           end)
-        {doc = PP.empty, env = Metavar.Ctx.empty, idx = 0}
+        {doc = Fpp.empty, env = Metavar.Ctx.empty, idx = 0}
     end
 
-  fun prettyValidation _(*env*) vld =
-    let
-      open RedPrlAbt infix \
-      val _ \ m = outb vld
-    in
-      PP.concat
-        [PP.text (TermPrinter.toString m),
-         PP.line,
-         PP.text (primToStringAbs vld)]
-    end
-
-  fun prettyState (psi |> vld) =
-    let
-      val {doc = goals, env, idx = _} = prettyGoals psi
-    in
-      PP.concat
-        [goals,
-         PP.newline,
-         PP.rule #"-",
-         PP.newline,
-         PP.text "Current Proof Extract:",
-         PP.newline,
-         PP.rule #"-",
-         PP.newline, PP.newline,
-         prettyValidation env vld]
-    end
-    *)
-
-    fun prettyState _ = raise Fail "TODO!"
+  fun prettyState (psi |> _) = 
+    #doc (prettyGoals psi)
 end

--- a/src/redprl/lcf.sml
+++ b/src/redprl/lcf.sml
@@ -3,7 +3,7 @@ structure LcfLanguage = LcfAbtLanguage (RedPrlAbt)
 structure Lcf :
 sig
   include LCF_UTIL
-  val prettyState : jdg state -> PP.doc
+  val prettyState : jdg state -> FinalPrinter.doc
 end =
 struct
   structure Lcf = Lcf (LcfLanguage)
@@ -11,7 +11,7 @@ struct
   open Def Lcf
   infix |> ||
 
-
+(*
   val prettySyms =
     PP.text o ListSpine.pretty (fn (u, sigma) => Sym.toString u ^ " : " ^ RedPrlAbt.O.Ar.Vl.PS.toString sigma) ", "
 
@@ -71,4 +71,7 @@ struct
          PP.newline, PP.newline,
          prettyValidation env vld]
     end
+    *)
+
+    fun prettyState _ = raise Fail "TODO!"
 end

--- a/src/redprl/lcf.sml
+++ b/src/redprl/lcf.sml
@@ -17,16 +17,16 @@ struct
   infixr 0 @@
 
   fun prettyGoal (x, jdg) =
-    Fpp.nest 2 @@ 
-      Fpp.vsep 
+    Fpp.nest 2 @@
+      Fpp.vsep
         [Fpp.seq [Fpp.hsep [Fpp.text "Goal", Fpp.text (Metavar.toString x)], Fpp.text "."],
          RedPrlSequent.pretty TermPrinter.ppTerm jdg]
 
-  val prettyGoals : jdg Tl.telescope -> {doc : Fpp.doc, env : J.env, idx : int} = 
+  val prettyGoals : jdg Tl.telescope -> {doc : Fpp.doc, env : J.env, idx : int} =
     let
       open RedPrlAbt
     in
-      Tl.foldl 
+      Tl.foldl
         (fn (x, jdg, {doc, env, idx}) =>
           let
             val x' = Metavar.named (Int.toString idx)
@@ -40,6 +40,6 @@ struct
         {doc = Fpp.empty, env = Metavar.Ctx.empty, idx = 0}
     end
 
-  fun prettyState (psi |> _) = 
+  fun prettyState (psi |> _) =
     #doc (prettyGoals psi)
 end

--- a/src/redprl/lcf_model.fun
+++ b/src/redprl/lcf_model.fun
@@ -39,15 +39,10 @@ struct
     Debug.wrap (fn _ => interpret (sign, env) (Machine.eval sign rule) alpha goal)
     handle exn => raise RedPrlError.annotate (getAnnotation rule) exn
 
-  fun printHole (pos : Pos.t, name) (state : Lcf.jdg Lcf.state) = 
+  fun printHole (pos : Pos.t, name : string option) (state : Lcf.jdg Lcf.state) = 
     let
-      (*val header = 
-        case name of 
-           NONE => PP.empty
-         | SOME n => PP.concat [PP.text n, PP.text ".", PP.newline]
-      val doc = PP.concat [header, Lcf.prettyState state]
-      val message = PP.toString 60 false doc*)
-      val message = raise Fail "TODO!"
+      val header = Fpp.seq [Fpp.text (Option.getOpt (name, "hole")), Fpp.char #"."]
+      val message = Fpp.vsep [header, Lcf.prettyState state]
     in
       RedPrlLog.print RedPrlLog.INFO (SOME pos, message)
     end

--- a/src/redprl/lcf_model.fun
+++ b/src/redprl/lcf_model.fun
@@ -16,9 +16,9 @@ struct
 
   structure O = RedPrlOpData
 
-  fun hyp z alpha jdg = 
-    Rules.Hyp.Project z alpha jdg 
-    handle _ => 
+  fun hyp z alpha jdg =
+    Rules.Hyp.Project z alpha jdg
+    handle _ =>
       Rules.Synth.FromWfHyp z alpha jdg
 
   fun interpret (sign, _(*env*)) rule =
@@ -39,7 +39,7 @@ struct
     Debug.wrap (fn _ => interpret (sign, env) (Machine.eval sign rule) alpha goal)
     handle exn => raise RedPrlError.annotate (getAnnotation rule) exn
 
-  fun printHole (pos : Pos.t, name : string option) (state : Lcf.jdg Lcf.state) = 
+  fun printHole (pos : Pos.t, name : string option) (state : Lcf.jdg Lcf.state) =
     let
       val header = Fpp.seq [Fpp.text (Option.getOpt (name, "hole")), Fpp.char #"."]
       val message = Fpp.vsep [header, Lcf.prettyState state]

--- a/src/redprl/lcf_model.fun
+++ b/src/redprl/lcf_model.fun
@@ -41,12 +41,13 @@ struct
 
   fun printHole (pos : Pos.t, name) (state : Lcf.jdg Lcf.state) = 
     let
-      val header = 
+      (*val header = 
         case name of 
            NONE => PP.empty
          | SOME n => PP.concat [PP.text n, PP.text ".", PP.newline]
       val doc = PP.concat [header, Lcf.prettyState state]
-      val message = PP.toString 60 false doc
+      val message = PP.toString 60 false doc*)
+      val message = raise Fail "TODO!"
     in
       RedPrlLog.print RedPrlLog.INFO (SOME pos, message)
     end

--- a/src/redprl/lcf_syntax.fun
+++ b/src/redprl/lcf_syntax.fun
@@ -14,8 +14,8 @@ struct
   type sign = Sig.sign
   type ann = Pos.t * string option
 
-  fun inheritAnnotation t1 t2 = 
-    case getAnnotation t2 of 
+  fun inheritAnnotation t1 t2 =
+    case getAnnotation t2 of
        NONE => setAnnotation (getAnnotation t1) t2
      | _ => t2
 
@@ -66,8 +66,8 @@ struct
 
   fun tactic sign tac =
     let
-      (*val _ = 
-        case getAnnotation tac of 
+      (*val _ =
+        case getAnnotation tac of
            SOME (ann : Pos.t) => print ("Tactic " ^ TermPrinter.toString tac ^ ": " ^ Pos.toString ann ^ "\n\n")
          | NONE => print ("Tactic " ^ TermPrinter.toString tac ^ ": has no annotation\n\n")*)
 
@@ -87,7 +87,7 @@ struct
        | O.MONO O.MTAC_REC $ [(_,[x]) \ mtx] => REC (x, inheritAnnotation mtac mtx)
        | O.MONO (O.MTAC_SEQ _) $ [_ \ mt1, (us,_) \ mt2] => SEQ (us, inheritAnnotation mtac mt1, inheritAnnotation mtac mt2)
        | O.MONO O.MTAC_ORELSE $ [_ \ mt1, _ \ mt2] => ORELSE (inheritAnnotation mtac mt1, inheritAnnotation mtac mt2)
-       | O.MONO (O.MTAC_HOLE msg) $ _ => HOLE (Option.valOf (getAnnotation mtac), msg) 
+       | O.MONO (O.MTAC_HOLE msg) $ _ => HOLE (Option.valOf (getAnnotation mtac), msg)
        | ` x => VAR x
        | _ => raise InvalidMultitactic
 end

--- a/src/redprl/lcf_syntax.fun
+++ b/src/redprl/lcf_syntax.fun
@@ -66,11 +66,6 @@ struct
 
   fun tactic sign tac =
     let
-      (*val _ =
-        case getAnnotation tac of
-           SOME (ann : Pos.t) => print ("Tactic " ^ TermPrinter.toString tac ^ ": " ^ Pos.toString ann ^ "\n\n")
-         | NONE => print ("Tactic " ^ TermPrinter.toString tac ^ ": has no annotation\n\n")*)
-
       val tac' = prepareTerm sign tac
     in
       case Tm.out tac' of

--- a/src/redprl/log.sig
+++ b/src/redprl/log.sig
@@ -7,7 +7,7 @@ sig
    | FAIL
    | TRACE
 
-  val print : level -> Pos.t option * string -> unit
+  val print : level -> Pos.t option * FinalPrinter.doc -> unit
 end
 
 signature REDPRL_LOG_UTIL =

--- a/src/redprl/log.sig
+++ b/src/redprl/log.sig
@@ -7,7 +7,7 @@ sig
    | FAIL
    | TRACE
 
-  val print : level -> Pos.t option * FinalPrinter.doc -> unit
+  val print : level -> Pos.t option * Fpp.doc -> unit
 end
 
 signature REDPRL_LOG_UTIL =

--- a/src/redprl/log.sml
+++ b/src/redprl/log.sml
@@ -13,7 +13,7 @@ struct
         case pos of
            SOME pos => Pos.toString pos
          | NONE => "[Unknown Location]"
-      
+
       val prefix =
         case lvl of
            INFO => "Info"
@@ -23,7 +23,7 @@ struct
          | TRACE => "Trace"
 
       val header =
-        Fpp.hsep 
+        Fpp.hsep
           [Fpp.text pos',
            Fpp.seq [Fpp.Atomic.squares (Fpp.text prefix), Fpp.Atomic.colon]]
 
@@ -50,12 +50,12 @@ struct
 end
 
 
-functor RedPrlLogUtil (L : REDPRL_LOG) : REDPRL_LOG_UTIL= 
+functor RedPrlLogUtil (L : REDPRL_LOG) : REDPRL_LOG_UTIL=
 struct
   open L
 
-  fun trace msg = 
-    () 
+  fun trace msg =
+    ()
     (*print TRACE (NONE, msg)*)
 end
 

--- a/src/redprl/log.sml
+++ b/src/redprl/log.sml
@@ -7,7 +7,7 @@ struct
    | FAIL
    | TRACE
 
-  fun formatMessage lvl (pos, msg : FinalPrinter.doc) : FinalPrinter.doc =
+  fun formatMessage lvl (pos, msg : Fpp.doc) : Fpp.doc =
     let
       val pos' =
         case pos of

--- a/src/redprl/log.sml
+++ b/src/redprl/log.sml
@@ -28,7 +28,7 @@ struct
            Fpp.seq [Fpp.Atomic.squares (Fpp.text prefix), Fpp.Atomic.colon]]
 
     in
-      Fpp.vsep [header, Fpp.nest 2 msg, Fpp.hardLine]
+      Fpp.seq [Fpp.nest 4 (Fpp.vsep [header, msg]), Fpp.hardLine, Fpp.hardLine]
     end
 
   val streamForLevel =

--- a/src/redprl/log.sml
+++ b/src/redprl/log.sml
@@ -7,7 +7,8 @@ struct
    | FAIL
    | TRACE
 
-  fun formatMessage lvl (pos, msg) =
+  fun formatMessage lvl (pos, msg) : (int, unit) FppTypes.output = raise Fail "TODO"
+(*  
     let
       val pos' =
         case pos of
@@ -27,7 +28,7 @@ struct
       val msg' = List.foldr op^ "" indented
     in
       pos' ^ " [" ^ prefix ^ "]:\n" ^ msg' ^"\n\n"
-    end
+    end*)
 
   val streamForLevel =
     fn INFO => TextIO.stdOut
@@ -40,7 +41,7 @@ struct
     let
       val stream = streamForLevel lvl
     in
-      TextIO.output (stream, formatMessage lvl msg);
+      FppRenderPlainText.render stream (formatMessage lvl msg);
       TextIO.flushOut stream
     end
 end

--- a/src/redprl/log.sml
+++ b/src/redprl/log.sml
@@ -7,14 +7,13 @@ struct
    | FAIL
    | TRACE
 
-  fun formatMessage lvl (pos, msg) : (int, unit) FppTypes.output = raise Fail "TODO"
-(*  
+  fun formatMessage lvl (pos, msg : FinalPrinter.doc) : FinalPrinter.doc =
     let
       val pos' =
         case pos of
            SOME pos => Pos.toString pos
          | NONE => "[Unknown Location]"
-
+      
       val prefix =
         case lvl of
            INFO => "Info"
@@ -23,12 +22,14 @@ struct
          | FAIL => "Error"
          | TRACE => "Trace"
 
-      val lines = String.fields (fn c => c = #"\n") msg
-      val indented = List.map (fn l => "  " ^ l ^ "\n") lines
-      val msg' = List.foldr op^ "" indented
+      val header =
+        Fpp.hsep 
+          [Fpp.text pos',
+           Fpp.seq [Fpp.Atomic.squares (Fpp.text prefix), Fpp.Atomic.colon]]
+
     in
-      pos' ^ " [" ^ prefix ^ "]:\n" ^ msg' ^"\n\n"
-    end*)
+      Fpp.vsep [header, Fpp.nest 2 msg, Fpp.hardLine]
+    end
 
   val streamForLevel =
     fn INFO => TextIO.stdOut
@@ -40,8 +41,10 @@ struct
   fun print lvl msg =
     let
       val stream = streamForLevel lvl
+      val doc = formatMessage lvl msg
+      val output = FinalPrinter.execPP doc
     in
-      FppRenderPlainText.render stream (formatMessage lvl msg);
+      FppRenderPlainText.render stream output;
       TextIO.flushOut stream
     end
 end

--- a/src/redprl/log.sml
+++ b/src/redprl/log.sml
@@ -28,7 +28,7 @@ struct
            Fpp.seq [Fpp.Atomic.squares (Fpp.text prefix), Fpp.Atomic.colon]]
 
     in
-      Fpp.seq [Fpp.nest 4 (Fpp.vsep [header, msg]), Fpp.hardLine, Fpp.hardLine]
+      Fpp.vsep [Fpp.nest 2 (Fpp.vsep [header, msg]), Fpp.hardLine, Fpp.hardLine]
     end
 
   val streamForLevel =

--- a/src/redprl/log.sml
+++ b/src/redprl/log.sml
@@ -28,7 +28,7 @@ struct
            Fpp.seq [Fpp.Atomic.squares (Fpp.text prefix), Fpp.Atomic.colon]]
 
     in
-      Fpp.vsep [Fpp.nest 2 (Fpp.vsep [header, msg]), Fpp.hardLine, Fpp.hardLine]
+      Fpp.vsep [Fpp.nest 2 (Fpp.vsep [header, msg]), Fpp.newline, Fpp.newline]
     end
 
   val streamForLevel =

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -483,7 +483,7 @@ struct
              ^ "["
              ^ dirToString f dir
              ^ "]"
-       | CUST (opid, [], _) => 
+       | CUST (opid, [], _) =>
            f opid
        | CUST (opid, ps, _) =>
            f opid ^ "{" ^ paramsToString f ps ^ "}"

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -414,7 +414,7 @@ struct
      | FST => "fst"
      | SND => "snd"
 
-     | PATH_TY => "paths"
+     | PATH_TY => "path"
      | PATH_ABS => "abs"
 
      | MTAC_SEQ _ => "seq"

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -483,6 +483,8 @@ struct
              ^ "["
              ^ dirToString f dir
              ^ "]"
+       | CUST (opid, [], _) => 
+           f opid
        | CUST (opid, ps, _) =>
            f opid ^ "{" ^ paramsToString f ps ^ "}"
        | RULE_LEMMA (opid, ps, _) =>

--- a/src/redprl/pretty.sml
+++ b/src/redprl/pretty.sml
@@ -33,6 +33,8 @@ sig
   val ppSort : RedPrlAbt.sort -> Fpp.doc
   val ppPsort : RedPrlAbt.psort -> Fpp.doc
   val ppValence : RedPrlAbt.valence -> Fpp.doc
+  val ppSym : RedPrlAbt.variable -> Fpp.doc
+  val ppParam : RedPrlAbt.param -> Fpp.doc
 end =
 struct
   structure Abt = RedPrlAbt

--- a/src/redprl/pretty.sml
+++ b/src/redprl/pretty.sml
@@ -3,14 +3,12 @@ structure Fpp = FinalPrettyPrinter (FppBasis)
 
 signature FINAL_PRINTER = 
 sig
-  type doc = unit Fpp.m
-  val execPP : doc -> (int, unit) FppTypes.output
+  val execPP : Fpp.doc -> (int, unit) FppTypes.output
 end
 
 structure FinalPrinter :> FINAL_PRINTER = 
 struct
   open FppBasis Fpp
-  type doc = unit m
 
   local 
     val initialEnv =
@@ -31,10 +29,10 @@ structure TermPrinter :
 sig
   type t = RedPrlAbt.abt
   val toString : t -> string
-  val ppTerm : t -> FinalPrinter.doc
-  val ppSort : RedPrlAbt.sort -> FinalPrinter.doc
-  val ppPsort : RedPrlAbt.psort -> FinalPrinter.doc
-  val ppValence : RedPrlAbt.valence -> FinalPrinter.doc
+  val ppTerm : t -> Fpp.doc
+  val ppSort : RedPrlAbt.sort -> Fpp.doc
+  val ppPsort : RedPrlAbt.psort -> Fpp.doc
+  val ppValence : RedPrlAbt.valence -> Fpp.doc
 end =
 struct
   structure Abt = RedPrlAbt

--- a/src/redprl/pretty.sml
+++ b/src/redprl/pretty.sml
@@ -138,6 +138,10 @@ struct
          Atomic.parens @@ expr @@ hvsep @@
            hvsep [ppComHead "hcom" dir, ppBinder ty, ppBinder cap]
              :: [ppTubes (eqs, tubes)]
+     | O.POLY (O.FCOM (dir, eqs)) $ (cap :: tubes) =>
+         Atomic.parens @@ expr @@ hvsep @@
+           hvsep [ppComHead "fcom" dir, ppBinder cap]
+             :: [ppTubes (eqs, tubes)]
 
      | theta $ [] =>
         ppOperator theta
@@ -161,8 +165,7 @@ struct
         (fn ((r1, r2), ([u], _) \ mx) =>
           Atomic.squares @@ hsep
             [seq [ppParam r1, Atomic.equals, ppParam r2],
-              text "->",
-              nest 1 @@ hvsep [Atomic.braces @@ ppSym u, ppTerm mx]])
+             nest 1 @@ hvsep [Atomic.braces @@ ppSym u, ppTerm mx]])
         (eqs, tubes)
 
 

--- a/src/redprl/pretty.sml
+++ b/src/redprl/pretty.sml
@@ -127,8 +127,8 @@ struct
          Atomic.parens @@ expr @@ hvsep [ppTerm m, ppTerm n]
      | O.MONO O.PAIR $ [_ \ m, _ \ n] =>
          collection (char #"<") (char #">") Atomic.comma [ppTerm m, ppTerm n]
-     | O.POLY (O.LOOP r) $ _ =>
-         seq [text "loop", Atomic.squares @@ ppParam r]
+     | O.POLY (O.LOOP x) $ [] => 
+         Atomic.parens @@ expr @@ hvsep @@ [text "loop", ppParam x]
      | O.POLY (O.PATH_AP r) $ [_ \ m] =>
          Atomic.parens @@ expr @@ hvsep [text "@", ppTerm m, ppParam r]
      | `x => ppVar x

--- a/src/redprl/pretty.sml
+++ b/src/redprl/pretty.sml
@@ -47,6 +47,7 @@ struct
   infix 0 $ $$ $# \
   infixr 0 @@
 
+  val ppSym = text o Sym.toString
   val ppVar = text o Var.toString
   val ppParam = text o P.toString Sym.toString
 
@@ -55,8 +56,11 @@ struct
        [] => empty
      | _ => m
 
-  val ppOperator =
-    text o RedPrlOperator.toString Sym.toString
+  fun ppOperator theta =
+    case theta of 
+       O.POLY (O.CUST (opid, [], _)) => ppSym opid
+     | O.POLY (O.CUST (opid, params, _)) => Atomic.braces @@ hsep @@ ppSym opid :: List.map (fn (p, _) => ppParam p) params
+     | _ =>  text @@ RedPrlOperator.toString Sym.toString theta
 
   fun ppComHead name (r, r') =
     seq [text name, Atomic.braces @@ seq [ppParam r, text "~>", ppParam r']]
@@ -156,7 +160,7 @@ struct
           Atomic.squares @@ hsep
             [seq [ppParam r1, Atomic.equals, ppParam r2],
               text "->",
-              nest 1 @@ hvsep [Atomic.braces (text (Sym.toString u)), ppTerm mx]])
+              nest 1 @@ hvsep [Atomic.braces @@ ppSym u, ppTerm mx]])
         (eqs, tubes)
 
 
@@ -168,7 +172,7 @@ struct
   and symBinding us =
     unlessEmpty us @@
       Atomic.braces @@
-        hsep @@ List.map (text o Sym.toString) us
+        hsep @@ List.map ppSym us
 
   and varBinding xs =
     unlessEmpty xs @@

--- a/src/redprl/pretty.sml
+++ b/src/redprl/pretty.sml
@@ -1,16 +1,16 @@
 structure FppBasis = FppPrecedenceBasis (FppInitialBasis (FppPlainBasisTypes))
 structure Fpp = FinalPrettyPrinter (FppBasis)
 
-signature FINAL_PRINTER = 
+signature FINAL_PRINTER =
 sig
   val execPP : Fpp.doc -> (int, unit) FppTypes.output
 end
 
-structure FinalPrinter :> FINAL_PRINTER = 
+structure FinalPrinter :> FINAL_PRINTER =
 struct
   open FppBasis Fpp
 
-  local 
+  local
     val initialEnv =
       {maxWidth = 80,
        maxRibbon = 60,
@@ -20,12 +20,12 @@ struct
        formatting = (),
        formatAnn = fn _ => ()}
   in
-    fun execPP (m : unit m)  = 
+    fun execPP (m : unit m)  =
       #output (m emptyPrecEnv initialEnv {curLine = []})
   end
 end
 
-structure TermPrinter : 
+structure TermPrinter :
 sig
   type t = RedPrlAbt.abt
   val toString : t -> string
@@ -50,19 +50,19 @@ struct
   val ppVar = text o Var.toString
   val ppParam = text o P.toString Sym.toString
 
-  fun unlessEmpty xs m = 
-    case xs of 
+  fun unlessEmpty xs m =
+    case xs of
        [] => empty
      | _ => m
 
-  val ppOperator = 
+  val ppOperator =
     text o RedPrlOperator.toString Sym.toString
 
-  fun ppComHead name (r, r') = 
+  fun ppComHead name (r, r') =
     seq [text name, Atomic.braces @@ seq [ppParam r, text "~>", ppParam r']]
 
-  fun intersperse s xs = 
-    case xs of 
+  fun intersperse s xs =
+    case xs of
        [] => []
      | [x] => [x]
      | x::xs => seq [x, s] :: intersperse s xs
@@ -70,10 +70,10 @@ struct
 
   (* This is still quite rudimentary; we can learn to more interesting things like alignment, etc. *)
 
-  fun multiDFun (doms : (variable list * abt) list) m = 
-    case Abt.out m of 
+  fun multiDFun (doms : (variable list * abt) list) m =
+    case Abt.out m of
        O.MONO O.DFUN $ [_ \ a, (_, [x]) \ bx] =>
-         (case doms of 
+         (case doms of
              [] => multiDFun (([x], a) :: doms) bx
            | (xs, a') :: doms' =>
                if Abt.eq (a, a') then
@@ -82,10 +82,10 @@ struct
                  multiDFun (([x], a) :: doms) bx)
      | _ => (List.rev doms, m)
 
-  fun multiDProd (doms : (variable list * abt) list) m = 
-    case Abt.out m of 
+  fun multiDProd (doms : (variable list * abt) list) m =
+    case Abt.out m of
        O.MONO O.DPROD $ [_ \ a, (_, [x]) \ bx] =>
-         (case doms of 
+         (case doms of
              [] => multiDFun (([x], a) :: doms) bx
            | (xs, a') :: doms' =>
                if Abt.eq (a, a') then
@@ -94,36 +94,36 @@ struct
                  multiDProd (([x], a) :: doms) bx)
      | _ => (List.rev doms, m)
 
-  fun multiLam (xs : variable list) m = 
-    case Abt.out m of 
-       O.MONO O.LAM $ [(_, [x]) \ mx] => 
+  fun multiLam (xs : variable list) m =
+    case Abt.out m of
+       O.MONO O.LAM $ [(_, [x]) \ mx] =>
          multiLam (x :: xs) mx
      | _ => (List.rev xs, m)
 
-  fun printQuant opr (doms, cod) = 
+  fun printQuant opr (doms, cod) =
     Atomic.parens @@ expr @@ hvsep @@
       (text opr)
         :: List.map (fn (xs, a) => Atomic.squares @@ hsep @@ List.map ppVar xs @ [ppTerm a]) doms
           @ [ppTerm cod]
 
-  and printLam (xs, m) = 
-    Atomic.parens @@ expr @@ hvsep @@ 
+  and printLam (xs, m) =
+    Atomic.parens @@ expr @@ hvsep @@
       [hvsep [text "lam", varBinding xs], align @@ ppTerm m]
 
-  and ppTerm m = 
-    case Abt.out m of 
+  and ppTerm m =
+    case Abt.out m of
        O.POLY (O.HYP_REF x) $ [] => seq [text ",", ppVar x]
      | O.MONO O.DFUN $ _ =>
          printQuant "->" @@ multiDFun [] m
      | O.MONO O.DPROD $ _ =>
          printQuant "*" @@ multiDProd [] m
-     | O.MONO O.LAM $ _ => 
+     | O.MONO O.LAM $ _ =>
          printLam @@ multiLam [] m
-     | O.MONO O.AP $ [_ \ m, _ \ n] => 
+     | O.MONO O.AP $ [_ \ m, _ \ n] =>
          Atomic.parens @@ expr @@ hvsep [ppTerm m, ppTerm n]
-     | O.MONO O.PAIR $ [_ \ m, _ \ n] => 
+     | O.MONO O.PAIR $ [_ \ m, _ \ n] =>
          collection (char #"<") (char #">") Atomic.comma [ppTerm m, ppTerm n]
-     | O.POLY (O.LOOP r) $ _ => 
+     | O.POLY (O.LOOP r) $ _ =>
          seq [text "loop", Atomic.squares @@ ppParam r]
      | O.POLY (O.PATH_AP r) $ [_ \ m] =>
          Atomic.parens @@ expr @@ hvsep [text "@", ppTerm m, ppParam r]
@@ -133,13 +133,13 @@ struct
            hvsep [ppComHead "hcom" dir, ppBinder ty, ppBinder cap]
              :: [ppTubes (eqs, tubes)]
 
-     | theta $ [] => 
+     | theta $ [] =>
         ppOperator theta
-     | theta $ [([], []) \ arg] => 
+     | theta $ [([], []) \ arg] =>
         Atomic.parens @@ expr @@ hvsep @@ [ppOperator theta, atLevel 10 @@ ppTerm arg]
-     | theta $ [(us, xs) \ arg] => 
-        Atomic.parens @@ expr @@ hvsep [hvsep [ppOperator theta, seq [symBinding us, varBinding xs]], align @@ ppTerm arg] 
-     | theta $ args => 
+     | theta $ [(us, xs) \ arg] =>
+        Atomic.parens @@ expr @@ hvsep [hvsep [ppOperator theta, seq [symBinding us, varBinding xs]], align @@ ppTerm arg]
+     | theta $ args =>
         Atomic.parens @@ expr @@
           hvsep @@ ppOperator theta :: List.map ppBinder args
 
@@ -149,30 +149,30 @@ struct
             unlessEmpty ps @@ collection (char #"{") (char #"}") Atomic.comma @@ List.map (ppParam o #1) ps,
             unlessEmpty ms @@ collection (char #"[") (char #"]") Atomic.comma @@ List.map ppTerm ms]
 
-  and ppTubes (eqs, tubes) = 
+  and ppTubes (eqs, tubes) =
     expr @@ hvsep @@
-      ListPair.map 
-        (fn ((r1, r2), ([u], _) \ mx) => 
+      ListPair.map
+        (fn ((r1, r2), ([u], _) \ mx) =>
           Atomic.squares @@ hsep
             [seq [ppParam r1, Atomic.equals, ppParam r2],
               text "->",
               nest 1 @@ hvsep [Atomic.braces (text (Sym.toString u)), ppTerm mx]])
         (eqs, tubes)
 
-  
-  and ppBinder ((us, xs) \ m) = 
-    case (us, xs) of 
+
+  and ppBinder ((us, xs) \ m) =
+    case (us, xs) of
         ([], []) => atLevel 10 @@ ppTerm m
-      | _ => grouped @@ hvsep [seq [symBinding us, varBinding xs], align @@ ppTerm m] 
+      | _ => grouped @@ hvsep [seq [symBinding us, varBinding xs], align @@ ppTerm m]
 
   and symBinding us =
     unlessEmpty us @@
-      Atomic.braces @@ 
+      Atomic.braces @@
         hsep @@ List.map (text o Sym.toString) us
 
   and varBinding xs =
     unlessEmpty xs @@
-      Atomic.squares @@ 
+      Atomic.squares @@
         hsep @@ List.map ppVar xs
 
 
@@ -181,26 +181,26 @@ struct
 
   fun ppValence ((sigmas, taus), tau) =
     let
-      val prefix = 
-        case (sigmas, taus) of 
+      val prefix =
+        case (sigmas, taus) of
            ([], []) => empty
          | _ => seq [symSorts sigmas, varSorts taus, char #"."]
     in
       seq [prefix, ppSort tau]
     end
 
-  and symSorts sigmas = 
+  and symSorts sigmas =
     unlessEmpty sigmas @@
-      Atomic.braces @@ 
+      Atomic.braces @@
         hsep @@ intersperse Atomic.comma @@ List.map ppPsort sigmas
 
   and varSorts taus =
     unlessEmpty taus @@
-      Atomic.squares @@ 
+      Atomic.squares @@
         hsep @@ intersperse Atomic.comma @@ List.map ppSort taus
 
-  val toString = 
-    FppRenderPlainText.toString 
+  val toString =
+    FppRenderPlainText.toString
       o FinalPrinter.execPP
       o ppTerm
 end

--- a/src/redprl/pretty.sml
+++ b/src/redprl/pretty.sml
@@ -67,7 +67,7 @@ struct
     case xs of 
        [] => []
      | [x] => [x]
-     | x::xs => x :: s :: intersperse s xs
+     | x::xs => seq [x, s] :: intersperse s xs
 
 
   (* This is still quite rudimentary; we can learn to more interesting things like alignment, etc. *)
@@ -86,7 +86,7 @@ struct
      | O.POLY (O.LOOP r) $ _ => 
          seq [text "loop", Atomic.squares @@ ppParam r]
      | O.POLY (O.PATH_AP r) $ [_ \ m] =>
-         inf 2 LEFT {opr = char #"@", arg1 = ppTerm m, arg2 = ppParam r}
+         Atomic.parens @@ expr @@ hvsep [text "@", ppTerm m, ppParam r]
      | `x => ppVar x
      | O.POLY (O.HCOM (dir, eqs)) $ (ty :: cap :: tubes) =>
          Atomic.parens @@ expr @@ hvsep @@
@@ -99,10 +99,9 @@ struct
         Atomic.parens @@ expr @@ hvsep @@ [ppOperator theta, atLevel 10 @@ ppTerm arg]
      | theta $ [(us, xs) \ arg] => 
         Atomic.parens @@ expr @@ hvsep [hvsep [ppOperator theta, seq [symBinding us, varBinding xs]], align @@ ppTerm arg] 
-
      | theta $ args => 
         Atomic.parens @@ expr @@
-          hvsep @@ ppOperator theta :: (List.map ppBinder args)
+          hvsep @@ ppOperator theta :: List.map ppBinder args
 
      | x $# (ps, ms) =>
          seq

--- a/src/redprl/pretty.sml
+++ b/src/redprl/pretty.sml
@@ -63,7 +63,7 @@ struct
      | `x => ppVar x
      | theta $ args => 
          text (RedPrlOperator.toString Sym.toString theta)
-           >> collection (char #"(") (char #")") (char #";") (List.map ppBinder args)
+           >> unlessEmpty args (collection (char #"(") (char #")") (char #";") (List.map ppBinder args))
      | x $# (ps, ms) =>
          char #"#" >> text (Abt.Metavar.toString x) 
            >> unlessEmpty ps (collection (char #"{") (char #"}") Atomic.comma (List.map (ppParam o #1) ps))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -454,6 +454,7 @@ atomicRawTac
 
   | LPAREN OPNAME customOpParams RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))
   | LPAREN OPNAME customOpParams bindings RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), bindings)) 
+  | LPAREN operator bindings RPAREN (Ast.$$ (operator, bindings))
 
   | operator (Ast.$$ (operator, []))
   | metavar metavarArgs (Ast.$$# (metavar, metavarArgs))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -260,7 +260,7 @@ param
 
 params
   : param ([param])
-  | param COMMA params (param :: params)
+  | param params (param :: params)
   | ([])
 
 equation

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -36,13 +36,13 @@ struct
     multitacToTac (O.MONO O.MTAC_ORELSE $$ [([],[]) \ tacToMulitac t1, ([],[]) \ tacToMulitac t2])
 end
 
-structure Quant = 
+structure Quant =
 struct
   infix $$ $ \
 
   fun makeQuant opr [] cod = cod
     | makeQuant opr (([], _) :: doms) cod = makeQuant opr doms cod
-    | makeQuant opr ((x :: xs, a) :: doms) cod = 
+    | makeQuant opr ((x :: xs, a) :: doms) cod =
        O.MONO opr $$ [([],[]) \ a, ([],[x]) \ makeQuant opr ((xs, a) :: doms) cod]
 
   val makeDFun = makeQuant O.DFUN
@@ -262,13 +262,10 @@ boundVar
 symbols
   : boundVar ([boundVar])
   | boundVar symbols (boundVar :: symbols)
-  | ([])
 
 terms
   : term ([term])
   | term terms (term :: terms)
-  | PERCENT LBRACKET tactic RBRACKET COMMA terms (tactic :: terms)
-  | ([])
 
 binder
   : LBRACKET symbols RBRACKET LSQUARE symbols RSQUARE (symbols1, symbols2)
@@ -278,7 +275,6 @@ binder
 
 binding
   : binder term (\ (binder, term))
-  | binder PERCENT LBRACKET tactic RBRACKET (\ (binder, tactic))
 
 bindings
   : binding ([binding])
@@ -332,11 +328,13 @@ quantifierData
 atomicRawTerm
   : LPAREN term term RPAREN (Ast.$$ (O.MONO O.AP, [\ (([],[]),term1), \ (([],[]), term2)]))
   | LPAREN operator bindings RPAREN (Ast.$$ (operator, bindings))
-  | operator (Ast.$$ (operator, []))
   | LPAREN FCOM LBRACKET dir RBRACKET binding tubes RPAREN
       (let val (eqs, tubes) = ListPair.unzip tubes in Ast.$$ (O.POLY (O.FCOM (dir, eqs)), (binding :: tubes)) end)
   | LPAREN HCOM LBRACKET dir RBRACKET binding binding tubes RPAREN
       (let val (eqs, tubes) = ListPair.unzip tubes in Ast.$$ (O.POLY (O.HCOM (dir, eqs)), (binding1 :: binding2 :: tubes)) end)
+  | OPNAME customOpParams (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))
+
+  
   | metavar metavarArgs (Ast.$$# (metavar, metavarArgs))
   | COMMA VARNAME (Ast.$$ (O.POLY (O.HYP_REF VARNAME), []))
   | VARNAME (`` VARNAME)
@@ -402,7 +400,7 @@ src_genjdg
   : src_sequent ([], src_sequent)
   | LBRACKET symBindings RBRACKET PIPE src_sequent (symBindings, src_sequent)
 
-src_ruleConcl 
+src_ruleConcl
   : src_sequent (src_sequent)
 
 src_rulePremises

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -288,11 +288,11 @@ bindings
   | ([])
 
 tube
-  : equation RIGHT_ARROW binding (equation, binding)
+  : LSQUARE equation RIGHT_ARROW binding RSQUARE (equation, binding)
 
 tubes
   : tube ([tube])
-  | tube SEMI tubes (tube :: tubes)
+  | tube tubes (tube :: tubes)
   | ([])
 
 metavarArgs
@@ -335,9 +335,9 @@ atomicRawTerm
   : LPAREN term term RPAREN (Ast.$$ (O.MONO O.AP, [\ (([],[]),term1), \ (([],[]), term2)]))
   | LPAREN operator bindings RPAREN (Ast.$$ (operator, bindings))
   | operator (Ast.$$ (operator, []))
-  | FCOM LBRACKET dir RBRACKET LPAREN binding RPAREN LSQUARE tubes RSQUARE
+  | LPAREN FCOM LBRACKET dir RBRACKET binding tubes RPAREN
       (let val (eqs, tubes) = ListPair.unzip tubes in Ast.$$ (O.POLY (O.FCOM (dir, eqs)), (binding :: tubes)) end)
-  | HCOM LBRACKET dir RBRACKET LPAREN binding SEMI binding RPAREN LSQUARE tubes RSQUARE
+  | LPAREN HCOM LBRACKET dir RBRACKET binding binding tubes RPAREN
       (let val (eqs, tubes) = ListPair.unzip tubes in Ast.$$ (O.POLY (O.HCOM (dir, eqs)), (binding1 :: binding2 :: tubes)) end)
   | metavar metavarArgs (Ast.$$# (metavar, metavarArgs))
   | COMMA VARNAME (Ast.$$ (O.POLY (O.HYP_REF VARNAME), []))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -259,9 +259,9 @@ terms
   | ([])
 
 binder
-  : LBRACKET symbols RBRACKET LSQUARE symbols RSQUARE DOT (symbols1, symbols2)
-  | LBRACKET symbols RBRACKET DOT (symbols, [])
-  | LSQUARE symbols RSQUARE DOT ([], symbols)
+  : LBRACKET symbols RBRACKET LSQUARE symbols RSQUARE (symbols1, symbols2)
+  | LBRACKET symbols RBRACKET (symbols, [])
+  | LSQUARE symbols RSQUARE ([], symbols)
   | ([], [])
 
 binding
@@ -270,7 +270,7 @@ binding
 
 bindings
   : binding ([binding])
-  | binding SEMI bindings (binding :: bindings)
+  | binding bindings (binding :: bindings)
   | ([])
 
 tube
@@ -308,11 +308,11 @@ metavar
 dir
   : param SQUIGGLE_ARROW param ((param1, param2))
 
-term : rawTerm %prec FUN_APP (annotate (Pos.pos (rawTerm1left fileName) (rawTerm1right fileName)) rawTerm)
+term : atomicRawTerm %prec FUN_APP (annotate (Pos.pos (atomicRawTerm1left fileName) (atomicRawTerm1right fileName)) atomicRawTerm)
 
 atomicRawTerm
-  : LPAREN term RPAREN (term)
-  | operator LPAREN bindings RPAREN (Ast.$$ (operator, bindings))
+  : LPAREN term term RPAREN (Ast.$$ (O.MONO O.AP, [\ (([],[]),term1), \ (([],[]), term2)]))
+  | LPAREN operator bindings RPAREN (Ast.$$ (operator, bindings))
   | operator (Ast.$$ (operator, []))
   | FCOM LBRACKET dir RBRACKET LPAREN binding RPAREN LSQUARE tubes RSQUARE
       (let val (eqs, tubes) = ListPair.unzip tubes in Ast.$$ (O.POLY (O.FCOM (dir, eqs)), (binding :: tubes)) end)
@@ -321,8 +321,8 @@ atomicRawTerm
   | metavar metavarArgs (Ast.$$# (metavar, metavarArgs))
   | COMMA VARNAME (Ast.$$ (O.POLY (O.HYP_REF VARNAME), []))
   | VARNAME (`` VARNAME)
-  | LPAREN boundVar COLON term RPAREN RIGHT_ARROW term (Ast.$$ (O.MONO O.DFUN, [\ (([],[]), term1), \ (([],[boundVar]), term2)]))
-  | LPAREN boundVar COLON term RPAREN TIMES term (Ast.$$ (O.MONO O.DPROD, [\ (([],[]), term1), \ (([],[boundVar]), term2)]))
+  | LPAREN RIGHT_ARROW LSQUARE boundVar term RSQUARE term RPAREN (Ast.$$ (O.MONO O.DFUN, [\ (([],[]), term1), \ (([],[boundVar]), term2)]))
+  | LPAREN TIMES LSQUARE boundVar term RSQUARE term RPAREN (Ast.$$ (O.MONO O.DPROD, [\ (([],[]), term1), \ (([],[boundVar]), term2)]))
   | LANGLE term COMMA term RANGLE (Ast.$$ (O.MONO O.PAIR, [\ (([],[]), term1), \ (([],[]), term2)]))
   | BOOL (Ast.$$ (O.MONO O.BOOL, []))
   | TT (Ast.$$ (O.MONO O.TRUE, []))
@@ -337,16 +337,16 @@ atomicRawTerm
 
 atomicTerm : atomicRawTerm (annotate (Pos.pos (atomicRawTerm1left fileName) (atomicRawTerm1right fileName)) atomicRawTerm)
 
-rawFunApp
+(*rawFunApp
   : rawTerm atomicTerm %prec FUN_APP (Ast.$$ (O.MONO O.AP, [\ (([],[]), (annotate (Pos.pos (rawTerm1left fileName) (rawTerm1right fileName)) rawTerm)), \ (([],[]), atomicTerm)]))
   | atomicTerm %prec FUN_APP (atomicTerm)
 
-funApp : rawFunApp (annotate (Pos.pos (rawFunAppleft fileName) (rawFunAppright fileName)) rawFunApp)
+funApp : rawFunApp (annotate (Pos.pos (rawFunAppleft fileName) (rawFunAppright fileName)) rawFunApp)*)
 
-rawTerm
+(*rawTerm
   : funApp RIGHT_ARROW term (Ast.$$ (O.MONO O.DFUN, [\ (([],[]), funApp), \ (([],["_"]), term)]))
   | funApp TIMES term (Ast.$$ (O.MONO O.DPROD, [\ (([],[]), funApp), \ (([],["_"]), term)]))
-  | funApp %prec RIGHT_ARROW (funApp)
+  | funApp %prec RIGHT_ARROW (funApp)*)
 
 rawJudgment
   : term JDG_TRUE (Ast.$$ (O.MONO O.JDG_TRUE, [\ (([],[]), term)]))
@@ -437,7 +437,7 @@ atomicRawTac
   | CASE VARNAME OF BASE DOUBLE_RIGHT_ARROW tactic PIPE LOOP LBRACKET VARNAME RBRACKET DOUBLE_RIGHT_ARROW tactic
       (Ast.$$ (O.POLY (O.DEV_S1_ELIM VARNAME1), [\ (([],[]), tactic1), \(([VARNAME2], []), tactic2)]))
 
-  | operator LPAREN bindings RPAREN (Ast.$$ (operator, bindings))
+  | LPAREN operator bindings RPAREN (Ast.$$ (operator, bindings))
   | operator (Ast.$$ (operator, []))
   | metavar metavarArgs (Ast.$$# (metavar, metavarArgs))
   | VARNAME (`` VARNAME)

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -36,6 +36,21 @@ struct
     multitacToTac (O.MONO O.MTAC_ORELSE $$ [([],[]) \ tacToMulitac t1, ([],[]) \ tacToMulitac t2])
 end
 
+structure Quant = 
+struct
+  infix $$ $ \
+
+  fun makeDFun [] cod = cod
+    | makeDFun ((x,a) :: doms) cod = 
+       O.MONO O.DFUN $$ [([],[]) \ a, ([],[x]) \ makeDFun doms cod]
+
+  fun makeDProd [] cod = cod
+    | makeDProd ((x,a) :: doms) cod = 
+       O.MONO O.DPROD $$ [([],[]) \ a, ([],[x]) \ makeDFun doms cod]
+
+    
+end
+
 
 %%
 %header (functor RedPrlLrValsFun (structure Token : TOKEN))
@@ -59,6 +74,7 @@ end
  | SEMI
  | COMMA
  | LAMBDA
+ | ABS
  | SQUIGGLE
  | SQUIGGLE_ARROW
  | FRESH
@@ -70,8 +86,6 @@ end
 
  | FCOM | BOOL | TT | FF | IF | S_BOOL | S_IF | VOID | S1 | BASE | LOOP | FST | SND | PATHS | HCOM | COE
  | THEN | ELSE | LET | WITH | CASE | OF
-
- | FUN_APP
 
  | DIM | EXN | LBL | LVL | HYP
  | EXP | TAC | TRIV
@@ -89,9 +103,7 @@ end
 %right LEFT_ARROW RIGHT_ARROW DOUBLE_PIPE SEMI
 %right TIMES
 %nonassoc COMMA COLON
-%left FUN_APP
-%left AT_SIGN
-%nonassoc FCOM BOOL TT FF IF S_BOOL S_IF VOID S1 BASE LOOP LAMBDA FST SND PATHS HCOM COE HASH LANGLE LPAREN VARNAME OPNAME
+%nonassoc AT_SIGN FCOM BOOL TT FF IF S_BOOL S_IF VOID S1 BASE LOOP LAMBDA ABS FST SND PATHS HCOM COE HASH LANGLE LPAREN VARNAME OPNAME
 
 
 
@@ -106,6 +118,8 @@ end
  | atomicRawTerm of ast
    (* ... annotated with source position*)
  | atomicTerm of ast
+
+ | quantifierData of (string * ast) list * ast
 
    (* a type-theoretic term, annotated with source position *)
  | term of ast
@@ -289,6 +303,7 @@ metavarArgs
 
 operator
   : LAMBDA (O.MONO O.LAM)
+  | ABS (O.MONO O.PATH_ABS)
   | COE LBRACKET dir RBRACKET (O.POLY (O.COE dir))
   | OPNAME customOpParams (O.POLY (O.CUST (OPNAME, customOpParams, NONE)))
   | RULE_LEMMA OPNAME customOpParams (O.POLY (O.RULE_LEMMA (OPNAME, customOpParams, NONE)))
@@ -308,7 +323,13 @@ metavar
 dir
   : param SQUIGGLE_ARROW param ((param1, param2))
 
-term : atomicRawTerm %prec FUN_APP (annotate (Pos.pos (atomicRawTerm1left fileName) (atomicRawTerm1right fileName)) atomicRawTerm)
+term : atomicRawTerm (annotate (Pos.pos (atomicRawTerm1left fileName) (atomicRawTerm1right fileName)) atomicRawTerm)
+
+quantifierData
+  : LSQUARE boundVar term RSQUARE quantifierData (((boundVar, term) :: #1 quantifierData), #2 quantifierData)
+  | term quantifierData ((("_", term) :: #1 quantifierData), #2 quantifierData)
+  | term ([], term)
+
 
 atomicRawTerm
   : LPAREN term term RPAREN (Ast.$$ (O.MONO O.AP, [\ (([],[]),term1), \ (([],[]), term2)]))
@@ -321,8 +342,8 @@ atomicRawTerm
   | metavar metavarArgs (Ast.$$# (metavar, metavarArgs))
   | COMMA VARNAME (Ast.$$ (O.POLY (O.HYP_REF VARNAME), []))
   | VARNAME (`` VARNAME)
-  | LPAREN RIGHT_ARROW LSQUARE boundVar term RSQUARE term RPAREN (Ast.$$ (O.MONO O.DFUN, [\ (([],[]), term1), \ (([],[boundVar]), term2)]))
-  | LPAREN TIMES LSQUARE boundVar term RSQUARE term RPAREN (Ast.$$ (O.MONO O.DPROD, [\ (([],[]), term1), \ (([],[boundVar]), term2)]))
+  | LPAREN RIGHT_ARROW quantifierData RPAREN (Quant.makeDFun (#1 quantifierData) (#2 quantifierData))
+  | LPAREN TIMES quantifierData RPAREN (Quant.makeDProd (#1 quantifierData) (#2 quantifierData))
   | LANGLE term COMMA term RANGLE (Ast.$$ (O.MONO O.PAIR, [\ (([],[]), term1), \ (([],[]), term2)]))
   | BOOL (Ast.$$ (O.MONO O.BOOL, []))
   | TT (Ast.$$ (O.MONO O.TRUE, []))
@@ -332,21 +353,9 @@ atomicRawTerm
   | S1 (Ast.$$ (O.MONO O.S1, []))
   | BASE (Ast.$$ (O.MONO O.BASE, []))
   | LOOP LBRACKET param RBRACKET (Ast.$$ (O.POLY (O.LOOP param), []))
-  | LANGLE boundVar RANGLE term (Ast.$$ (O.MONO O.PATH_ABS, [\ (([boundVar],[]), term)]))
-  | atomicTerm AT_SIGN param %prec AT_SIGN (Ast.$$ (O.POLY (O.PATH_AP param), [\ (([],[]), atomicTerm)]))
+  | LPAREN AT_SIGN atomicTerm param RPAREN (Ast.$$ (O.POLY (O.PATH_AP param), [\ (([],[]), atomicTerm)]))
 
 atomicTerm : atomicRawTerm (annotate (Pos.pos (atomicRawTerm1left fileName) (atomicRawTerm1right fileName)) atomicRawTerm)
-
-(*rawFunApp
-  : rawTerm atomicTerm %prec FUN_APP (Ast.$$ (O.MONO O.AP, [\ (([],[]), (annotate (Pos.pos (rawTerm1left fileName) (rawTerm1right fileName)) rawTerm)), \ (([],[]), atomicTerm)]))
-  | atomicTerm %prec FUN_APP (atomicTerm)
-
-funApp : rawFunApp (annotate (Pos.pos (rawFunAppleft fileName) (rawFunAppright fileName)) rawFunApp)*)
-
-(*rawTerm
-  : funApp RIGHT_ARROW term (Ast.$$ (O.MONO O.DFUN, [\ (([],[]), funApp), \ (([],["_"]), term)]))
-  | funApp TIMES term (Ast.$$ (O.MONO O.DPROD, [\ (([],[]), funApp), \ (([],["_"]), term)]))
-  | funApp %prec RIGHT_ARROW (funApp)*)
 
 rawJudgment
   : term JDG_TRUE (Ast.$$ (O.MONO O.JDG_TRUE, [\ (([],[]), term)]))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -454,7 +454,7 @@ atomicRawTac
   | RULE_ELIM VARNAME COLON sort (Ast.$$ (O.POLY (O.RULE_ELIM (VARNAME, sort)), []))
   | RULE_ELIM VARNAME (Ast.$$ (O.POLY (O.RULE_ELIM (VARNAME, O.EXP)), []))
   | RULE_UNFOLD OPNAME (Ast.$$ (O.POLY (O.RULE_UNFOLD OPNAME), []))
-  | APOSTROPHE term (Ast.$$ (O.MONO O.RULE_WITNESS, [\ (([],[]), term)]))
+  | BACK_TICK term (Ast.$$ (O.MONO O.RULE_WITNESS, [\ (([],[]), term)]))
   | RULE_HEAD_EXP (Ast.$$ (O.MONO O.RULE_HEAD_EXP, []))
 
   | atomicTac DOUBLE_PIPE tactic %prec DOUBLE_PIPE (Tac.orElse (atomicTac, tactic))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -368,7 +368,7 @@ atomicRawTerm
   | VOID (Ast.$$ (O.MONO O.VOID, []))
   | S1 (Ast.$$ (O.MONO O.S1, []))
   | BASE (Ast.$$ (O.MONO O.BASE, []))
-  | LOOP LBRACKET param RBRACKET (Ast.$$ (O.POLY (O.LOOP param), []))
+  | LPAREN LOOP param RPAREN (Ast.$$ (O.POLY (O.LOOP param), []))
   | LPAREN AT_SIGN atomicTerm param RPAREN (Ast.$$ (O.POLY (O.PATH_AP param), [\ (([],[]), atomicTerm)]))
 
 atomicTerm : atomicRawTerm (annotate (Pos.pos (atomicRawTerm1left fileName) (atomicRawTerm1right fileName)) atomicRawTerm)
@@ -473,7 +473,7 @@ atomicRawTac
       (Ast.$$ (O.POLY (O.DEV_DFUN_ELIM VARNAME2), [\ (([],[]), tactic1), \ (([VARNAME1, "_"],[]), tactic2)]))
   | LET LANGLE VARNAME COMMA VARNAME RANGLE EQUALS VARNAME DOT tactic
       (Ast.$$ (O.POLY (O.DEV_DPROD_ELIM VARNAME3), [\ (([VARNAME1, VARNAME2],[]), tactic)]))
-  | CASE VARNAME OF BASE DOUBLE_RIGHT_ARROW tactic PIPE LOOP LBRACKET VARNAME RBRACKET DOUBLE_RIGHT_ARROW tactic
+  | CASE VARNAME OF BASE DOUBLE_RIGHT_ARROW tactic PIPE LOOP VARNAME DOUBLE_RIGHT_ARROW tactic
       (Ast.$$ (O.POLY (O.DEV_S1_ELIM VARNAME1), [\ (([],[]), tactic1), \(([VARNAME2], []), tactic2)]))
 
   | RULE_LEMMA term (Tac.makeLemma term)

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -49,7 +49,7 @@ struct
   val makeDProd = makeQuant O.DPROD
 
   fun makeLam [] m = m
-    | makeLam (x::xs) m = 
+    | makeLam (x::xs) m =
         O.MONO O.LAM $$ [([],[x]) \ makeLam xs m]
 end
 
@@ -89,7 +89,7 @@ end
  | FCOM | BOOL | TT | FF | IF | S_BOOL | S_IF | VOID | S1 | BASE | LOOP | FST | SND | PATHS | HCOM | COE
  | THEN | ELSE | LET | WITH | CASE | OF
 
- | FUN_APP 
+ | FUN_APP
 
  | DIM | EXN | LBL | LVL | HYP
  | EXP | TAC | TRIV
@@ -344,7 +344,7 @@ atomicRawTerm
   | LPAREN operator bindings RPAREN (Ast.$$ (operator, bindings))
 
   | LPAREN OPNAME customOpParams RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))
-  | LPAREN OPNAME customOpParams bindings RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), bindings)) 
+  | LPAREN OPNAME customOpParams bindings RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), bindings))
 
   | LPAREN term term RPAREN (Ast.$$ (O.MONO O.AP, [\ (([],[]),term1), \ (([],[]), term2)]))
 
@@ -469,7 +469,7 @@ atomicRawTac
       (Ast.$$ (O.POLY (O.DEV_S1_ELIM VARNAME1), [\ (([],[]), tactic1), \(([VARNAME2], []), tactic2)]))
 
   | LPAREN OPNAME customOpParams RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))
-  | LPAREN OPNAME customOpParams bindings RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), bindings)) 
+  | LPAREN OPNAME customOpParams bindings RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), bindings))
   | LPAREN operator bindings RPAREN (Ast.$$ (operator, bindings))
 
   | operator (Ast.$$ (operator, []))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -36,7 +36,7 @@ struct
     multitacToTac (O.MONO O.MTAC_ORELSE $$ [([],[]) \ tacToMulitac t1, ([],[]) \ tacToMulitac t2])
 end
 
-structure Quant =
+structure Multi =
 struct
   infix $$ $ \
 
@@ -47,6 +47,10 @@ struct
 
   val makeDFun = makeQuant O.DFUN
   val makeDProd = makeQuant O.DPROD
+
+  fun makeLam [] m = m
+    | makeLam (x::xs) m = 
+        O.MONO O.LAM $$ [([],[x]) \ makeLam xs m]
 end
 
 
@@ -286,8 +290,7 @@ metavarArgs
 
 
 operator
-  : LAMBDA (O.MONO O.LAM)
-  | ABS (O.MONO O.PATH_ABS)
+  : ABS (O.MONO O.PATH_ABS)
   | COE LBRACKET dir RBRACKET (O.POLY (O.COE dir))
   | RULE_LEMMA OPNAME customOpParams (O.POLY (O.RULE_LEMMA (OPNAME, customOpParams, NONE)))
   | IF (O.MONO O.IF)
@@ -348,8 +351,9 @@ atomicRawTerm
 
   | metavar metavarArgs (Ast.$$# (metavar, metavarArgs))
   | COMMA VARNAME (Ast.$$ (O.POLY (O.HYP_REF VARNAME), []))
-  | LPAREN RIGHT_ARROW quantifierData RPAREN (Quant.makeDFun (#1 quantifierData) (#2 quantifierData))
-  | LPAREN TIMES quantifierData RPAREN (Quant.makeDProd (#1 quantifierData) (#2 quantifierData))
+  | LPAREN RIGHT_ARROW quantifierData RPAREN (Multi.makeDFun (#1 quantifierData) (#2 quantifierData))
+  | LPAREN TIMES quantifierData RPAREN (Multi.makeDProd (#1 quantifierData) (#2 quantifierData))
+  | LPAREN LAMBDA LSQUARE symbols RSQUARE term RPAREN (Multi.makeLam symbols term)
   | LANGLE term COMMA term RANGLE (Ast.$$ (O.MONO O.PAIR, [\ (([],[]), term1), \ (([],[]), term2)]))
   | BOOL (Ast.$$ (O.MONO O.BOOL, []))
   | TT (Ast.$$ (O.MONO O.TRUE, []))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -40,15 +40,13 @@ structure Quant =
 struct
   infix $$ $ \
 
-  fun makeDFun [] cod = cod
-    | makeDFun ((x,a) :: doms) cod = 
-       O.MONO O.DFUN $$ [([],[]) \ a, ([],[x]) \ makeDFun doms cod]
+  fun makeQuant opr [] cod = cod
+    | makeQuant opr (([], _) :: doms) cod = makeQuant opr doms cod
+    | makeQuant opr ((x :: xs, a) :: doms) cod = 
+       O.MONO opr $$ [([],[]) \ a, ([],[x]) \ makeQuant opr ((xs, a) :: doms) cod]
 
-  fun makeDProd [] cod = cod
-    | makeDProd ((x,a) :: doms) cod = 
-       O.MONO O.DPROD $$ [([],[]) \ a, ([],[x]) \ makeDFun doms cod]
-
-    
+  val makeDFun = makeQuant O.DFUN
+  val makeDProd = makeQuant O.DPROD
 end
 
 
@@ -119,7 +117,7 @@ end
    (* ... annotated with source position*)
  | atomicTerm of ast
 
- | quantifierData of (string * ast) list * ast
+ | quantifierData of (string list * ast) list * ast
 
    (* a type-theoretic term, annotated with source position *)
  | term of ast
@@ -263,12 +261,12 @@ boundVar
 
 symbols
   : boundVar ([boundVar])
-  | boundVar COMMA symbols (boundVar :: symbols)
+  | boundVar symbols (boundVar :: symbols)
   | ([])
 
 terms
   : term ([term])
-  | term COMMA terms (term :: terms)
+  | term terms (term :: terms)
   | PERCENT LBRACKET tactic RBRACKET COMMA terms (tactic :: terms)
   | ([])
 
@@ -326,8 +324,8 @@ dir
 term : atomicRawTerm (annotate (Pos.pos (atomicRawTerm1left fileName) (atomicRawTerm1right fileName)) atomicRawTerm)
 
 quantifierData
-  : LSQUARE boundVar term RSQUARE quantifierData (((boundVar, term) :: #1 quantifierData), #2 quantifierData)
-  | term quantifierData ((("_", term) :: #1 quantifierData), #2 quantifierData)
+  : LSQUARE symbols term RSQUARE quantifierData (((symbols, term) :: #1 quantifierData), #2 quantifierData)
+  | term quantifierData (((["_"], term) :: #1 quantifierData), #2 quantifierData)
   | term ([], term)
 
 

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -34,6 +34,11 @@ struct
 
   fun orElse (t1, t2) =
     multitacToTac (O.MONO O.MTAC_ORELSE $$ [([],[]) \ tacToMulitac t1, ([],[]) \ tacToMulitac t2])
+
+  fun makeLemma tm = 
+    case Ast.out tm of
+       O.POLY (O.CUST params) $ bindings => O.POLY (O.RULE_LEMMA params) $$ bindings
+     | _ => raise Fail "Invalid 'rule' term"
 end
 
 structure Multi =
@@ -289,19 +294,9 @@ metavarArgs
   | ([], [])
 
 
-operator
-  : ABS (O.MONO O.PATH_ABS)
-  | COE LBRACKET dir RBRACKET (O.POLY (O.COE dir))
-  | RULE_LEMMA OPNAME customOpParams (O.POLY (O.RULE_LEMMA (OPNAME, customOpParams, NONE)))
-  | IF (O.MONO O.IF)
-  | S_IF (O.MONO O.S_IF)
-  | PATHS (O.MONO O.PATH_TY)
-  | FST (O.MONO O.FST)
-  | SND (O.MONO O.SND)
 
 customOpParams
-  : LBRACKET params RBRACKET (List.map (fn x => (x, NONE)) params)
-  | ([])
+  : params (List.map (fn x => (x, NONE)) params)
 
 metavar
   : HASH ident (ident)
@@ -330,6 +325,16 @@ bindings
   : binding bindings (binding :: bindings)
   | binding ([binding])
 
+operator
+  : ABS (O.MONO O.PATH_ABS)
+  | COE LBRACKET dir RBRACKET (O.POLY (O.COE dir))
+  | IF (O.MONO O.IF)
+  | S_IF (O.MONO O.S_IF)
+  | PATHS (O.MONO O.PATH_TY)
+  | FST (O.MONO O.FST)
+  | SND (O.MONO O.SND)
+
+
 atomicRawTerm
   : VARNAME (`` VARNAME)
   | LPAREN FCOM LBRACKET dir RBRACKET binding tubes RPAREN
@@ -343,8 +348,9 @@ atomicRawTerm
 
   | LPAREN operator bindings RPAREN (Ast.$$ (operator, bindings))
 
-  | LPAREN OPNAME customOpParams RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))
-  | LPAREN OPNAME customOpParams bindings RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), bindings))
+
+  | LPAREN LBRACKET OPNAME customOpParams RBRACKET bindings RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), bindings))
+  | LPAREN OPNAME bindings RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, [], NONE)), bindings))
 
   | LPAREN term term RPAREN (Ast.$$ (O.MONO O.AP, [\ (([],[]),term1), \ (([],[]), term2)]))
 
@@ -375,7 +381,9 @@ funApp : rawFunApp (annotate (Pos.pos (rawFunAppleft fileName) (rawFunAppright f
 
 rawTerm
   : funApp %prec FUN_APP (funApp)
-  | OPNAME customOpParams %prec FUN_APP (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))
+  | LBRACKET OPNAME customOpParams RBRACKET %prec FUN_APP (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))
+
+  | OPNAME %prec FUN_APP (Ast.$$ (O.POLY (O.CUST (OPNAME, [], NONE)), []))
 
 
 
@@ -468,6 +476,7 @@ atomicRawTac
   | CASE VARNAME OF BASE DOUBLE_RIGHT_ARROW tactic PIPE LOOP LBRACKET VARNAME RBRACKET DOUBLE_RIGHT_ARROW tactic
       (Ast.$$ (O.POLY (O.DEV_S1_ELIM VARNAME1), [\ (([],[]), tactic1), \(([VARNAME2], []), tactic2)]))
 
+  | RULE_LEMMA term (Tac.makeLemma term)
   | LPAREN OPNAME customOpParams RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))
   | LPAREN OPNAME customOpParams bindings RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), bindings))
   | LPAREN operator bindings RPAREN (Ast.$$ (operator, bindings))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -35,7 +35,7 @@ struct
   fun orElse (t1, t2) =
     multitacToTac (O.MONO O.MTAC_ORELSE $$ [([],[]) \ tacToMulitac t1, ([],[]) \ tacToMulitac t2])
 
-  fun makeLemma tm = 
+  fun makeLemma tm =
     case Ast.out tm of
        O.POLY (O.CUST params) $ bindings => O.POLY (O.RULE_LEMMA params) $$ bindings
      | _ => raise Fail "Invalid 'rule' term"
@@ -281,7 +281,7 @@ terms
 
 
 tube
-  : LSQUARE equation RIGHT_ARROW binding RSQUARE (equation, binding)
+  : LSQUARE equation binding RSQUARE (equation, binding)
 
 tubes
   : tube ([tube])

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -85,6 +85,8 @@ end
  | FCOM | BOOL | TT | FF | IF | S_BOOL | S_IF | VOID | S1 | BASE | LOOP | FST | SND | PATHS | HCOM | COE
  | THEN | ELSE | LET | WITH | CASE | OF
 
+ | FUN_APP 
+
  | DIM | EXN | LBL | LVL | HYP
  | EXP | TAC | TRIV
 
@@ -101,6 +103,7 @@ end
 %right LEFT_ARROW RIGHT_ARROW DOUBLE_PIPE SEMI
 %right TIMES
 %nonassoc COMMA COLON
+%left FUN_APP
 %nonassoc AT_SIGN FCOM BOOL TT FF IF S_BOOL S_IF VOID S1 BASE LOOP LAMBDA ABS FST SND PATHS HCOM COE HASH LANGLE LPAREN VARNAME OPNAME
 
 
@@ -303,14 +306,12 @@ metavar
 dir
   : param SQUIGGLE_ARROW param ((param1, param2))
 
-term : atomicRawTerm (annotate (Pos.pos (atomicRawTerm1left fileName) (atomicRawTerm1right fileName)) atomicRawTerm)
+term : rawTerm %prec FUN_APP (annotate (Pos.pos (rawTerm1left fileName) (rawTerm1right fileName)) rawTerm)
 
 quantifierData
   : LSQUARE symbols term RSQUARE quantifierData (((symbols, term) :: #1 quantifierData), #2 quantifierData)
   | term quantifierData (((["_"], term) :: #1 quantifierData), #2 quantifierData)
   | term ([], term)
-
-
 
 binder
   : LBRACKET symbols RBRACKET LSQUARE symbols RSQUARE (symbols1, symbols2)
@@ -339,7 +340,6 @@ atomicRawTerm
 
   | LPAREN operator bindings RPAREN (Ast.$$ (operator, bindings))
 
-  (*| OPNAME customOpParams (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))*)
   | LPAREN OPNAME customOpParams RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))
   | LPAREN OPNAME customOpParams bindings RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), bindings)) 
 
@@ -362,6 +362,18 @@ atomicRawTerm
   | LPAREN AT_SIGN atomicTerm param RPAREN (Ast.$$ (O.POLY (O.PATH_AP param), [\ (([],[]), atomicTerm)]))
 
 atomicTerm : atomicRawTerm (annotate (Pos.pos (atomicRawTerm1left fileName) (atomicRawTerm1right fileName)) atomicRawTerm)
+
+rawFunApp
+  : LPAREN rawTerm atomicTerm RPAREN %prec FUN_APP (Ast.$$ (O.MONO O.AP, [\ (([],[]), (annotate (Pos.pos (rawTerm1left fileName) (rawTerm1right fileName)) rawTerm)), \ (([],[]), atomicTerm)]))
+  | atomicTerm %prec FUN_APP (atomicTerm)
+
+funApp : rawFunApp (annotate (Pos.pos (rawFunAppleft fileName) (rawFunAppright fileName)) rawFunApp)
+
+rawTerm
+  : funApp %prec FUN_APP (funApp)
+  | OPNAME customOpParams %prec FUN_APP (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))
+
+
 
 rawJudgment
   : term JDG_TRUE (Ast.$$ (O.MONO O.JDG_TRUE, [\ (([],[]), term)]))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -267,19 +267,6 @@ terms
   : term ([term])
   | term terms (term :: terms)
 
-binder
-  : LBRACKET symbols RBRACKET LSQUARE symbols RSQUARE (symbols1, symbols2)
-  | LBRACKET symbols RBRACKET (symbols, [])
-  | LSQUARE symbols RSQUARE ([], symbols)
-  | ([], [])
-
-binding
-  : binder term (\ (binder, term))
-
-bindings
-  : binding ([binding])
-  | binding bindings (binding :: bindings)
-  | ([])
 
 tube
   : LSQUARE equation RIGHT_ARROW binding RSQUARE (equation, binding)
@@ -287,7 +274,6 @@ tube
 tubes
   : tube ([tube])
   | tube tubes (tube :: tubes)
-  | ([])
 
 metavarArgs
   : LBRACKET params RBRACKET LSQUARE terms RSQUARE (params, terms)
@@ -295,11 +281,11 @@ metavarArgs
   | LSQUARE terms RSQUARE ([], terms)
   | ([], [])
 
+
 operator
   : LAMBDA (O.MONO O.LAM)
   | ABS (O.MONO O.PATH_ABS)
   | COE LBRACKET dir RBRACKET (O.POLY (O.COE dir))
-  | OPNAME customOpParams (O.POLY (O.CUST (OPNAME, customOpParams, NONE)))
   | RULE_LEMMA OPNAME customOpParams (O.POLY (O.RULE_LEMMA (OPNAME, customOpParams, NONE)))
   | IF (O.MONO O.IF)
   | S_IF (O.MONO O.S_IF)
@@ -325,19 +311,43 @@ quantifierData
   | term ([], term)
 
 
+
+binder
+  : LBRACKET symbols RBRACKET LSQUARE symbols RSQUARE (symbols1, symbols2)
+  | LBRACKET symbols RBRACKET (symbols, [])
+  | LSQUARE symbols RSQUARE ([], symbols)
+
+
+binding
+  : binder term (\ (binder, term))
+  | term (\ (([],[]), term))
+
+bindings
+  : binding bindings (binding :: bindings)
+  | binding ([binding])
+
 atomicRawTerm
-  : LPAREN term term RPAREN (Ast.$$ (O.MONO O.AP, [\ (([],[]),term1), \ (([],[]), term2)]))
-  | LPAREN operator bindings RPAREN (Ast.$$ (operator, bindings))
+  : VARNAME (`` VARNAME)
   | LPAREN FCOM LBRACKET dir RBRACKET binding tubes RPAREN
       (let val (eqs, tubes) = ListPair.unzip tubes in Ast.$$ (O.POLY (O.FCOM (dir, eqs)), (binding :: tubes)) end)
+  | LPAREN FCOM LBRACKET dir RBRACKET binding RPAREN
+      (Ast.$$ (O.POLY (O.FCOM (dir, [])), [binding]))
   | LPAREN HCOM LBRACKET dir RBRACKET binding binding tubes RPAREN
       (let val (eqs, tubes) = ListPair.unzip tubes in Ast.$$ (O.POLY (O.HCOM (dir, eqs)), (binding1 :: binding2 :: tubes)) end)
-  | OPNAME customOpParams (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))
+  | LPAREN HCOM LBRACKET dir RBRACKET binding binding RPAREN
+      (Ast.$$ (O.POLY (O.HCOM (dir, [])), [binding1, binding2]))
 
-  
+  | LPAREN operator bindings RPAREN (Ast.$$ (operator, bindings))
+
+  (*| OPNAME customOpParams (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))*)
+  | LPAREN OPNAME customOpParams RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))
+  | LPAREN OPNAME customOpParams bindings RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), bindings)) 
+
+  | LPAREN term term RPAREN (Ast.$$ (O.MONO O.AP, [\ (([],[]),term1), \ (([],[]), term2)]))
+
+
   | metavar metavarArgs (Ast.$$# (metavar, metavarArgs))
   | COMMA VARNAME (Ast.$$ (O.POLY (O.HYP_REF VARNAME), []))
-  | VARNAME (`` VARNAME)
   | LPAREN RIGHT_ARROW quantifierData RPAREN (Quant.makeDFun (#1 quantifierData) (#2 quantifierData))
   | LPAREN TIMES quantifierData RPAREN (Quant.makeDProd (#1 quantifierData) (#2 quantifierData))
   | LANGLE term COMMA term RANGLE (Ast.$$ (O.MONO O.PAIR, [\ (([],[]), term1), \ (([],[]), term2)]))
@@ -442,7 +452,9 @@ atomicRawTac
   | CASE VARNAME OF BASE DOUBLE_RIGHT_ARROW tactic PIPE LOOP LBRACKET VARNAME RBRACKET DOUBLE_RIGHT_ARROW tactic
       (Ast.$$ (O.POLY (O.DEV_S1_ELIM VARNAME1), [\ (([],[]), tactic1), \(([VARNAME2], []), tactic2)]))
 
-  | LPAREN operator bindings RPAREN (Ast.$$ (operator, bindings))
+  | LPAREN OPNAME customOpParams RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), []))
+  | LPAREN OPNAME customOpParams bindings RPAREN (Ast.$$ (O.POLY (O.CUST (OPNAME, customOpParams, NONE)), bindings)) 
+
   | operator (Ast.$$ (operator, []))
   | metavar metavarArgs (Ast.$$# (metavar, metavarArgs))
   | VARNAME (`` VARNAME)

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -141,4 +141,4 @@ whitespace = [\ \t];
 {lower}{identChr}* => (Tokens.VARNAME (posTupleWith (size yytext) yytext));
 {upper}{identChr}* => (Tokens.OPNAME (posTupleWith (size yytext) yytext));
 
-.                  => (RedPrlLog.print RedPrlLog.FAIL (SOME (Pos.pos (!pos yyarg) (!pos yyarg)), "lexical error: skipping unrecognized character '" ^ yytext ^ "'"); continue ());
+.                  => (RedPrlLog.print RedPrlLog.FAIL (SOME (Pos.pos (!pos yyarg) (!pos yyarg)), Fpp.text ("lexical error: skipping unrecognized character '" ^ yytext ^ "'")); continue ());

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -90,7 +90,7 @@ whitespace = [\ \t];
 "abs"              => (Tokens.ABS (posTuple (size yytext)));
 "fst"              => (Tokens.FST (posTuple (size yytext)));
 "snd"              => (Tokens.SND (posTuple (size yytext)));
-"paths"            => (Tokens.PATHS (posTuple (size yytext)));
+"path"            => (Tokens.PATHS (posTuple (size yytext)));
 "hcom"             => (Tokens.HCOM (posTuple (size yytext)));
 "coe"              => (Tokens.COE (posTuple (size yytext)));
 

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -87,6 +87,7 @@ whitespace = [\ \t];
 "base"             => (Tokens.BASE (posTuple (size yytext)));
 "loop"             => (Tokens.LOOP (posTuple (size yytext)));
 "lam"              => (Tokens.LAMBDA (posTuple (size yytext)));
+"abs"              => (Tokens.ABS (posTuple (size yytext)));
 "fst"              => (Tokens.FST (posTuple (size yytext)));
 "snd"              => (Tokens.SND (posTuple (size yytext)));
 "paths"            => (Tokens.PATHS (posTuple (size yytext)));

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -483,12 +483,12 @@ struct
        | UPDATE (x,_) => "UPDATE " ^ Sym.toString x
        | INSERT (x,_) => "INSERT " ^ Sym.toString x
 
-    fun applyDiffs alpha i xrho deltas H : catjdg Hyps.telescope = 
-      case deltas of 
+    fun applyDiffs alpha i xrho deltas H : catjdg Hyps.telescope =
+      case deltas of
          [] => H
        | DELETE x :: deltas => applyDiffs alpha i xrho deltas (Hyps.remove x H)
        | UPDATE (x, jdg) :: deltas => applyDiffs alpha i xrho deltas (Hyps.modify x (fn _ => jdg) H)
-       | INSERT (x, jdg) :: deltas => 
+       | INSERT (x, jdg) :: deltas =>
            let
              val x' = alpha i
              val jdg' = CJ.map (RedPrlAbt.renameVars xrho) jdg

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1577,7 +1577,7 @@ struct
               (case catjdg of
                   CJ.TRUE _ => StepTrue hyp z alpha jdg
                 | CJ.EQ _ => StepEq hyp z alpha jdg
-                | _ => raise E.error [E.% ("Could not find suitable elimination rule for " ^ (raise Fail "TODO!"))])
+                | _ => raise E.error [E.% ("Could not find suitable elimination rule [TODO, display information]")])
            | _ => raise E.error [E.% "Could not find suitable elimination rule"]
         end
     in

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1577,7 +1577,7 @@ struct
               (case catjdg of
                   CJ.TRUE _ => StepTrue hyp z alpha jdg
                 | CJ.EQ _ => StepEq hyp z alpha jdg
-                | _ => raise E.error [E.% ("Could not find suitable elimination rule for " ^ CJ.toString catjdg)])
+                | _ => raise E.error [E.% ("Could not find suitable elimination rule for " ^ (raise Fail "TODO!"))])
            | _ => raise E.error [E.% "Could not find suitable elimination rule"]
         end
     in

--- a/src/redprl/refiner.sig
+++ b/src/redprl/refiner.sig
@@ -10,17 +10,17 @@ sig
   type 'a bview
 
   val Lemma : sign -> opid -> param list -> abt bview list -> rule
-  
+
   val Cut : catjdg -> rule
   val Elim : sign -> hyp -> rule
-  val AutoStep : sign -> rule  
+  val AutoStep : sign -> rule
 
   structure Equality :
   sig
     val Symmetry : rule
   end
 
-  structure Computation : 
+  structure Computation :
   sig
     val Unfold : sign -> opid -> rule
     val EqHeadExpansion : sign -> rule
@@ -36,7 +36,7 @@ sig
     val Project : hyp -> rule
   end
 
-  structure Synth : 
+  structure Synth :
   sig
     val FromWfHyp : hyp -> rule
   end

--- a/src/redprl/refiner_composition_kit.fun
+++ b/src/redprl/refiner_composition_kit.fun
@@ -76,7 +76,7 @@ struct
             val tube1 = substSymbol (P.ret w, v) tube1
             val J = (I, H) >> CJ.EQ ((tube0, tube1), ty)
           in
-            Option.map 
+            Option.map
               (fn (I, J) >> jdg => #1 (makeGoal @@ (I @ [(w,P.DIM)], H) >> jdg))
               (Restriction.restrict J [eq0, eq1])
           end
@@ -166,10 +166,10 @@ struct
         val Syn.HCOM {dir=(r, r'), ty=ty0, cap, tubes} = Syn.out hcom
         val () = assertParamEq "HCom.CapEq source and target of direction" (r, r')
         val () = assertAlphaEq (ty0, ty)
-  
+
         val (goalTy, _) = makeGoal @@ (I, H) >> CJ.TYPE ty
         val (goalEq, _) = makeGoal @@ (I, H) >> CJ.EQ ((cap, other), ty)
-  
+
         val w = alpha 0
       in
         T.empty
@@ -189,11 +189,11 @@ struct
         val Syn.HCOM {dir=(r, r'), ty=ty0, cap, tubes} = Syn.out hcom
         val (eq, (u, tube)) = Option.valOf (List.find (fn (eq, _) => P.eq Sym.eq eq) tubes)
         val () = assertAlphaEq (ty0, ty)
-  
+
         val (goalTy, _) = makeGoal @@ (I, H) >> CJ.TYPE ty
         val (goalCap, _) = makeGoal @@ (I, H) >> CJ.MEM (cap, ty)
         val (goalEq, _) = makeGoal @@ (I, H) >> CJ.EQ ((substSymbol (r', u) tube, other), ty)
-  
+
         val w = alpha 0
       in
         T.empty

--- a/src/redprl/refiner_kit.fun
+++ b/src/redprl/refiner_kit.fun
@@ -66,7 +66,7 @@ struct
       open Abt infix 1 $#
       val x = newMeta ""
       val vl as (_, tau) = J.sort jdg
-      val (ps, ms) = 
+      val (ps, ms) =
         case jdg of
            (I, H) >> _ => (List.map (fn (u, sigma) => (P.VAR u, sigma)) I, hypsToSpine H)
          | MATCH _ => ([],[])

--- a/src/redprl/refiner_types.fun
+++ b/src/redprl/refiner_types.fun
@@ -208,9 +208,9 @@ struct
         raise E.error [E.% "Expected strict bool elimination problem"]
   end
 
-  structure Void = 
+  structure Void =
   struct
-    fun EqType _ jdg = 
+    fun EqType _ jdg =
       let
         val _ = RedPrlLog.trace "Void.EqType"
         val (I, H) >> CJ.EQ_TYPE (a, b) = jdg
@@ -229,8 +229,8 @@ struct
         val CJ.TRUE ty = lookupHyp H z
         val Syn.VOID = Syn.out ty
 
-        val evidence = 
-          case catjdg of 
+        val evidence =
+          case catjdg of
              CJ.TRUE _ => Syn.into Syn.TT
            | CJ.EQ _ => trivial
            | CJ.EQ_TYPE _ => trivial

--- a/src/redprl/sequent.sig
+++ b/src/redprl/sequent.sig
@@ -21,7 +21,7 @@ sig
 
   val map : ('a -> 'b) -> 'a jdg -> 'b jdg
 
-  val pretty : ('a -> string) -> 'a jdg -> FinalPrinter.doc
+  val pretty : ('a -> FinalPrinter.doc) -> 'a jdg -> FinalPrinter.doc
 
   val eq : CJ.Tm.abt jdg * CJ.Tm.abt jdg -> bool
 

--- a/src/redprl/sequent.sig
+++ b/src/redprl/sequent.sig
@@ -21,8 +21,7 @@ sig
 
   val map : ('a -> 'b) -> 'a jdg -> 'b jdg
 
-  val pretty : ('a -> string) -> 'a jdg -> PP.doc
-  val toString : ('a -> string) -> 'a jdg -> string
+  val pretty : ('a -> string) -> 'a jdg -> FinalPrinter.doc
 
   val eq : CJ.Tm.abt jdg * CJ.Tm.abt jdg -> bool
 

--- a/src/redprl/sequent.sig
+++ b/src/redprl/sequent.sig
@@ -21,7 +21,7 @@ sig
 
   val map : ('a -> 'b) -> 'a jdg -> 'b jdg
 
-  val pretty : ('a -> FinalPrinter.doc) -> 'a jdg -> FinalPrinter.doc
+  val pretty : ('a -> Fpp.doc) -> 'a jdg -> Fpp.doc
 
   val eq : CJ.Tm.abt jdg * CJ.Tm.abt jdg -> bool
 

--- a/src/redprl/sequent.sml
+++ b/src/redprl/sequent.sml
@@ -34,7 +34,7 @@ struct
 
 
   fun renameHypsInTerm srho =
-    Tm.substSymenv (Tm.Sym.Ctx.map Tm.O.P.VAR srho) 
+    Tm.substSymenv (Tm.Sym.Ctx.map Tm.O.P.VAR srho)
       o Tm.renameVars srho
 
   local
@@ -49,17 +49,17 @@ struct
              andalso telescopeEq (t1', t2')
        | _ => false
 
-    fun relabelHyps H srho = 
+    fun relabelHyps H srho =
       let
         val srho' = Tm.Sym.Ctx.map Tm.O.P.VAR srho
       in
-        case out H of 
+        case out H of
            EMPTY => Hyps.empty
-         | CONS (x, catjdg, Hx) => 
+         | CONS (x, catjdg, Hx) =>
            let
              val catjdg' = CJ.map (Tm.substSymenv srho') catjdg
            in
-             case Tm.Sym.Ctx.find srho x of 
+             case Tm.Sym.Ctx.find srho x of
                  NONE => Hyps.cons x catjdg' (relabelHyps Hx srho)
                | SOME y => Hyps.cons y catjdg' (relabelHyps Hx srho)
            end
@@ -67,16 +67,16 @@ struct
 
   end
 
-  fun relabel srho = 
-    fn (I, H) >> catjdg => 
-       (List.map (fn (u, sigma) => (Tm.Sym.Ctx.lookup srho u handle _ => u, sigma)) I, relabelHyps H srho) 
+  fun relabel srho =
+    fn (I, H) >> catjdg =>
+       (List.map (fn (u, sigma) => (Tm.Sym.Ctx.lookup srho u handle _ => u, sigma)) I, relabelHyps H srho)
          >> CJ.map (renameHypsInTerm srho) catjdg
      | jdg => map (renameHypsInTerm srho) jdg
 
   structure P = CJ.Tm.O.P and PS = CJ.Tm.O.Ar.Vl.PS
 
   fun prettySyms syms =
-    Fpp.collection 
+    Fpp.collection
       (Fpp.char #"{")
       (Fpp.char #"}")
       (Fpp.Atomic.comma)
@@ -85,7 +85,7 @@ struct
   fun prettyHyps f : 'a ctx -> Fpp.doc =
     Fpp.vsep o Hyps.foldr (fn (x, a, r) => Fpp.hsep [Fpp.text (Tm.Sym.toString x), Fpp.Atomic.colon, f a] :: r) []
 
-  fun pretty f : 'a jdg -> Fpp.doc = 
+  fun pretty f : 'a jdg -> Fpp.doc =
     fn (I, H) >> catjdg =>
        Fpp.seq
          [case I of [] => Fpp.empty | _ => Fpp.seq [prettySyms I, Fpp.newline],
@@ -98,8 +98,8 @@ struct
     fn (jdg1 as (I1, H1) >> catjdg1, jdg2 as (I2, H2) >> catjdg2) =>
        (let
 
-         fun unifyPsorts (sigma1, sigma2) = 
-           if PS.eq (sigma1, sigma2) then sigma1 else 
+         fun unifyPsorts (sigma1, sigma2) =
+           if PS.eq (sigma1, sigma2) then sigma1 else
              raise Fail "psort mismatch in Sequent.eq"
 
          val I = ListPair.mapEq (fn ((_, sigma1), (_, sigma2)) => (Sym.new (), unifyPsorts (sigma1, sigma2))) (I1, I2)

--- a/src/redprl/sequent.sml
+++ b/src/redprl/sequent.sml
@@ -86,7 +86,11 @@ struct
     Fpp.vsep o Hyps.foldr (fn (x, a, r) => Fpp.hsep [Fpp.text (Tm.Sym.toString x), Fpp.Atomic.colon, f a] :: r) []
 
   fun pretty f : 'a jdg -> FinalPrinter.doc = 
-    fn (I, H) >> catjdg => Fpp.vsep [prettySyms I, prettyHyps (CJ.pretty f) H, Fpp.hsep [Fpp.text "\226\138\162", CJ.pretty f catjdg]]
+    fn (I, H) >> catjdg =>
+       Fpp.seq
+         [case I of [] => Fpp.empty | _ => Fpp.seq [prettySyms I, Fpp.newline],
+          if Hyps.isEmpty H then Fpp.empty else Fpp.seq [prettyHyps (CJ.pretty f) H, Fpp.newline],
+          Fpp.hsep [Fpp.text "\226\138\162", CJ.pretty f catjdg]]
      | MATCH (th, k, a, _, _) => Fpp.hsep [f a, Fpp.text "match", Fpp.text (Tm.O.toString Tm.Sym.toString th), Fpp.text "@", Fpp.text (Int.toString k)]
 
 

--- a/src/redprl/sequent.sml
+++ b/src/redprl/sequent.sml
@@ -82,10 +82,10 @@ struct
       (Fpp.Atomic.comma)
       (List.map (fn (u, sigma) => Fpp.hsep [Fpp.text (Sym.toString u), Fpp.Atomic.colon, Fpp.text (Tm.O.Ar.Vl.PS.toString sigma)]) syms)
 
-  fun prettyHyps f : 'a ctx -> FinalPrinter.doc =
+  fun prettyHyps f : 'a ctx -> Fpp.doc =
     Fpp.vsep o Hyps.foldr (fn (x, a, r) => Fpp.hsep [Fpp.text (Tm.Sym.toString x), Fpp.Atomic.colon, f a] :: r) []
 
-  fun pretty f : 'a jdg -> FinalPrinter.doc = 
+  fun pretty f : 'a jdg -> Fpp.doc = 
     fn (I, H) >> catjdg =>
        Fpp.seq
          [case I of [] => Fpp.empty | _ => Fpp.seq [prettySyms I, Fpp.newline],

--- a/src/redprl/sequent.sml
+++ b/src/redprl/sequent.sml
@@ -75,30 +75,19 @@ struct
 
   structure P = CJ.Tm.O.P and PS = CJ.Tm.O.Ar.Vl.PS
 
+  fun prettySyms syms =
+    Fpp.collection 
+      (Fpp.char #"{")
+      (Fpp.char #"}")
+      (Fpp.Atomic.comma)
+      (List.map (fn (u, sigma) => Fpp.hsep [Fpp.text (Sym.toString u), Fpp.Atomic.colon, Fpp.text (Tm.O.Ar.Vl.PS.toString sigma)]) syms)
 
+  fun prettyHyps f : 'a ctx -> FinalPrinter.doc =
+    Fpp.vsep o Hyps.foldr (fn (x, a, r) => Fpp.hsep [Fpp.text (Tm.Sym.toString x), Fpp.Atomic.colon, f a] :: r) []
 
-  (*local
-    open PP
-  in
-    fun prettySyms' [] = concat []
-      | prettySyms' [(u, sigma)] = concat [text (Tm.Sym.toString u), text " : ", text (Tm.O.Ar.Vl.PS.toString sigma)]
-      | prettySyms' ((u, sigma) :: syms) = concat [text (Tm.Sym.toString u), text " : ", text (Tm.O.Ar.Vl.PS.toString sigma), text " , ", prettySyms' syms]
-
-    fun prettySyms [] = concat []
-      | prettySyms syms = concat [text "{", prettySyms' syms, text "}.", line]
-
-    fun prettyHyps f : 'a ctx -> doc =
-      Hyps.foldl
-        (fn (x, a, r) => concat [r, text (Tm.Sym.toString x), text " : ", f a, line])
-        empty
-
-    fun pretty f : 'a jdg -> doc =
-      fn (I, H) >> catjdg => concat [prettySyms I, prettyHyps (CJ.pretty f) H, text "\226\138\162 ", CJ.pretty f catjdg]
-       | MATCH (th, k, a, _, _) => concat [text (f a), text " match ", text (Tm.O.toString Tm.Sym.toString th), text " @ ", int k]
-  end*)
-
-  fun pretty f = raise Fail "TODO!"
-  fun toString f = raise Fail "TODO!"
+  fun pretty f : 'a jdg -> FinalPrinter.doc = 
+    fn (I, H) >> catjdg => Fpp.vsep [prettySyms I, prettyHyps (CJ.pretty f) H, Fpp.hsep [Fpp.text "\226\138\162", CJ.pretty f catjdg]]
+     | MATCH (th, k, a, _, _) => Fpp.hsep [f a, Fpp.text "match", Fpp.text (Tm.O.toString Tm.Sym.toString th), Fpp.text "@", Fpp.text (Int.toString k)]
 
 
   val rec eq =

--- a/src/redprl/sequent.sml
+++ b/src/redprl/sequent.sml
@@ -77,7 +77,7 @@ struct
 
 
 
-  local
+  (*local
     open PP
   in
     fun prettySyms' [] = concat []
@@ -95,9 +95,10 @@ struct
     fun pretty f : 'a jdg -> doc =
       fn (I, H) >> catjdg => concat [prettySyms I, prettyHyps (CJ.pretty f) H, text "\226\138\162 ", CJ.pretty f catjdg]
        | MATCH (th, k, a, _, _) => concat [text (f a), text " match ", text (Tm.O.toString Tm.Sym.toString th), text " @ ", int k]
-  end
+  end*)
 
-  fun toString f = PP.toString 80 true o pretty f
+  fun pretty f = raise Fail "TODO!"
+  fun toString f = raise Fail "TODO!"
 
 
   val rec eq =

--- a/src/redprl/sequent.sml
+++ b/src/redprl/sequent.sml
@@ -90,7 +90,7 @@ struct
        Fpp.seq
          [case I of [] => Fpp.empty | _ => Fpp.seq [prettySyms I, Fpp.newline],
           if Hyps.isEmpty H then Fpp.empty else Fpp.seq [prettyHyps (CJ.pretty f) H, Fpp.newline],
-          Fpp.hsep [Fpp.text "\226\138\162", CJ.pretty f catjdg]]
+          Fpp.hsep [Fpp.text "!-", CJ.pretty f catjdg]]
      | MATCH (th, k, a, _, _) => Fpp.hsep [f a, Fpp.text "match", Fpp.text (Tm.O.toString Tm.Sym.toString th), Fpp.text "@", Fpp.text (Int.toString k)]
 
 

--- a/src/redprl/sequent.sml
+++ b/src/redprl/sequent.sml
@@ -90,7 +90,7 @@ struct
        Fpp.seq
          [case I of [] => Fpp.empty | _ => Fpp.seq [prettySyms I, Fpp.newline],
           if Hyps.isEmpty H then Fpp.empty else Fpp.seq [prettyHyps (CJ.pretty f) H, Fpp.newline],
-          Fpp.hsep [Fpp.text "!-", CJ.pretty f catjdg]]
+          Fpp.hsep [Fpp.text ">>", CJ.pretty f catjdg]]
      | MATCH (th, k, a, _, _) => Fpp.hsep [f a, Fpp.text "match", Fpp.text (Tm.O.toString Tm.Sym.toString th), Fpp.text "@", Fpp.text (Int.toString k)]
 
 

--- a/src/redprl/signature.sig
+++ b/src/redprl/signature.sig
@@ -62,5 +62,4 @@ sig
   val command : sign -> src_opid cmd * Pos.t -> sign
 
   val check : sign -> bool
-  val toString : sign -> string
 end

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -19,12 +19,12 @@ struct
       (Fpp.Atomic.comma)
       (List.map (fn (u, sigma) => Fpp.hsep [Fpp.text (Sym.toString u), Fpp.Atomic.colon, Fpp.text (Ar.Vl.PS.toString sigma)]) ps)
 
-  fun prettyArgs ps = 
+  fun prettyArgs args = 
     Fpp.collection
       (Fpp.char #"(")
       (Fpp.char #")")
       (Fpp.char #";")
-      (List.map (fn (x, vl) => Fpp.hsep [Fpp.text (Metavar.toString x), Fpp.Atomic.colon, Fpp.text (Ar.Vl.toString vl)]) ps) (* TODO: prettyValence *)
+      (List.map (fn (x, vl) => Fpp.hsep [Fpp.text (Metavar.toString x), Fpp.Atomic.colon, TermPrinter.ppValence vl]) args)
 
   fun prettyEntry (sign : sign) (opid : symbol, {sourceOpid, params, arguments, sort, spec, state} : entry) : FinalPrinter.doc =
     Fpp.seq

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -30,19 +30,18 @@ struct
         List.map (fn (x, vl) => Fpp.hsep [Fpp.text (Metavar.toString x), Fpp.Atomic.colon, TermPrinter.ppValence vl]) args
 
   fun prettyEntry (sign : sign) (opid : symbol, {sourceOpid, params, arguments, sort, spec, state} : entry) : FinalPrinter.doc =
-    Fpp.seq
+    Fpp.hsep
       [Fpp.text "Def",
-        Fpp.space 1,
         Fpp.text @@ Sym.toString opid,
-        prettyParams params,
-        prettyArgs arguments,
-        Fpp.space 1,
+        Fpp.seq [prettyParams params, prettyArgs arguments],
         Fpp.Atomic.colon,
-        Fpp.space 1,
-        Fpp.text (RedPrlSort.toString sort),
-        Fpp.space 1,
+        case spec of
+           NONE => Fpp.text (RedPrlSort.toString sort)
+         | SOME jdg =>
+             Fpp.grouped @@ Fpp.Atomic.squares @@ Fpp.seq
+               [Fpp.nest 2 @@ Fpp.seq [Fpp.newline, RedPrlSequent.pretty TermPrinter.ppTerm jdg],
+               Fpp.newline],
         Fpp.Atomic.equals,
-        Fpp.space 1,
         Fpp.grouped @@ Fpp.Atomic.squares @@ Fpp.seq
           [Fpp.nest 2 @@ Fpp.seq [Fpp.newline, TermPrinter.ppTerm @@ extract state],
           Fpp.newline],
@@ -458,7 +457,6 @@ struct
         E.hush (ETelescope.lookup (#elabSign sign) eopid) >>= (fn edecl =>
           E.ret (ECMD (PRINT eopid)) <*
             (case edecl of
-            (* TODO fix *)
                 EDEF entry => E.info (SOME pos, Fpp.vsep [Fpp.text "Elaborated:", prettyEntry sign (eopid, entry)])
               | _ => E.warn (SOME pos, Fpp.text "Invalid declaration name"))))
 

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -12,21 +12,21 @@ struct
   open MiniSig
   structure O = RedPrlOpData and E = ElabMonadUtil (ElabMonad)
 
-  fun intersperse s xs = 
-    case xs of 
+  fun intersperse s xs =
+    case xs of
        [] => []
      | [x] => [x]
      | x::xs => Fpp.seq [x, s] :: intersperse s xs
 
   fun prettyParams ps =
     Fpp.Atomic.braces @@ Fpp.grouped @@ Fpp.hvsep @@
-      intersperse Fpp.Atomic.comma @@ 
+      intersperse Fpp.Atomic.comma @@
         List.map (fn (u, sigma) => Fpp.hsep [Fpp.text (Sym.toString u), Fpp.Atomic.colon, Fpp.text (Ar.Vl.PS.toString sigma)]) ps
 
 
   fun prettyArgs args =
     Fpp.Atomic.parens @@ Fpp.grouped @@ Fpp.hvsep @@
-      intersperse (Fpp.text ";") @@ 
+      intersperse (Fpp.text ";") @@
         List.map (fn (x, vl) => Fpp.hsep [Fpp.text (Metavar.toString x), Fpp.Atomic.colon, TermPrinter.ppValence vl]) args
 
   fun prettyEntry (sign : sign) (opid : symbol, {sourceOpid, params, arguments, sort, spec, state} : entry) : Fpp.doc =
@@ -84,8 +84,8 @@ struct
       infix $ $$ $# $$# \
 
 
-      fun inheritAnnotation t1 t2 = 
-        case getAnnotation t2 of 
+      fun inheritAnnotation t1 t2 =
+        case getAnnotation t2 of
           NONE => setAnnotation (getAnnotation t1) t2
         | _ => t2
 
@@ -120,16 +120,16 @@ struct
       and processTerm sign m =
         inheritAnnotation m (processTerm' sign m)
 
-      fun processSrcCatjdg sign = 
+      fun processSrcCatjdg sign =
         RedPrlCategoricalJudgment.map (processTerm sign)
 
-      fun processSrcSeq sign (hyps, concl) = 
+      fun processSrcSeq sign (hyps, concl) =
         (List.map (fn (x, hyp) => (x, processSrcCatjdg sign hyp)) hyps, processSrcCatjdg sign concl)
 
-      fun processSrcGenJdg sign (bs, seq) = 
+      fun processSrcGenJdg sign (bs, seq) =
         (bs, processSrcSeq sign seq)
 
-      fun processSrcRuleSpec sign (premises, goal) = 
+      fun processSrcRuleSpec sign (premises, goal) =
         (List.map (processSrcGenJdg sign) premises, processSrcSeq sign goal)
 
     in
@@ -236,17 +236,17 @@ struct
     structure CJ = RedPrlCategoricalJudgment and Sort = RedPrlOpData and Hyps = RedPrlSequent.Hyps
 
     fun elabAst (metactx, env) ast : abt =
-      let 
+      let
         val abt = AstToAbt.convertOpen (metactx, metactxToNameEnv metactx) (env, env) (ast, Sort.EXP)
-      in 
+      in
         abt
       end
 
-    fun elabSrcCatjdg (metactx, symctx, varctx, env) : src_catjdg -> abt CJ.jdg = 
+    fun elabSrcCatjdg (metactx, symctx, varctx, env) : src_catjdg -> abt CJ.jdg =
       CJ.map (elabAst (metactx, env))
       (* TODO check scoping *)
 
-    fun addHypName (env, symctx, varctx) (srcname, tau) = 
+    fun addHypName (env, symctx, varctx) (srcname, tau) =
       let
         val x = NameEnv.lookup env srcname handle _ => Sym.named srcname
         val env' = NameEnv.insert env srcname x
@@ -256,7 +256,7 @@ struct
         (env', symctx', varctx', x)
       end
 
-    fun addSymName (env, symctx) (srcname, psort) = 
+    fun addSymName (env, symctx) (srcname, psort) =
       let
         val u = Sym.named srcname
         val env' = NameEnv.insert env srcname u
@@ -265,7 +265,7 @@ struct
         (env', symctx')
       end
 
-    fun addVarName (env, varctx) (srcname, sort) = 
+    fun addVarName (env, varctx) (srcname, sort) =
       let
         val x = Var.named srcname
         val env' = NameEnv.insert env srcname x
@@ -274,8 +274,8 @@ struct
         (env', varctx')
       end
 
- 
-    fun elabSrcSeqHyp (metactx, symctx, varctx, env) (srcname, srcjdg) : Tm.symctx * Tm.varctx * symbol NameEnv.dict * symbol * abt CJ.jdg = 
+
+    fun elabSrcSeqHyp (metactx, symctx, varctx, env) (srcname, srcjdg) : Tm.symctx * Tm.varctx * symbol NameEnv.dict * symbol * abt CJ.jdg =
       let
         val catjdg = elabSrcCatjdg (metactx, symctx, varctx, env) srcjdg
         val tau = CJ.synthesis catjdg
@@ -287,7 +287,7 @@ struct
     fun elabSrcSeqHyps (metactx, symctx, varctx, env) : src_seqhyp list -> symbol NameEnv.dict * abt CJ.jdg Hyps.telescope =
       let
         fun go env syms vars H [] = (env, H)
-          | go env syms vars H (hyp :: hyps) = 
+          | go env syms vars H (hyp :: hyps) =
               let
                 val (syms', vars', env', x, jdg) = elabSrcSeqHyp (metactx, syms, vars, env) hyp
               in
@@ -297,7 +297,7 @@ struct
         go env symctx varctx Hyps.empty
       end
 
-    fun elabSrcSequent (metactx, symctx, varctx, env) (seq : src_sequent) : symbol NameEnv.dict * jdg = 
+    fun elabSrcSequent (metactx, symctx, varctx, env) (seq : src_sequent) : symbol NameEnv.dict * jdg =
       let
         val (hyps, concl) = seq
         val (env', hyps') = elabSrcSeqHyps (metactx, symctx, varctx, env) hyps
@@ -306,7 +306,7 @@ struct
         (env', RedPrlSequent.>> (([], hyps'), concl')) (* todo: I := ? *)
       end
 
-    fun elabSrcGenJdg (metactx, symctx, env) (syms, seq) : symbol NameEnv.dict * jdg Lcf.eff = 
+    fun elabSrcGenJdg (metactx, symctx, env) (syms, seq) : symbol NameEnv.dict * jdg Lcf.eff =
       let
         val (env', symctx') = List.foldl (fn (sym, (env, symctx)) => addSymName (env, symctx) sym) (env, symctx) syms
 
@@ -318,7 +318,7 @@ struct
         (env'''', seq')
       end
 
-    fun elabSrcRuleSpec (metactx, symctx, env) (spec : src_rulespec) = 
+    fun elabSrcRuleSpec (metactx, symctx, env) (spec : src_rulespec) =
       let
         val (subgoals, goal) = spec
         val (env', subgoals') = List.foldr (fn (subgoal, (env, subgoals)) => let val (env', subgoal') = elabSrcGenJdg (metactx, symctx, env) subgoal in (env', subgoal' :: subgoals) end) (env, []) subgoals
@@ -328,7 +328,7 @@ struct
       end
 
     fun convertToAbt (metactx, symctx, env) ast sort =
-      E.wrap (RedPrlAst.getAnnotation ast, fn () => 
+      E.wrap (RedPrlAst.getAnnotation ast, fn () =>
         AstToAbt.convertOpen (metactx, metactxToNameEnv metactx) (env, NameEnv.empty) (ast, sort)
         handle AstToAbt.BadConversion (msg, pos) => error pos [Err.% msg])
       >>= scopeCheck (metactx, symctx, Var.Ctx.empty)
@@ -366,24 +366,24 @@ struct
 
       structure Tl = TelescopeUtil (Lcf.Tl)
 
-      fun checkProofState (pos, subgoalsSpec) state = 
+      fun checkProofState (pos, subgoalsSpec) state =
         let
           val Lcf.|> (subgoals, _) = state
-          fun goalEqualTo goal1 goal2 = 
+          fun goalEqualTo goal1 goal2 =
             if RedPrlSequent.eq (goal1, goal2) then true
             else
               (RedPrlLog.print RedPrlLog.WARN (pos, Fpp.hvsep [RedPrlSequent.pretty TermPrinter.ppTerm goal1, Fpp.text "not equal to", RedPrlSequent.pretty TermPrinter.ppTerm goal2]);
                false)
 
           fun go ([], Tl.ConsView.EMPTY) = true
-            | go (jdgSpec :: subgoalsSpec, Tl.ConsView.CONS (_, jdgReal, subgoalsReal)) = 
+            | go (jdgSpec :: subgoalsSpec, Tl.ConsView.CONS (_, jdgReal, subgoalsReal)) =
                 goalEqualTo jdgSpec jdgReal andalso go (subgoalsSpec, Tl.ConsView.out subgoalsReal)
             | go _ = false
 
           val proofStateCorrect = go (subgoalsSpec, Tl.ConsView.out subgoals)
           val subgoalsCount = Tl.foldr (fn (_,_,n) => 1 + n) 0 subgoals
         in
-          if proofStateCorrect then 
+          if proofStateCorrect then
             E.ret state
           else
             E.warn (pos, Fpp.text (Int.toString (subgoalsCount) ^ " Remaining Obligations"))
@@ -399,27 +399,27 @@ struct
             let
               (* TODO: deal with syms ?? *)
               val tau = CJ.synthesis concl
-              val (params'', symctx', env') = 
+              val (params'', symctx', env') =
                 Hyps.foldr
-                  (fn (x, jdg, (ps, ctx, env)) => 
-                    ((x, RedPrlSortData.HYP tau) :: ps, Tm.Sym.Ctx.insert ctx x (RedPrlSortData.HYP tau), NameEnv.insert env (Sym.toString x) x)) 
+                  (fn (x, jdg, (ps, ctx, env)) =>
+                    ((x, RedPrlSortData.HYP tau) :: ps, Tm.Sym.Ctx.insert ctx x (RedPrlSortData.HYP tau), NameEnv.insert env (Sym.toString x) x))
                   (params', symctx, env)
                   hyps
             in
-              convertToAbt (metactx, symctx', env') script TAC 
+              convertToAbt (metactx, symctx', env') script TAC
                 >>= (fn scriptTm => elabRefine sign (seqjdg, scriptTm))
                 >>= checkProofState (pos, subgoalsSpec)
                 >>= (fn state => E.ret @@ EDEF {sourceOpid = opid, params = params'', arguments = arguments', sort = tau, spec = SOME seqjdg, state = state})
             end)
         end
 
-      fun thmToRule {arguments, params, goal, script} = 
+      fun thmToRule {arguments, params, goal, script} =
         {arguments = arguments,
          params = params,
          spec = ([], goal),
          script = script}
 
-      fun elabThm sign opid pos thm = 
+      fun elabThm sign opid pos thm =
         elabDerivedRule sign opid pos (thmToRule thm)
     end
 
@@ -463,14 +463,14 @@ struct
       open RedPrlAbt infix $ \
       structure O = RedPrlOpData
 
-      fun printExtractOf (pos, state) : unit E.t = 
+      fun printExtractOf (pos, state) : unit E.t =
         E.info (SOME pos, Fpp.vsep [Fpp.text "Extract:", TermPrinter.ppTerm (extract state)])
     in
-      fun elabExtract (sign : sign) (pos, opid) = 
-        E.wrap (SOME pos, fn _ => NameEnv.lookup (#nameEnv sign) opid) >>= (fn eopid => 
-          E.hush (ETelescope.lookup (#elabSign sign) eopid) >>= (fn edecl => 
+      fun elabExtract (sign : sign) (pos, opid) =
+        E.wrap (SOME pos, fn _ => NameEnv.lookup (#nameEnv sign) opid) >>= (fn eopid =>
+          E.hush (ETelescope.lookup (#elabSign sign) eopid) >>= (fn edecl =>
             E.ret (ECMD (EXTRACT eopid)) <*
-              (case edecl of 
+              (case edecl of
                   EDEF entry => printExtractOf (pos, #state entry)
                 | _ => E.warn (SOME pos, Fpp.text "Invalid declaration name"))))
     end
@@ -483,7 +483,7 @@ struct
            in
              ETelescope.snoc (#elabSign sign) fresh (E.delay (fn _ => elabPrint sign (pos, opid)))
            end
-       | EXTRACT opid => 
+       | EXTRACT opid =>
            let
              val fresh = Sym.named "_"
            in

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -29,7 +29,7 @@ struct
       intersperse (Fpp.text ";") @@ 
         List.map (fn (x, vl) => Fpp.hsep [Fpp.text (Metavar.toString x), Fpp.Atomic.colon, TermPrinter.ppValence vl]) args
 
-  fun prettyEntry (sign : sign) (opid : symbol, {sourceOpid, params, arguments, sort, spec, state} : entry) : FinalPrinter.doc =
+  fun prettyEntry (sign : sign) (opid : symbol, {sourceOpid, params, arguments, sort, spec, state} : entry) : Fpp.doc =
     Fpp.hsep
       [Fpp.text "Def",
         Fpp.text @@ Sym.toString opid,

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -12,6 +12,15 @@ struct
   open MiniSig
   structure O = RedPrlOpData and E = ElabMonadUtil (ElabMonad)
 
+  fun printDecl (opid : string, decl) : FinalPrinter.doc =
+    case decl of 
+       DEF {arguments, params, sort, definiens} => Fpp.text "TODO"
+     | THM {arguments, params, goal, script} => Fpp.text "TODO"
+     | RULE {arguments, params, spec, script} => Fpp.text "TODO"
+     | TAC {arguments, params, script} => Fpp.text "TODO"
+
+  fun printEntry _ _ : FinalPrinter.doc = Fpp.text "TODO"
+
   (*local
     fun argsToString f =
       ListSpine.pretty (fn (x, vl) => "#" ^ f x ^ " : " ^ RedPrlArity.Vl.toString vl) ", "
@@ -110,10 +119,6 @@ struct
       end
   end
   *)
-
-  fun toString _ = raise Fail "TODO"
-  fun declToString _ = raise Fail "TODO"
-  fun entryToString _ = raise Fail "TODO!"
 
   val empty =
     {sourceSign = Telescope.empty,
@@ -511,7 +516,7 @@ struct
       let
         val esign' = ETelescope.truncateFrom (#elabSign sign) eopid
         val sign' = {sourceSign = #sourceSign sign, elabSign = esign', nameEnv = #nameEnv sign}
-        fun decorate e = e >>= (fn x => E.dump (pos, declToString (opid, decl)) *> E.ret x)
+        fun decorate e = e >>= (fn x => E.dump (pos, printDecl (opid, decl)) *> E.ret x)
       in
         ETelescope.snoc esign' eopid (decorate (E.delay (fn _ =>
           case processDecl sign decl of
@@ -527,7 +532,7 @@ struct
           E.ret (ECMD (PRINT eopid)) <*
             (case edecl of
             (* TODO fix *)
-                EDEF entry => E.info (SOME pos, Fpp.text ("Elaborated:\n" ^ entryToString sign (eopid, entry)))
+                EDEF entry => E.info (SOME pos, Fpp.vsep [Fpp.text "Elaborated:", printEntry sign (eopid, entry)])
               | _ => E.warn (SOME pos, Fpp.text "Invalid declaration name"))))
 
     local

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -32,8 +32,7 @@ struct
   fun prettyEntry (sign : sign) (opid : symbol, {sourceOpid, params, arguments, sort, spec, state} : entry) : Fpp.doc =
     Fpp.hsep
       [Fpp.text "Def",
-        Fpp.text @@ Sym.toString opid,
-        Fpp.seq [prettyParams params, prettyArgs arguments],
+        Fpp.seq [Fpp.text @@ Sym.toString opid, prettyParams params, prettyArgs arguments],
         Fpp.Atomic.colon,
         case spec of
            NONE => Fpp.text (RedPrlSort.toString sort)

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -6,16 +6,13 @@ struct
   structure ElabNotation = MonadNotation (E)
   open ElabNotation infix >>= *> <*
 
-
   fun @@ (f, x) = f x
   infixr @@
 
   open MiniSig
   structure O = RedPrlOpData and E = ElabMonadUtil (ElabMonad)
 
-  local
-    open PP
-
+  (*local
     fun argsToString f =
       ListSpine.pretty (fn (x, vl) => "#" ^ f x ^ " : " ^ RedPrlArity.Vl.toString vl) ", "
       
@@ -101,6 +98,7 @@ struct
     fun entryToString (sign : sign) =
       PP.toString 80 false o prettyEntry sign
 
+
     fun toString ({sourceSign,...} : sign) =
       let
         open Telescope.ConsView
@@ -111,6 +109,11 @@ struct
         go (out sourceSign)
       end
   end
+  *)
+
+  fun toString _ = raise Fail "TODO"
+  fun declToString _ = raise Fail "TODO"
+  fun entryToString _ = raise Fail "TODO!"
 
   val empty =
     {sourceSign = Telescope.empty,

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -371,8 +371,7 @@ struct
           fun goalEqualTo goal1 goal2 = 
             if RedPrlSequent.eq (goal1, goal2) then true
             else
-              (* TODO: fix *)
-              (RedPrlLog.print RedPrlLog.WARN (pos, Fpp.text (RedPrlJudgment.toString goal1 ^ " not equal to " ^ RedPrlJudgment.toString goal2));
+              (RedPrlLog.print RedPrlLog.WARN (pos, Fpp.hvsep [RedPrlSequent.pretty TermPrinter.ppTerm goal1, Fpp.text "not equal to", RedPrlSequent.pretty TermPrinter.ppTerm goal2]);
                false)
 
           fun go ([], Tl.ConsView.EMPTY) = true

--- a/src/redprl/signature_mini.sml
+++ b/src/redprl/signature_mini.sml
@@ -1,4 +1,4 @@
-structure MiniSig = 
+structure MiniSig =
 struct
   structure Tm = RedPrlAbt
 
@@ -83,17 +83,17 @@ struct
     end
 
 
-  local 
+  local
     open RedPrlOpData Tm RedPrlSequent
     infix $ \ >>
 
     (* Observe that hypotheses have a dual nature: they are both symbols and variables. When reviving a proof state,
       we have to rename hypotheses in *both* their moments. This routine constructs the appropriate substitution
       for hypotheses qua variables. *)
-    fun hypothesisRenaming (entry : entry) (ps : Tm.param list) : Tm.varenv = 
+    fun hypothesisRenaming (entry : entry) (ps : Tm.param list) : Tm.varenv =
       let
-        fun handleHyp ((u, psort), ptm, ctx) = 
-          case psort of 
+        fun handleHyp ((u, psort), ptm, ctx) =
+          case psort of
             RedPrlSortData.HYP tau =>
               let
                 val v = case ptm of RedPrlParameterTerm.VAR v => v
@@ -114,7 +114,7 @@ struct
         Hyps.remove u H'
       end
 
-    fun relabelHyps (entry : entry) (ps : Tm.param list) H = 
+    fun relabelHyps (entry : entry) (ps : Tm.param list) H =
       let
         fun handleHyp ((u, psort), ptm, H) =
           case psort of
@@ -134,7 +134,7 @@ struct
       fn (I, H) >> catjdg => (I, relabelHyps entry ps H) >> catjdg
       | jdg => jdg
   in
-    fun resuscitateTheorem sign opid ps args = 
+    fun resuscitateTheorem sign opid ps args =
       let
         val entry = lookup sign opid
         val paramsSig = #params entry
@@ -158,7 +158,7 @@ struct
       end
 
       fun extract (Lcf.|> (subgoals, validation)) =
-        case outb validation of 
+        case outb validation of
            _ \ term => term
     end
 end

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -125,7 +125,7 @@ Def Cmp(#f; #g) = [
   (lam [x] (#f (#g x)))
 ].
 
-Thm StrictBoolTest : [ (SNot) = (Cmp (SNot) (Cmp (SNot) (SNot))) in (-> sbool sbool) ] by [
+Thm StrictBoolTest : [ SNot = (Cmp SNot (Cmp SNot SNot)) in (-> sbool sbool) ] by [
   auto
 ].
 
@@ -160,8 +160,8 @@ Tac FunExtTac(#A; #B; #F; #G) = [
 
 // We ought to be able to use FunExt as a lemma, but our machinery is not yet set up for that.
 // Instead, we can use FunExtTac.
-Thm NotNotPath : [(paths {_} (-> bool bool) (Cmp (Not) (Not)) (lam [x] x))] by [
-  (FunExtTac bool bool (Cmp (Not) (Not)) (lam [x] x));
+Thm NotNotPath : [(paths {_} (-> bool bool) (Cmp Not Not) (lam [x] x))] by [
+  (FunExtTac bool bool (Cmp Not Not) (lam [x] x));
 
   {lam x. if x then <i> 'tt else <i> 'ff};
   auto

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -1,13 +1,21 @@
-Thm BoolTest : [ bool -> bool ] by [
+Thm BoolTest : [ 
+  (-> bool bool)
+] by [
   { lam x. if x then 'tt else 'ff };
   auto
 ].
 
-Thm PathTest : [ paths({_}. S1; base; base) ] by [
+Thm PathTest : [
+  (paths {_} S1 base base)
+] by [
   { <x> 'loop{x} }; auto
 ].
 
-Thm LowLevel : [ (bool -> bool) -> bool ] by [
+Thm LowLevel : [
+  (->
+    (-> bool bool)
+    bool)
+] by [
   fresh f <- auto;
   fresh x, x/eq <- elim f;
   [ 'tt, hyp x];
@@ -16,13 +24,17 @@ Thm LowLevel : [ (bool -> bool) -> bool ] by [
 
 Extract LowLevel.
 
-Thm FunElimTest : [ (bool -> bool) -> bool ] by [
+Thm FunElimTest : [
+  (->
+    (-> bool bool)
+    bool)
+] by [
   { lam f. let x = f {'tt}. hyp x };
 
   auto
 ].
 
-Thm S1ElimTest : [ S1 -> S1 ] by [
+Thm S1ElimTest : [ (-> S1 S1) ] by [
   { lam s.
     case s of
        base => 'base
@@ -38,11 +50,12 @@ Tac Try(#t : tac) = [
 
 // Useful for stepping through a proof RedPRL completes automatically, to see
 // what is being done.
-Tac TryStep = [ Try(%{auto-step}) ].
+Tac TryStep = [ (Try %{auto-step}) ].
 
 Thm ApEqTest : [
-  (f : bool -> bool)
-    -> paths({_}. bool; f tt; f tt)
+  (-> 
+   [f (-> bool bool)]
+   (paths {_} bool (f tt) (f tt)))
 ] by [
   { lam f. <_> '(,f tt) };
 
@@ -51,7 +64,7 @@ Thm ApEqTest : [
 ].
 
 Def BoolEta(#M) = [
-  if([a].bool; #M; tt; ff)
+  (if [a] bool #M tt ff)
 ].
 
 // Let's prove the existence of a path between the identity function on booleans, and the
@@ -61,10 +74,15 @@ Def BoolEta(#M) = [
 // calculus. The advantage of this style of proof is that we can leave holes, and interactively figure out
 // what we need to do.
 //
-Thm PathTest2 : [ paths({_}. bool -> bool; lam([b].b); lam([b].BoolEta(b))) ] by [
-  { let h : [(b:bool) -> paths({_}.bool; b; BoolEta(b))] =
+Thm PathTest2 : [
+  (paths 
+    {_} (-> bool bool)
+    (lam [b] b)
+    (lam [b] (BoolEta b)))
+] by [
+  { let h : [(-> [b bool] (paths {_} bool b (BoolEta b))) ] =
       lam b. if b then <y> 'tt else <y> 'ff.
-    <x> lam c. let p = h {hyp c}. '(,p @ x)
+    <x> lam c. let p = h {hyp c}. '(@ ,p x)
   };
 
   auto
@@ -75,13 +93,23 @@ Thm PathTest2 : [ paths({_}. bool -> bool; lam([b].b); lam([b].BoolEta(b))) ] by
 // This approach has the advantage of being far more concise, but it has the disadvantage of
 // not being interactive: you must know ahead of time the entirety of the program, and
 // cannot take advantage of types in order to synthesize part of it.
-Thm PathTest3 : [ paths({_}. bool -> bool; lam([b].b); lam([b].BoolEta(b))) ] by [
+Thm PathTest3 : [
+  (paths 
+    {_} (-> bool bool)
+    (lam [b] b)
+    (lam [b] (BoolEta b)))
+] by [
   // I'm surprised that RedPRL can typecheck this properly! Quite encouraging.
-  '(<x> lam([b]. if([b].paths({_}.bool; b; BoolEta(b)); b; <_> tt; <_> ff) @ x));
+  '(abs {x} 
+    (lam [b]
+     (@ (if [b] (paths {_} bool b (BoolEta b)) b (abs {_} tt) (abs {_} ff))
+        x)));
   auto
 ].
 
-Thm PairTest : [ (a : S1) * paths({_}. S1; a; base) ] by [
+Print PathTest3.
+
+Thm PairTest : [ (* [a S1] (paths {_} S1 a base)) ] by [
   < {'base}
   , <x> 'loop{x}
   >;
@@ -90,18 +118,18 @@ Thm PairTest : [ (a : S1) * paths({_}. S1; a; base) ] by [
 
 
 Def SNot = [
-  lam([x]. if/s(x; ff; tt))
+  (lam [x] (if/s x ff tt))
 ].
 
 Def Cmp(#f; #g) = [
-  lam([x]. #f (#g x))
+  (lam [x] (#f (#g x)))
 ].
 
-Thm StrictBoolTest : [ SNot = Cmp(SNot; Cmp(SNot; SNot)) in sbool -> sbool ] by [
+Thm StrictBoolTest : [ SNot = (Cmp SNot (Cmp SNot SNot)) in (-> sbool sbool) ] by [
   auto
 ].
 
-Thm Not : [bool -> bool] by [
+Thm Not : [(-> [_ bool] bool)] by [
   {lam x. if x then 'ff else 'tt};
   auto
 ].
@@ -109,13 +137,13 @@ Thm Not : [bool -> bool] by [
 Thm FunExt(#A; #B) : [
   type/A : #A type,
   type/B : #B type
-  >> (f : #A -> #B)
-  -> (g : #A -> #B)
-  -> (p : (y : #A) -> paths({_}. #B; f y; g y))
-  -> paths({_}. #A -> #B; f; g)
+  >> (-> [f (-> #A #B)]
+         [g (-> #A #B)]
+         [p (-> [y #A] (paths {_} #B (f y) (g y)))]
+         (paths {_} (-> #A #B) f g))
 ] by [
   {lam f. lam g. lam p.
-    <i> lam a. let q = p hyp a. '(,q @i)};
+    <i> lam a. let q = p hyp a. '(@ ,q i)};
   auto
 ].
 
@@ -124,15 +152,15 @@ Print FunExt.
 
 
 Tac FunExtTac(#A; #B; #F; #G) = [
-  let p : [(x:#A) -> paths({_}.bool; #F x; #G x)] = {}.
-  {<i> lam a. let q = p hyp a. '(,q @i)};
+  let p : [(-> [x #A] (paths {_} bool (#F x) (#G x)))] = {}.
+  {<i> lam a. let q = p hyp a. '(@ ,q i)};
   auto
 ].
 
 // We ought to be able to use FunExt as a lemma, but our machinery is not yet set up for that.
 // Instead, we can use FunExtTac.
-Thm NotNotPath : [paths({_}.bool -> bool; Cmp(Not;Not); lam([x].x))] by [
-  FunExtTac(bool; bool; Cmp(Not; Not); lam([x].x));
+Thm NotNotPath : [(paths {_} (-> bool bool) (Cmp Not Not) (lam [x] x))] by [
+  (FunExtTac bool bool (Cmp Not Not) (lam [x] x));
 
   {lam x. if x then <i> 'tt else <i> 'ff};
   auto
@@ -141,7 +169,7 @@ Thm NotNotPath : [paths({_}.bool -> bool; Cmp(Not;Not); lam([x].x))] by [
 Extract NotNotPath.
 Print FunExtTac.
 
-Thm Singleton : [(x : bool) * paths({_}.bool; x; tt)] by [
+Thm Singleton : [(* [x bool] (paths {_} bool x tt))] by [
   < 'tt, <x> 'tt >;
   auto
 ].

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -152,7 +152,6 @@ Thm FunExt(#A; #B) : [
 Print FunExt.
 
 
-
 Tac FunExtTac(#A; #B; #F; #G) = [
   let p : [(-> [x #A] (paths {_} bool (#F x) (#G x)))] = {}.
   {<i> lam a. let q = p hyp a. '(@ ,q i)};

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -6,7 +6,7 @@ Thm BoolTest : [
 ].
 
 Thm PathTest : [
-  (paths {_} S1 base base)
+  (path {_} S1 base base)
 ] by [
   { <x> '(loop x) }; auto
 ].
@@ -55,7 +55,7 @@ Tac TryStep = [ auto-step || id ].
 Thm ApEqTest : [
   (-> 
    [f (-> bool bool)]
-   (paths {_} bool (f tt) (f tt)))
+   (path {_} bool (f tt) (f tt)))
 ] by [
   { lam f. <_> '(,f tt) };
 
@@ -75,12 +75,12 @@ Def BoolEta(#M) = [
 // what we need to do.
 //
 Thm PathTest2 : [
-  (paths 
+  (path 
     {_} (-> bool bool)
     (lam [b] b)
     (lam [b] (BoolEta b)))
 ] by [
-  { let h : [(-> [b bool] (paths {_} bool b (BoolEta b))) ] =
+  { let h : [(-> [b bool] (path {_} bool b (BoolEta b))) ] =
       lam b. if b then <y> 'tt else <y> 'ff.
     <x> lam c. let p = h {hyp c}. '(@ ,p x)
   };
@@ -94,7 +94,7 @@ Thm PathTest2 : [
 // not being interactive: you must know ahead of time the entirety of the program, and
 // cannot take advantage of types in order to synthesize part of it.
 Thm PathTest3 : [
-  (paths 
+  (path 
     {_} (-> bool bool)
     (lam [b] b)
     (lam [b] (BoolEta b)))
@@ -102,14 +102,14 @@ Thm PathTest3 : [
   // I'm surprised that RedPRL can typecheck this properly! Quite encouraging.
   '(abs {x} 
     (lam [b]
-     (@ (if [b] (paths {_} bool b (BoolEta b)) b (abs {_} tt) (abs {_} ff))
+     (@ (if [b] (path {_} bool b (BoolEta b)) b (abs {_} tt) (abs {_} ff))
         x)));
   auto
 ].
 
 Print PathTest3.
 
-Thm PairTest : [ (* [a S1] (paths {_} S1 a base)) ] by [
+Thm PairTest : [ (* [a S1] (path {_} S1 a base)) ] by [
   < {'base}
   , <x> '(loop x)
   >;
@@ -152,8 +152,8 @@ Thm FunExt(#A; #B) : [
   (->
    [f (-> #A #B)]
    [g (-> #A #B)]
-   [p (-> [y #A] (paths {_} #B (f y) (g y)))]
-   (paths {_} (-> #A #B) f g))
+   [p (-> [y #A] (path {_} #B (f y) (g y)))]
+   (path {_} (-> #A #B) f g))
 ] by [
   {lam f. lam g. lam p.
     <i> lam a. let q = p hyp a. '(@ ,q i)};
@@ -164,14 +164,14 @@ Print FunExt.
 
 
 Tac FunExtTac(#A; #B; #F; #G) = [
-  let p : [(-> [x #A] (paths {_} bool (#F x) (#G x)))] = {}.
+  let p : [(-> [x #A] (path {_} bool (#F x) (#G x)))] = {}.
   {<i> lam a. let q = p hyp a. '(@ ,q i)};
   auto
 ].
 
 // We ought to be able to use FunExt as a lemma, but our machinery is not yet set up for that.
 // Instead, we can use FunExtTac.
-Thm NotNotPath : [(paths {_} (-> bool bool) (Cmp Not Not) (lam [x] x))] by [
+Thm NotNotPath : [(path {_} (-> bool bool) (Cmp Not Not) (lam [x] x))] by [
   (FunExtTac bool bool (Cmp Not Not) (lam [x] x));
 
   {lam x. if x then <i> 'tt else <i> 'ff};
@@ -181,7 +181,7 @@ Thm NotNotPath : [(paths {_} (-> bool bool) (Cmp Not Not) (lam [x] x))] by [
 Extract NotNotPath.
 Print FunExtTac.
 
-Thm Singleton : [(* [x bool] (paths {_} bool x tt))] by [
+Thm Singleton : [(* [x bool] (path {_} bool x tt))] by [
   < 'tt, <x> 'tt >;
   auto
 ].

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -125,7 +125,7 @@ Def Cmp(#f; #g) = [
   (lam [x] (#f (#g x)))
 ].
 
-Thm StrictBoolTest : [ SNot = (Cmp SNot (Cmp SNot SNot)) in (-> sbool sbool) ] by [
+Thm StrictBoolTest : [ (SNot) = (Cmp (SNot) (Cmp (SNot) (SNot))) in (-> sbool sbool) ] by [
   auto
 ].
 
@@ -160,8 +160,8 @@ Tac FunExtTac(#A; #B; #F; #G) = [
 
 // We ought to be able to use FunExt as a lemma, but our machinery is not yet set up for that.
 // Instead, we can use FunExtTac.
-Thm NotNotPath : [(paths {_} (-> bool bool) (Cmp Not Not) (lam [x] x))] by [
-  (FunExtTac bool bool (Cmp Not Not) (lam [x] x));
+Thm NotNotPath : [(paths {_} (-> bool bool) (Cmp (Not) (Not)) (lam [x] x))] by [
+  (FunExtTac bool bool (Cmp (Not) (Not)) (lam [x] x));
 
   {lam x. if x then <i> 'tt else <i> 'ff};
   auto

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -119,6 +119,9 @@ Thm FunExt(#A; #B) : [
   auto
 ].
 
+Print FunExt.
+
+
 
 Tac FunExtTac(#A; #B; #F; #G) = [
   let p : [(x:#A) -> paths({_}.bool; #F x; #G x)] = {}.
@@ -136,7 +139,7 @@ Thm NotNotPath : [paths({_}.bool -> bool; Cmp(Not;Not); lam([x].x))] by [
 ].
 
 Extract NotNotPath.
-
+Print FunExtTac.
 
 Thm Singleton : [(x : bool) * paths({_}.bool; x; tt)] by [
   < 'tt, <x> 'tt >;

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -137,10 +137,12 @@ Thm Not : [(-> [_ bool] bool)] by [
 Thm FunExt(#A; #B) : [
   type/A : #A type,
   type/B : #B type
-  >> (-> [f (-> #A #B)]
-         [g (-> #A #B)]
-         [p (-> [y #A] (paths {_} #B (f y) (g y)))]
-         (paths {_} (-> #A #B) f g))
+  >>
+  (->
+   [f (-> #A #B)]
+   [g (-> #A #B)]
+   [p (-> [y #A] (paths {_} #B (f y) (g y)))]
+   (paths {_} (-> #A #B) f g))
 ] by [
   {lam f. lam g. lam p.
     <i> lam a. let q = p hyp a. '(@ ,q i)};

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -8,7 +8,7 @@ Thm BoolTest : [
 Thm PathTest : [
   (paths {_} S1 base base)
 ] by [
-  { <x> 'loop{x} }; auto
+  { <x> '(loop x) }; auto
 ].
 
 Thm LowLevel : [
@@ -38,7 +38,7 @@ Thm S1ElimTest : [ (-> S1 S1) ] by [
   { lam s.
     case s of
        base => 'base
-     | loop{x} => 'loop{x}
+     | loop x => '(loop x)
   };
 
   auto
@@ -111,7 +111,7 @@ Print PathTest3.
 
 Thm PairTest : [ (* [a S1] (paths {_} S1 a base)) ] by [
   < {'base}
-  , <x> 'loop{x}
+  , <x> '(loop x)
   >;
   auto
 ].
@@ -124,6 +124,17 @@ Def SNot = [
 Def Cmp(#f; #g) = [
   (lam [x] (#f (#g x)))
 ].
+
+
+Def MyLoop{x:dim}(#m) = [
+  <#m, (loop x)>
+].
+
+Def Test = [
+  ({MyLoop 0} (loop 1))
+].
+
+Print Test.
 
 Thm StrictBoolTest : [ SNot = (Cmp SNot (Cmp SNot SNot)) in (-> sbool sbool) ] by [
   auto

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -50,7 +50,7 @@ Tac Try(#t : tac) = [
 
 // Useful for stepping through a proof RedPRL completes automatically, to see
 // what is being done.
-Tac TryStep = [ (Try %{auto-step}) ].
+Tac TryStep = [ auto-step || id ].
 
 Thm ApEqTest : [
   (-> 

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -1,14 +1,14 @@
 Thm BoolTest : [ 
   (-> bool bool)
 ] by [
-  { lam x. if x then 'tt else 'ff };
+  { lam x. if x then `tt else `ff };
   auto
 ].
 
 Thm PathTest : [
   (path {_} S1 base base)
 ] by [
-  { <x> '(loop x) }; auto
+  { <x> `(loop x) }; auto
 ].
 
 Thm LowLevel : [
@@ -18,7 +18,7 @@ Thm LowLevel : [
 ] by [
   fresh f <- auto;
   fresh x, x/eq <- elim f;
-  [ 'tt, hyp x];
+  [ `tt, hyp x];
   auto
 ].
 
@@ -29,7 +29,7 @@ Thm FunElimTest : [
     (-> bool bool)
     bool)
 ] by [
-  { lam f. let x = f {'tt}. hyp x };
+  { lam f. let x = f {`tt}. hyp x };
 
   auto
 ].
@@ -37,8 +37,8 @@ Thm FunElimTest : [
 Thm S1ElimTest : [ (-> S1 S1) ] by [
   { lam s.
     case s of
-       base => 'base
-     | loop x => '(loop x)
+       base => `base
+     | loop x => `(loop x)
   };
 
   auto
@@ -57,7 +57,7 @@ Thm ApEqTest : [
    [f (-> bool bool)]
    (path {_} bool (f tt) (f tt)))
 ] by [
-  { lam f. <_> '(,f tt) };
+  { lam f. <_> `(,f tt) };
 
   // Try commenting out the following line, and stepping through the proof with TryStep.
   auto
@@ -81,8 +81,8 @@ Thm PathTest2 : [
     (lam [b] (BoolEta b)))
 ] by [
   { let h : [(-> [b bool] (path {_} bool b (BoolEta b))) ] =
-      lam b. if b then <y> 'tt else <y> 'ff.
-    <x> lam c. let p = h {hyp c}. '(@ ,p x)
+      lam b. if b then <y> `tt else <y> `ff.
+    <x> lam c. let p = h {hyp c}. `(@ ,p x)
   };
 
   auto
@@ -100,7 +100,7 @@ Thm PathTest3 : [
     (lam [b] (BoolEta b)))
 ] by [
   // I'm surprised that RedPRL can typecheck this properly! Quite encouraging.
-  '(abs {x} 
+  `(abs {x} 
     (lam [b]
      (@ (if [b] (path {_} bool b (BoolEta b)) b (abs {_} tt) (abs {_} ff))
         x)));
@@ -110,8 +110,8 @@ Thm PathTest3 : [
 Print PathTest3.
 
 Thm PairTest : [ (* [a S1] (path {_} S1 a base)) ] by [
-  < {'base}
-  , <x> '(loop x)
+  < `base
+  , <x> `(loop x)
   >;
   auto
 ].
@@ -141,7 +141,7 @@ Thm StrictBoolTest : [ SNot = (Cmp SNot (Cmp SNot SNot)) in (-> sbool sbool) ] b
 ].
 
 Thm Not : [(-> [_ bool] bool)] by [
-  {lam x. if x then 'ff else 'tt};
+  {lam x. if x then `ff else `tt};
   auto
 ].
 
@@ -156,7 +156,7 @@ Thm FunExt(#A; #B) : [
    (path {_} (-> #A #B) f g))
 ] by [
   {lam f. lam g. lam p.
-    <i> lam a. let q = p hyp a. '(@ ,q i)};
+    <i> lam a. let q = p hyp a. `(@ ,q i)};
   auto
 ].
 
@@ -165,7 +165,7 @@ Print FunExt.
 
 Tac FunExtTac(#A; #B; #F; #G) = [
   let p : [(-> [x #A] (path {_} bool (#F x) (#G x)))] = {}.
-  {<i> lam a. let q = p hyp a. '(@ ,q i)};
+  {<i> lam a. let q = p hyp a. `(@ ,q i)};
   auto
 ].
 
@@ -174,7 +174,7 @@ Tac FunExtTac(#A; #B; #F; #G) = [
 Thm NotNotPath : [(path {_} (-> bool bool) (Cmp Not Not) (lam [x] x))] by [
   (FunExtTac bool bool (Cmp Not Not) (lam [x] x));
 
-  {lam x. if x then <i> 'tt else <i> 'ff};
+  {lam x. if x then <i> `tt else <i> `ff};
   auto
 ].
 
@@ -182,6 +182,6 @@ Extract NotNotPath.
 Print FunExtTac.
 
 Thm Singleton : [(* [x bool] (path {_} bool x tt))] by [
-  < 'tt, <x> 'tt >;
+  < `tt, <x> `tt >;
   auto
 ].

--- a/test/failure/bad-hcom-empty.prl
+++ b/test/failure/bad-hcom-empty.prl
@@ -1,6 +1,6 @@
 Thm Bool : [
   bool true
 ] by [
-  {'(hcom{0 ~> 1} bool tt)};
+  {`(hcom{0 ~> 1} bool tt)};
   auto
 ].

--- a/test/failure/bad-hcom-empty.prl
+++ b/test/failure/bad-hcom-empty.prl
@@ -1,6 +1,6 @@
 Thm Bool : [
   bool true
 ] by [
-  {'hcom{; 0 ~> 1}(bool; tt)};
-  auto;
+  {'(hcom{0 ~> 1} bool tt)};
+  auto
 ].

--- a/test/failure/bad-hcom-step.prl
+++ b/test/failure/bad-hcom-step.prl
@@ -5,6 +5,6 @@ Thm BoolSym : [
    (path {_} bool b a))
 ] by [
   { lam a. lam b. lam p. <i> 
-     '(hcom{0 ~> 1} bool ,a [i=0 {j} (@ ,p j)] [i=1 {_} ,a])};
+     `(hcom{0 ~> 1} bool ,a [i=0 {j} (@ ,p j)] [i=1 {_} ,a])};
   [auto-step; head-expand]
 ].

--- a/test/failure/bad-hcom-step.prl
+++ b/test/failure/bad-hcom-step.prl
@@ -1,10 +1,10 @@
 Thm BoolSym : [
   (-> 
    [a b bool]
-   (paths {_} bool a b)
-   (paths {_} bool b a))
+   (path {_} bool a b)
+   (path {_} bool b a))
 ] by [
   { lam a. lam b. lam p. <i> 
-     '(hcom{0 ~> 1} bool ,a [i=0 -> {j} (@ ,p j)] [i=1 -> {_} ,a])};
+     '(hcom{0 ~> 1} bool ,a [i=0 {j} (@ ,p j)] [i=1 {_} ,a])};
   [auto-step; head-expand]
 ].

--- a/test/failure/bad-hcom-step.prl
+++ b/test/failure/bad-hcom-step.prl
@@ -1,8 +1,10 @@
 Thm BoolSym : [
-  (a : bool) -> (b : bool) ->
-  paths({_}.bool; a; b) ->
-  paths({_}.bool; b; a) true
+  (-> 
+   [a b bool]
+   (paths {_} bool a b)
+   (paths {_} bool b a))
 ] by [
-  { lam a. lam b. lam p. <i> 'hcom{i=0, i=1; 0 ~> 1}(bool; ,a; {j}. ,p @ j; {_}. ,a)};
+  { lam a. lam b. lam p. <i> 
+     '(hcom{0 ~> 1} bool ,a [i=0 -> {j} (@ ,p j)] [i=1 -> {_} ,a])};
   [auto-step; head-expand]
 ].

--- a/test/failure/bad-hcom-stuck.prl
+++ b/test/failure/bad-hcom-stuck.prl
@@ -1,6 +1,6 @@
 Thm Bool : [
   bool true
 ] by [
-  {'hcom{0=1; 0 ~> 1}(bool; tt; {_}.tt)};
+  {'(hcom{0 ~> 1} bool tt [0=1 -> {_} tt])};
   auto
 ].

--- a/test/failure/bad-hcom-stuck.prl
+++ b/test/failure/bad-hcom-stuck.prl
@@ -1,6 +1,6 @@
 Thm Bool : [
   bool true
 ] by [
-  {'(hcom{0 ~> 1} bool tt [0=1 -> {_} tt])};
+  {'(hcom{0 ~> 1} bool tt [0=1 {_} tt])};
   auto
 ].

--- a/test/failure/bad-hcom-stuck.prl
+++ b/test/failure/bad-hcom-stuck.prl
@@ -1,6 +1,6 @@
 Thm Bool : [
   bool true
 ] by [
-  {'(hcom{0 ~> 1} bool tt [0=1 {_} tt])};
+  {`(hcom{0 ~> 1} bool tt [0=1 {_} tt])};
   auto
 ].

--- a/test/failure/bad-op.prl
+++ b/test/failure/bad-op.prl
@@ -1,4 +1,4 @@
-Def Foo(#a : exp; #b : exp) : exp = [ (x : #a) -> #b ].
+Def Foo(#a : exp; #b : exp) : exp = [ (-> #a #b) ].
 
-Thm Foo-bool-type : [Foo(bool) type] by [
+Thm Foo-bool-type : [(Foo bool) type] by [
 ].

--- a/test/failure/freemeta.prl
+++ b/test/failure/freemeta.prl
@@ -1,3 +1,3 @@
 Def Cmp(#f : exp; #g : exp) : exp = [
-  lam([x]. #f (#h x))
+  (lam [x] (#f (#h x)))
 ].

--- a/test/failure/lexical-error.prl
+++ b/test/failure/lexical-error.prl
@@ -1,3 +1,3 @@
-Thm BoolTest : [ (_ : bool) -> bool true ] by [
+Thm BoolTest : [ (-> bool bool) true ] by [
   { lam _. '_tt }; auto
 ].

--- a/test/failure/lexical-error.prl
+++ b/test/failure/lexical-error.prl
@@ -1,3 +1,3 @@
 Thm BoolTest : [ (-> bool bool) true ] by [
-  { lam _. '_tt }; auto
+  { lam _. `_tt }; auto
 ].

--- a/test/failure/undef-custom.prl
+++ b/test/failure/undef-custom.prl
@@ -1,5 +1,5 @@
 Def Not : exp = [
-  lam([x]. if/s(x; ff; tt))
+  (lam [x] (if/s x ff tt))
 ].
 
 // An [Output] message should display for not(), even though the

--- a/test/success/bool-fhcom-without-open-eval.prl
+++ b/test/success/bool-fhcom-without-open-eval.prl
@@ -7,7 +7,7 @@ Thm FHcom/trans3 : [
 ] by [
   { <a> lam b. lam c. lam d.
     lam pab. lam pac. lam pbd.
-    <i> '(fcom{0~>1} (@ ,pab i) [i=0 {j} (@ ,pac j)] [i=1 {j} (@ ,pbd j)])
+    <i> `(fcom{0~>1} (@ ,pab i) [i=0 {j} (@ ,pac j)] [i=1 {j} (@ ,pbd j)])
   };
   auto
 ].
@@ -21,7 +21,7 @@ Thm FHcom/trans2 : [
    (path {_} bool a c))
 ] by [
   { lam a. lam b. lam c. lam pab. lam pbc.
-    <i> '(fcom{0~>1} (@ ,pab i) [i=0 {_} ,a] [i=1 {j} (@ ,pbc j)])
+    <i> `(fcom{0~>1} (@ ,pab i) [i=0 {_} ,a] [i=1 {j} (@ ,pbc j)])
   };
   auto
 ].
@@ -32,7 +32,7 @@ Thm FHcom/symm : [
    (path {_} bool b a))
 ] by [
   { lam a. lam b. lam pab.
-    <i> '(fcom{0~>1} ,a [i=0 {j} (@,pab j)] [i=1 {_} ,a])
+    <i> `(fcom{0~>1} ,a [i=0 {j} (@,pab j)] [i=1 {_} ,a])
   };
   auto
 ].

--- a/test/success/bool-fhcom-without-open-eval.prl
+++ b/test/success/bool-fhcom-without-open-eval.prl
@@ -1,55 +1,49 @@
 Thm FHcom/trans3 : [
-     (a : bool)
-  -> (b : bool)
-  -> (c : bool) 
-  -> (d : bool) 
-  -> paths({_}.bool; a; b)
-  -> paths({_}.bool; a; c)
-  -> paths({_}.bool; b; d) 
-  -> paths({_}.bool; c; d)
+  (-> [a bool] [b bool] [c bool] [d bool]
+   (paths {_} bool a b)
+   (paths {_} bool a c)
+   (paths {_} bool b d)
+   (paths {_} bool c d))
 ] by [
   { <a> lam b. lam c. lam d.
     lam pab. lam pac. lam pbd.
-    <i> 'fcom{0~>1}(,pab @ i) [i=0 -> {j}. ,pac @ j; i=1 -> {j}. ,pbd @ j]
+    <i> '(fcom{0~>1} (@ ,pab i) [i=0 -> {j} (@ ,pac j)] [i=1 -> {j} (@ ,pbd j)])
   };
   auto
 ].
 
 Thm FHcom/trans2 : [
-     (a : bool)
-  -> (b : bool)
-  -> (c : bool)
-  -> paths({_}.bool; a; b)
-  -> paths({_}.bool; b; c)
-  -> paths({_}.bool; a; c)
+  (-> [a bool] [b bool] [c bool]
+   (paths {_} bool a b)
+   (paths {_} bool b c)
+   (paths {_} bool a c))
 ] by [
   { lam a. lam b. lam c. lam pab. lam pbc.
-    <i> 'fcom{0~>1}(,pab @ i) [i=0 -> {_}. ,a; i=1 -> {j}. ,pbc @ j]
+    <i> '(fcom{0~>1} (@ ,pab i) [i=0 -> {_} ,a] [i=1 -> {j} (@ ,pbc j)])
   };
   auto
 ].
 
 Thm FHcom/symm : [
-     (a : bool)
-  -> (b : bool)
-  -> paths({_}.bool; a; b)
-  -> paths({_}.bool; b; a)
+  (-> [a bool] [b bool]
+   (paths {_} bool a b)
+   (paths {_} bool b a))
 ] by [
   { lam a. lam b. lam pab.
-    <i> 'fcom{0~>1}(,a) [i=0 -> {j}. ,pab @ j; i=1 -> {_}. ,a]
+    <i> '(fcom{0~>1} ,a [i=0 -> {j} (@,pab j)] [i=1 -> {_} ,a])
   };
   auto
 ].
 
 Thm Tube : [
   x : bool
-  >> fcom{0~>1}(x) [1=1 -> {_}.x; 0=0 -> {_}. x] = x in bool
+  >> (fcom{0~>1} x [1=1 -> {_} x] [0=0 -> {_} x]) = x in bool
 ] by [
   auto
 ].
 
 Thm TrueByEvaluation : [
-  fcom{0 ~> 0}(tt) [] in bool
+  (fcom{0 ~> 0} tt) in bool
 ] by [
   auto
 ].

--- a/test/success/bool-fhcom-without-open-eval.prl
+++ b/test/success/bool-fhcom-without-open-eval.prl
@@ -12,6 +12,8 @@ Thm FHcom/trans3 : [
   auto
 ].
 
+Print FHcom/trans3.
+
 Thm FHcom/trans2 : [
   (-> [a b c bool]
    (paths {_} bool a b)

--- a/test/success/bool-fhcom-without-open-eval.prl
+++ b/test/success/bool-fhcom-without-open-eval.prl
@@ -1,13 +1,13 @@
 Thm FHcom/trans3 : [
   (-> [a b c d bool]
-   (paths {_} bool a b)
-   (paths {_} bool a c)
-   (paths {_} bool b d)
-   (paths {_} bool c d))
+   (path {_} bool a b)
+   (path {_} bool a c)
+   (path {_} bool b d)
+   (path {_} bool c d))
 ] by [
   { <a> lam b. lam c. lam d.
     lam pab. lam pac. lam pbd.
-    <i> '(fcom{0~>1} (@ ,pab i) [i=0 -> {j} (@ ,pac j)] [i=1 -> {j} (@ ,pbd j)])
+    <i> '(fcom{0~>1} (@ ,pab i) [i=0 {j} (@ ,pac j)] [i=1 {j} (@ ,pbd j)])
   };
   auto
 ].
@@ -16,30 +16,30 @@ Print FHcom/trans3.
 
 Thm FHcom/trans2 : [
   (-> [a b c bool]
-   (paths {_} bool a b)
-   (paths {_} bool b c)
-   (paths {_} bool a c))
+   (path {_} bool a b)
+   (path {_} bool b c)
+   (path {_} bool a c))
 ] by [
   { lam a. lam b. lam c. lam pab. lam pbc.
-    <i> '(fcom{0~>1} (@ ,pab i) [i=0 -> {_} ,a] [i=1 -> {j} (@ ,pbc j)])
+    <i> '(fcom{0~>1} (@ ,pab i) [i=0 {_} ,a] [i=1 {j} (@ ,pbc j)])
   };
   auto
 ].
 
 Thm FHcom/symm : [
   (-> [a b bool]
-   (paths {_} bool a b)
-   (paths {_} bool b a))
+   (path {_} bool a b)
+   (path {_} bool b a))
 ] by [
   { lam a. lam b. lam pab.
-    <i> '(fcom{0~>1} ,a [i=0 -> {j} (@,pab j)] [i=1 -> {_} ,a])
+    <i> '(fcom{0~>1} ,a [i=0 {j} (@,pab j)] [i=1 {_} ,a])
   };
   auto
 ].
 
 Thm Tube : [
   x : bool
-  >> (fcom{0~>1} x [1=1 -> {_} x] [0=0 -> {_} x]) = x in bool
+  >> (fcom{0~>1} x [1=1 {_} x] [0=0 {_} x]) = x in bool
 ] by [
   auto
 ].

--- a/test/success/bool-fhcom-without-open-eval.prl
+++ b/test/success/bool-fhcom-without-open-eval.prl
@@ -1,5 +1,5 @@
 Thm FHcom/trans3 : [
-  (-> [a bool] [b bool] [c bool] [d bool]
+  (-> [a b c d bool]
    (paths {_} bool a b)
    (paths {_} bool a c)
    (paths {_} bool b d)
@@ -13,7 +13,7 @@ Thm FHcom/trans3 : [
 ].
 
 Thm FHcom/trans2 : [
-  (-> [a bool] [b bool] [c bool]
+  (-> [a b c bool]
    (paths {_} bool a b)
    (paths {_} bool b c)
    (paths {_} bool a c))
@@ -25,7 +25,7 @@ Thm FHcom/trans2 : [
 ].
 
 Thm FHcom/symm : [
-  (-> [a bool] [b bool]
+  (-> [a b bool]
    (paths {_} bool a b)
    (paths {_} bool b a))
 ] by [

--- a/test/success/bool-pair-test.prl
+++ b/test/success/bool-pair-test.prl
@@ -1,4 +1,4 @@
-Thm Test : [ bool * bool = bool * bool type ] by [
+Thm Test : [ (* bool bool) = (* bool bool) type ] by [
   auto
 ].
 

--- a/test/success/coe.prl
+++ b/test/success/coe.prl
@@ -17,3 +17,6 @@ Rule CoeTestCap{r:dim}(#A : {dim}.exp) : [
 ] by [
   auto
 ].
+
+
+Extract CoeTestCap.

--- a/test/success/coe.prl
+++ b/test/success/coe.prl
@@ -4,7 +4,7 @@ Rule CoeTest{r:dim, r':dim}(#A : {dim}.exp) : [
   m : #A{r} >> #A{r'} = #A{r'} type;
   {x:dim} | m : #A{r} >> #A{x} = #A{x} type
   ==>
-  m : #A{r} >> coe{r ~> r'}({x}.#A{x}; m) in #A{r'}
+  m : #A{r} >> (coe{r ~> r'} {x} #A{x} m) in #A{r'}
 ] by [
   auto
 ].
@@ -13,7 +13,7 @@ Rule CoeTestCap{r:dim}(#A : {dim}.exp) : [
   m : #A{r} >> #A{r} = #A{r} type;
   {x:dim} | m : #A{r} >> #A{x} = #A{x} type
   ==>
-  m : #A{r} >> coe{r ~> r}({x}.#A{x}; m) = m in #A{r}
+  m : #A{r} >> (coe{r ~> r} {x} #A{x} m) = m in #A{r}
 ] by [
   auto
 ].

--- a/test/success/conflict.prl
+++ b/test/success/conflict.prl
@@ -2,5 +2,5 @@
 // string parses as `all(id)`. For example `[]` could mean each() or
 // each(all(id)). The current parser arbitrarily chooses the latter.
 Thm Square-bracket : [ (-> (-> bool bool) bool) ] by [
-  {lam f. 'tt}; []; auto
+  {lam f. `tt}; []; auto
 ].

--- a/test/success/conflict.prl
+++ b/test/success/conflict.prl
@@ -1,12 +1,6 @@
-// The term syntax `f(foo)` is ambiguous: is it a custom operator f, or is
-// it a variable f with foo surrounded by parens.
-Thm Custom-op-versus-parens : [ (f : (x : bool) -> bool) -> bool ] by [
-  'lam([f]. f (f tt)); auto
-].
-
 // The tactic syntax is ambiguous in several places because the empty
 // string parses as `all(id)`. For example `[]` could mean each() or
 // each(all(id)). The current parser arbitrarily chooses the latter.
-Thm Square-bracket : [ (f : (x : bool) -> bool) -> bool ] by [
+Thm Square-bracket : [ (-> (-> bool bool) bool) ] by [
   {lam f. 'tt}; []; auto
 ].

--- a/test/success/connection.prl
+++ b/test/success/connection.prl
@@ -2,23 +2,34 @@ Thm Connection(#A) : [
   a/type : #A type >>
   (->
    [a b #A]
-   [p (paths {_} #A a b)]
-   (paths {i} (paths {_} #A a (@ p i)) (abs {_} a) p))
+   [p (path {_} #A a b)]
+   (path {i} (path {_} #A a (@ p i)) (abs {_} a) p))
 ] by [
-  {
-  lam a. lam b. lam p.
+  { lam a. lam b. lam p.
     <i> <j> 
       '(hcom{0~>1} #A ,a
-        [i=0 -> {k}
-          (hcom{1~>j} #A (hcom{1~>0} #A (@ ,p k) [k=0 -> {_} ,a] [k=1 -> {l} (@ ,p l)])
-           [k=0 -> {_} ,a]
-           [k=1 -> {_} ,a])]
-        [i=1 -> {k} (hcom{1~>j} #A (@ ,p k) [k=0 -> {_} ,a] [k=1 -> {l} (@ ,p l)])]
-        [j=0 -> {k}
-          (hcom{1~>i} #A (hcom{1~>0} #A (@ ,p k) [k=0 -> {_} ,a] [k=1 -> {l} (@ ,p l)])
-           [k=0 -> {_} ,a]
-           [k=1 -> {_} ,a])]
-        [j=1 -> {k} (hcom{1~>i} #A (@ ,p k) [k=0 -> {_} ,a] [k=1 -> {l} (@ ,p l)])])
+        [i=0 {k}
+          (hcom{1~>j} #A
+           (hcom{1~>0} #A (@ ,p k)
+            [k=0 {_} ,a]
+            [k=1 {l} (@ ,p l)])
+           [k=0 {_} ,a]
+           [k=1 {_} ,a])]
+        [i=1 {k}
+         (hcom{1~>j} #A (@ ,p k)
+          [k=0 {_} ,a]
+          [k=1 {l} (@ ,p l)])]
+        [j=0 {k}
+          (hcom{1~>i} #A
+           (hcom{1~>0} #A (@ ,p k)
+            [k=0 {_} ,a]
+            [k=1 {l} (@ ,p l)])
+           [k=0 {_} ,a]
+           [k=1 {_} ,a])]
+        [j=1 {k}
+         (hcom{1~>i} #A (@ ,p k)
+          [k=0 {_} ,a]
+          [k=1 {l} (@ ,p l)])])
   };
   auto
 ].

--- a/test/success/connection.prl
+++ b/test/success/connection.prl
@@ -23,4 +23,5 @@ Thm Connection(#A) : [
   auto
 ].
 
+Print Connection.
 Extract Connection.

--- a/test/success/connection.prl
+++ b/test/success/connection.prl
@@ -1,24 +1,23 @@
 Thm Connection(#A) : [
   a/type : #A type >>
-     (a : #A)
-  -> (b : #A)
-  -> (p : paths({_}.#A; a; b))
-  -> paths({i}.paths({_}.#A; a; p@i); <_>a; p)
+  (-> [a #A] [b #A]
+   [p (paths {_} #A a b)]
+   (paths {i} (paths {_} #A a (@ p i)) (abs {_} a) p))
 ] by [
   {
   lam a. lam b. lam p.
     <i> <j> 
-      'hcom{0~>1}(#A; ,a)
-        [i=0 -> {k}.
-          hcom{1~>j}(#A; hcom{1~>0}(#A; ,p @ k) [k=0 -> {_}.,a; k=1 -> {l}.,p @ l])
-            [k=0 -> {_}.,a;
-             k=1 -> {_}.,a];
-         i=1 -> {k}. hcom{1~>j}(#A; ,p @ k) [k=0 -> {_}.,a; k=1 -> {l}.,p @ l];
-         j=0 -> {k}.
-          hcom{1~>i}(#A; hcom{1~>0}(#A; ,p @ k) [k=0 -> {_}.,a; k=1 -> {l}.,p @ l])
-            [k=0 -> {_}.,a;
-             k=1 -> {_}.,a];
-         j=1 -> {k}. hcom{1~>i}(#A; ,p @ k) [k=0 -> {_}.,a; k=1 -> {l}.,p @ l]]
+      '(hcom{0~>1} #A ,a
+        [i=0 -> {k}
+          (hcom{1~>j} #A (hcom{1~>0} #A (@ ,p k) [k=0 -> {_} ,a] [k=1 -> {l} (@ ,p l)])
+           [k=0 -> {_} ,a]
+           [k=1 -> {_} ,a])]
+        [i=1 -> {k} (hcom{1~>j} #A (@ ,p k) [k=0 -> {_} ,a] [k=1 -> {l} (@ ,p l)])]
+        [j=0 -> {k}
+          (hcom{1~>i} #A (hcom{1~>0} #A (@ ,p k) [k=0 -> {_} ,a] [k=1 -> {l} (@ ,p l)])
+           [k=0 -> {_} ,a]
+           [k=1 -> {_} ,a])]
+        [j=1 -> {k} (hcom{1~>i} #A (@ ,p k) [k=0 -> {_} ,a] [k=1 -> {l} (@ ,p l)])])
   };
   auto
 ].

--- a/test/success/connection.prl
+++ b/test/success/connection.prl
@@ -1,6 +1,7 @@
 Thm Connection(#A) : [
   a/type : #A type >>
-  (-> [a #A] [b #A]
+  (->
+   [a b #A]
    [p (paths {_} #A a b)]
    (paths {i} (paths {_} #A a (@ p i)) (abs {_} a) p))
 ] by [

--- a/test/success/connection.prl
+++ b/test/success/connection.prl
@@ -7,7 +7,7 @@ Thm Connection(#A) : [
 ] by [
   { lam a. lam b. lam p.
     <i> <j> 
-      '(hcom{0~>1} #A ,a
+      `(hcom{0~>1} #A ,a
         [i=0 {k}
           (hcom{1~>j} #A
            (hcom{1~>0} #A (@ ,p k)

--- a/test/success/dashes-n-slashes.prl
+++ b/test/success/dashes-n-slashes.prl
@@ -1,5 +1,5 @@
 // Identifiers can contain hyphens and slashes
 Thm Ident-test/ : [ bool ] by [
-  { 'tt };
+  { `tt };
   auto
 ].

--- a/test/success/derived-rule.prl
+++ b/test/success/derived-rule.prl
@@ -23,7 +23,7 @@ Thm MyCorollary : [ (-> bool bool) ] by [
 
 Extract MyCorollary.
 
-Thm MyCorollary/Test : [ (MyCorollary) = (lam [z] (if [_] bool z ff tt)) in (-> bool bool) ] by [
+Thm MyCorollary/Test : [ MyCorollary = (lam [z] (if [_] bool z ff tt)) in (-> bool bool) ] by [
   auto
 ].
 

--- a/test/success/derived-rule.prl
+++ b/test/success/derived-rule.prl
@@ -17,20 +17,20 @@ Rule MyRule : [
 // it replaces the current goal with the premises induced by the derived rule. The
 // hypothetical contexts are also unified together in the appropriate way (i.e. we 
 // do not require strict equality of contexts, but only compatibility).
-Thm MyCorollary : [ bool -> bool ] by [
+Thm MyCorollary : [ (-> bool bool) ] by [
   {lam z. rule MyRule{z}; auto}; auto
 ].
 
 Extract MyCorollary.
 
-Thm MyCorollary/Test : [ MyCorollary = lam([z]. if([_]. bool; z; ff; tt)) in bool -> bool ] by [
+Thm MyCorollary/Test : [ MyCorollary = (lam [z] (if [_] bool z ff tt)) in (-> bool bool) ] by [
   auto
 ].
 
 Rule PiTypehood(#A; #B : [exp].exp) : [
   #A type;
   x : #A >> #B[x] type
-  ==> (x : #A) -> #B[x] type
+  ==> (-> [x #A] #B[x]) type
 ] by [
   auto
 ].
@@ -38,7 +38,7 @@ Rule PiTypehood(#A; #B : [exp].exp) : [
 Rule LambdaMembership(#A; #B : [exp].exp; #m : [exp].exp) : [
   x : #A >> #m[x] in #B[x];
   #A type
-  ==> lam([x].#m[x]) in (x : #A) -> #B[x]
+  ==> (lam [x] #m[x]) in (-> [x #A] #B[x])
 ] by [
   auto
 ].
@@ -46,13 +46,13 @@ Rule LambdaMembership(#A; #B : [exp].exp; #m : [exp].exp) : [
 Rule PiIntro(#A; #B : [exp].exp) : [
   x : #A >> #B[x];
   #A type
-  ==> (x:#A) -> #B[x]
+  ==> (-> [x #A] #B[x])
 ] by [
   auto
 ].
 
-Thm Test : [ bool -> bool] by [
-  fresh x <- rule PiIntro(bool; [x].bool);
+Thm Test : [ (-> bool bool)] by [
+  fresh x <- (rule PiIntro bool [x] bool);
   [ if x then 'ff else 'tt ];
   auto;
 ].

--- a/test/success/derived-rule.prl
+++ b/test/success/derived-rule.prl
@@ -18,9 +18,9 @@ Rule MyRule : [
 // hypothetical contexts are also unified together in the appropriate way (i.e. we 
 // do not require strict equality of contexts, but only compatibility).
 Thm MyCorollary : [ (-> bool bool) ] by [
-  {lam z. rule MyRule{z}; auto}; auto
+  {lam z. rule {MyRule z}; auto}; auto
 ].
-
+ 
 Extract MyCorollary.
 
 Thm MyCorollary/Test : [ MyCorollary = (lam [z] (if [_] bool z ff tt)) in (-> bool bool) ] by [
@@ -52,7 +52,7 @@ Rule PiIntro(#A; #B : [exp].exp) : [
 ].
 
 Thm Test : [ (-> bool bool)] by [
-  fresh x <- (rule PiIntro bool [x] bool);
+  fresh x <- rule (PiIntro bool [x] bool);
   [ if x then 'ff else 'tt ];
   auto;
 ].

--- a/test/success/derived-rule.prl
+++ b/test/success/derived-rule.prl
@@ -9,7 +9,7 @@ Rule MyRule : [
   x : bool >> tt in bool
   ==> x : bool >> bool
 ] by [
-  if x then 'ff else 'tt
+  if x then `ff else `tt
 ].
 
 // A derived rule can be applied using the built-in 'rule' rule. This checks whether
@@ -53,7 +53,7 @@ Rule PiIntro(#A; #B : [exp].exp) : [
 
 Thm Test : [ (-> bool bool)] by [
   fresh x <- rule (PiIntro bool [x] bool);
-  [ if x then 'ff else 'tt ];
+  [ if x then `ff else `tt ];
   auto;
 ].
 

--- a/test/success/derived-rule.prl
+++ b/test/success/derived-rule.prl
@@ -23,7 +23,7 @@ Thm MyCorollary : [ (-> bool bool) ] by [
 
 Extract MyCorollary.
 
-Thm MyCorollary/Test : [ MyCorollary = (lam [z] (if [_] bool z ff tt)) in (-> bool bool) ] by [
+Thm MyCorollary/Test : [ (MyCorollary) = (lam [z] (if [_] bool z ff tt)) in (-> bool bool) ] by [
   auto
 ].
 

--- a/test/success/hcom.prl
+++ b/test/success/hcom.prl
@@ -9,18 +9,18 @@
 Thm Hcom/Poly(#A) : [
   a/type : #A type
   >>
-    (a : #A)
-      -> (b : #A)
-      -> (c : #A) 
-      -> (d : #A) 
-      -> paths({_}.#A; a; b)
-      -> paths({_}.#A; a; c)
-      -> paths({_}.#A; b; d) 
-      -> paths({_}.#A; c; d)
+  (-> [a #A] [b #A] [c #A] [d #A]
+   (paths {_} #A a b)
+   (paths {_} #A a c)
+   (paths {_} #A b d)
+   (paths {_} #A c d))
 ] by [
   { lam a. lam b. lam c. lam d.
     lam pab. lam pac. lam pbd.
-    <i> 'hcom{0 ~> 1}(#A; ,pab @ i) [i=0 -> {j}. ,pac @ j; i=1 -> {j}. ,pbd @ j]
+    <i> 
+      '(hcom{0 ~> 1} #A (@ ,pab i) 
+        [i=0 -> {j} (@ ,pac j)]
+        [i=1 -> {j} (@ ,pbd j)])
   };
   auto
 ].
@@ -30,15 +30,16 @@ Extract Hcom/Poly.
 Thm Hcom/trans(#A) : [
   a/type : #A type
   >>
-    (a : #A)
-      -> (b : #A)
-      -> (c : #A)
-      -> paths({_}.#A; a; b)
-      -> paths({_}.#A; b; c)
-      -> paths({_}.#A; a; c)
+  (-> [a #A] [b #A] [c #A]
+   (paths {_} #A a b)
+   (paths {_} #A b c)
+   (paths {_} #A a c))
 ] by [
   { lam a. lam b. lam c. lam pab. lam pbc.
-    <i> 'hcom{0 ~> 1}(#A; ,pab @ i) [i=0 -> {_}. ,a; i=1 -> {j}. ,pbc @j]
+    <i>
+      '(hcom{0 ~> 1} #A (@ ,pab i) 
+        [i=0 -> {_} ,a] 
+        [i=1 -> {j} (@ ,pbc j)])
   };
   auto
 ].
@@ -46,13 +47,15 @@ Thm Hcom/trans(#A) : [
 Thm Hcom/symm(#A) : [
   a/type : #A type
   >> 
-    (a : #A) 
-      -> (b : #A)
-      -> paths({_}.#A; a; b)
-      -> paths({_}.#A; b; a)
+  (-> [a #A] [b #A]
+   (paths {_} #A a b)
+   (paths {_} #A b a))
 ] by [
   { lam a. lam b. lam pab.
-    <i> 'hcom{0 ~> 1}(#A; ,a) [i=0 -> {j}. ,pab @j; i=1 -> {_}. ,a]
+    <i>
+      '(hcom{0 ~> 1} #A ,a 
+        [i=0 -> {j} (@ ,pab j)]
+        [i=1 -> {_} ,a])
   };
   auto
 ].
@@ -60,7 +63,7 @@ Thm Hcom/symm(#A) : [
 Thm Cap{i : dim}(#A) : [ 
   a/type : #A type,
   x : #A
-  >> hcom{0 ~> 0}(#A; x) [i=0 -> {_}. x; i=1 -> {_}. x] = x in #A
+  >> (hcom{0 ~> 0} #A x [i=0 -> {_} x] [i=1 -> {_} x]) = x in #A
 ] by [
   auto
 ].
@@ -68,13 +71,13 @@ Thm Cap{i : dim}(#A) : [
 Thm Tube(#A) : [
   a/type : #A type,
   x : #A
-  >> hcom{0 ~> 1}(#A; x) [1=1 -> {_}. x; 0=0 -> {_}. x] = x in #A
+  >> (hcom{0 ~> 1} #A x [1=1 -> {_} x] [0=0 -> {_} x]) = x in #A
 ] by [
   auto
 ].
 
 Thm TrueByEvaluation : [
-  hcom{0 ~> 0}(bool; tt) [] in bool
+  (hcom{0 ~> 0} bool tt) in bool
 ] by [
   auto
 ].

--- a/test/success/hcom.prl
+++ b/test/success/hcom.prl
@@ -11,17 +11,17 @@ Thm Hcom/Poly(#A) : [
   >>
   (->
    [a b c d #A]
-   (paths {_} #A a b)
-   (paths {_} #A a c)
-   (paths {_} #A b d)
-   (paths {_} #A c d))
+   (path {_} #A a b)
+   (path {_} #A a c)
+   (path {_} #A b d)
+   (path {_} #A c d))
 ] by [
   { lam a. lam b. lam c. lam d.
     lam pab. lam pac. lam pbd.
     <i> 
       '(hcom{0 ~> 1} #A (@ ,pab i) 
-        [i=0 -> {j} (@ ,pac j)]
-        [i=1 -> {j} (@ ,pbd j)])
+        [i=0 {j} (@ ,pac j)]
+        [i=1 {j} (@ ,pbd j)])
   };
   auto
 ].
@@ -33,15 +33,15 @@ Thm Hcom/trans(#A) : [
   >>
   (->
    [a b c #A]
-   (paths {_} #A a b)
-   (paths {_} #A b c)
-   (paths {_} #A a c))
+   (path {_} #A a b)
+   (path {_} #A b c)
+   (path {_} #A a c))
 ] by [
   { lam a. lam b. lam c. lam pab. lam pbc.
     <i>
       '(hcom{0 ~> 1} #A (@ ,pab i) 
-        [i=0 -> {_} ,a] 
-        [i=1 -> {j} (@ ,pbc j)])
+        [i=0 {_} ,a] 
+        [i=1 {j} (@ ,pbc j)])
   };
   auto
 ].
@@ -51,14 +51,14 @@ Thm Hcom/symm(#A) : [
   >> 
   (->
    [a b #A]
-   (paths {_} #A a b)
-   (paths {_} #A b a))
+   (path {_} #A a b)
+   (path {_} #A b a))
 ] by [
   { lam a. lam b. lam pab.
     <i>
       '(hcom{0 ~> 1} #A ,a 
-        [i=0 -> {j} (@ ,pab j)]
-        [i=1 -> {_} ,a])
+        [i=0 {j} (@ ,pab j)]
+        [i=1 {_} ,a])
   };
   auto
 ].
@@ -66,7 +66,7 @@ Thm Hcom/symm(#A) : [
 Thm Cap{i : dim}(#A) : [ 
   a/type : #A type,
   x : #A
-  >> (hcom{0 ~> 0} #A x [i=0 -> {_} x] [i=1 -> {_} x]) = x in #A
+  >> (hcom{0 ~> 0} #A x [i=0 {_} x] [i=1 {_} x]) = x in #A
 ] by [
   auto
 ].
@@ -74,7 +74,7 @@ Thm Cap{i : dim}(#A) : [
 Thm Tube(#A) : [
   a/type : #A type,
   x : #A
-  >> (hcom{0 ~> 1} #A x [1=1 -> {_} x] [0=0 -> {_} x]) = x in #A
+  >> (hcom{0 ~> 1} #A x [1=1 {_} x] [0=0 {_} x]) = x in #A
 ] by [
   auto
 ].

--- a/test/success/hcom.prl
+++ b/test/success/hcom.prl
@@ -9,7 +9,8 @@
 Thm Hcom/Poly(#A) : [
   a/type : #A type
   >>
-  (-> [a #A] [b #A] [c #A] [d #A]
+  (->
+   [a b c d #A]
    (paths {_} #A a b)
    (paths {_} #A a c)
    (paths {_} #A b d)
@@ -30,7 +31,8 @@ Extract Hcom/Poly.
 Thm Hcom/trans(#A) : [
   a/type : #A type
   >>
-  (-> [a #A] [b #A] [c #A]
+  (->
+   [a b c #A]
    (paths {_} #A a b)
    (paths {_} #A b c)
    (paths {_} #A a c))
@@ -47,7 +49,8 @@ Thm Hcom/trans(#A) : [
 Thm Hcom/symm(#A) : [
   a/type : #A type
   >> 
-  (-> [a #A] [b #A]
+  (->
+   [a b #A]
    (paths {_} #A a b)
    (paths {_} #A b a))
 ] by [

--- a/test/success/hcom.prl
+++ b/test/success/hcom.prl
@@ -19,7 +19,7 @@ Thm Hcom/Poly(#A) : [
   { lam a. lam b. lam c. lam d.
     lam pab. lam pac. lam pbd.
     <i> 
-      '(hcom{0 ~> 1} #A (@ ,pab i) 
+      `(hcom{0 ~> 1} #A (@ ,pab i) 
         [i=0 {j} (@ ,pac j)]
         [i=1 {j} (@ ,pbd j)])
   };
@@ -39,7 +39,7 @@ Thm Hcom/trans(#A) : [
 ] by [
   { lam a. lam b. lam c. lam pab. lam pbc.
     <i>
-      '(hcom{0 ~> 1} #A (@ ,pab i) 
+      `(hcom{0 ~> 1} #A (@ ,pab i) 
         [i=0 {_} ,a] 
         [i=1 {j} (@ ,pbc j)])
   };
@@ -56,7 +56,7 @@ Thm Hcom/symm(#A) : [
 ] by [
   { lam a. lam b. lam pab.
     <i>
-      '(hcom{0 ~> 1} #A ,a 
+      `(hcom{0 ~> 1} #A ,a 
         [i=0 {j} (@ ,pab j)]
         [i=1 {_} ,a])
   };

--- a/test/success/logical-investigations.prl
+++ b/test/success/logical-investigations.prl
@@ -76,6 +76,3 @@ Thm Thm5(#A) : [
 ].
 
 Extract Thm5.
-
-// TODO: I would have given some examples about negation, but I just realized that RedPRL doesn't even have
-// the Void type! I'll add it soon.

--- a/test/success/logical-investigations.prl
+++ b/test/success/logical-investigations.prl
@@ -12,7 +12,7 @@
 Thm Thm1(#A; #B) : [
   type/A : #A type,
   type/B : #B type
-  >> #A -> #B -> #A
+  >> (-> #A #B #A)
 ] by [
   // The main part of the theorem is the following expression; but in RedPRL, this induces some
   // auxiliary subgoals, which have to be resolved. To do that, we put the main part of the proof
@@ -26,7 +26,7 @@ Thm Thm2(#A; #B; #C) : [
   type/A : #A type,
   type/B : #B type,
   type/C : #C type
-  >> ((#A -> #B) -> (#A -> #B -> #C) -> #A -> #C)
+  >> (-> (-> #A #B) (-> #A #B #C) #A #C)
 ] by [
   {lam f. lam g. lam a.
    // RedPRL's logic is a sequent calculus, which means that you apply 
@@ -41,18 +41,18 @@ Thm Thm2(#A; #B; #C) : [
 // It is worthwhile to print out the extract program / evidence for Thm2.
 Extract Thm2.
 
-Def Not(#A) = [ #A -> void ].
+Def Not(#A) = [ (-> #A void) ].
 
 Thm Not/wf(#A) : [
   type/A : #A type
-  >> Not(#A) type
+  >> (Not #A) type
 ] by [
   auto
 ].
 
 Thm Thm4(#A; #B) : [
   type/A : #A type
-  >> Not(#A) -> #A -> #B
+  >> (-> (Not #A) #A #B)
 ] by [
   { lam r. lam a.
     unfold Not;
@@ -64,7 +64,7 @@ Thm Thm4(#A; #B) : [
 
 Thm Thm5(#A) : [
   type/A : #A type
-  >> #A -> Not(Not(#A))
+  >> (-> #A (Not (Not #A)))
 ] by [
   { lam a.
     unfold Not;

--- a/test/success/path-ap-const.prl
+++ b/test/success/path-ap-const.prl
@@ -1,6 +1,6 @@
 Thm PathApConst : [
-  paths({_}.bool; tt; tt) -> bool
+  (-> (paths {_} bool tt tt) bool)
 ] by [
-  { lam p. ',p @ 0 };
+  { lam p. '(@ ,p 0) };
   auto;
 ].

--- a/test/success/path-ap-const.prl
+++ b/test/success/path-ap-const.prl
@@ -1,6 +1,6 @@
 Thm PathApConst : [
-  (-> (paths {_} bool tt tt) bool)
+  (-> (path {_} bool tt tt) bool)
 ] by [
-  { lam p. '(@ ,p 0) };
+  { lam p. `(@ ,p 0) };
   auto;
 ].

--- a/test/success/primitive-sequencing.prl
+++ b/test/success/primitive-sequencing.prl
@@ -1,4 +1,4 @@
-Thm PrimitiveSequencingTest : [bool -> bool -> bool -> bool] by [
+Thm PrimitiveSequencingTest : [(-> bool bool bool bool)] by [
   fresh x,y,z <- auto;
   hyp y
 ].

--- a/test/success/strict-bool.prl
+++ b/test/success/strict-bool.prl
@@ -1,19 +1,22 @@
 Def Cmp(#m; #n) = [
-  lam([x]. #m (#n x))
+  (lam [x] (#m (#n x)))
 ].
 
 Def SBool/Not = [
-  lam([x]. if/s(x; ff; tt))
+  (lam [x] (if/s x ff tt))
 ].
 
 Thm SBool/Not-Not-Id : [
-  Cmp(SBool/Not; SBool/Not) = lam([x].x) in sbool -> sbool
+  (Cmp SBool/Not SBool/Not) = (lam [x] x) in (-> [x sbool] sbool)
 ] by [
   auto
 ].
 
 Thm SBool/Not-Not-Id-Path : [
-  paths({_}.sbool -> sbool; Cmp(SBool/Not; SBool/Not); lam([x].x))
+  (paths
+    {_} (-> [x sbool] sbool)
+    (Cmp SBool/Not SBool/Not)
+    (lam [x] x))
 ] by [
   {<i> lam x. hyp x};
   auto

--- a/test/success/strict-bool.prl
+++ b/test/success/strict-bool.prl
@@ -13,7 +13,7 @@ Thm SBool/Not-Not-Id : [
 ].
 
 Thm SBool/Not-Not-Id-Path : [
-  (paths
+  (path
     {_} (-> sbool sbool)
     (Cmp SBool/Not SBool/Not)
     (lam [x] x))

--- a/test/success/strict-bool.prl
+++ b/test/success/strict-bool.prl
@@ -7,7 +7,7 @@ Def SBool/Not = [
 ].
 
 Thm SBool/Not-Not-Id : [
-  (Cmp (SBool/Not) (SBool/Not)) = (lam [x] x) in (-> sbool sbool)
+  (Cmp SBool/Not SBool/Not) = (lam [x] x) in (-> sbool sbool)
 ] by [
   auto
 ].
@@ -15,7 +15,7 @@ Thm SBool/Not-Not-Id : [
 Thm SBool/Not-Not-Id-Path : [
   (paths
     {_} (-> sbool sbool)
-    (Cmp (SBool/Not) (SBool/Not))
+    (Cmp SBool/Not SBool/Not)
     (lam [x] x))
 ] by [
   {<i> lam x. hyp x};

--- a/test/success/strict-bool.prl
+++ b/test/success/strict-bool.prl
@@ -7,7 +7,7 @@ Def SBool/Not = [
 ].
 
 Thm SBool/Not-Not-Id : [
-  (Cmp SBool/Not SBool/Not) = (lam [x] x) in (-> sbool sbool)
+  (Cmp (SBool/Not) (SBool/Not)) = (lam [x] x) in (-> sbool sbool)
 ] by [
   auto
 ].
@@ -15,7 +15,7 @@ Thm SBool/Not-Not-Id : [
 Thm SBool/Not-Not-Id-Path : [
   (paths
     {_} (-> sbool sbool)
-    (Cmp SBool/Not SBool/Not)
+    (Cmp (SBool/Not) (SBool/Not))
     (lam [x] x))
 ] by [
   {<i> lam x. hyp x};

--- a/test/success/strict-bool.prl
+++ b/test/success/strict-bool.prl
@@ -7,14 +7,14 @@ Def SBool/Not = [
 ].
 
 Thm SBool/Not-Not-Id : [
-  (Cmp SBool/Not SBool/Not) = (lam [x] x) in (-> [x sbool] sbool)
+  (Cmp SBool/Not SBool/Not) = (lam [x] x) in (-> sbool sbool)
 ] by [
   auto
 ].
 
 Thm SBool/Not-Not-Id-Path : [
   (paths
-    {_} (-> [x sbool] sbool)
+    {_} (-> sbool sbool)
     (Cmp SBool/Not SBool/Not)
     (lam [x] x))
 ] by [

--- a/test/success/two-times-two.prl
+++ b/test/success/two-times-two.prl
@@ -1,3 +1,4 @@
-Thm TwoTimesTwo : [ bool * bool ] by [
-  '(< tt , tt >); auto
+Thm TwoTimesTwo : [ (* bool bool) ] by [
+  '< tt , tt >;
+  auto
 ].

--- a/test/success/two-times-two.prl
+++ b/test/success/two-times-two.prl
@@ -1,4 +1,0 @@
-Thm TwoTimesTwo : [ (* bool bool) ] by [
-  '< tt , tt >;
-  auto
-].

--- a/test/success/unfold.prl
+++ b/test/success/unfold.prl
@@ -1,10 +1,10 @@
 Def Times(#A; #B) = [
-  (x : #A) * #B
+  (* #A #B)
 ].
 
 Thm Times/Proj(#A) : [
   a/type : #A type 
-  >> Times(bool; #A) -> #A
+  >> (-> (Times bool #A) #A)
 ] by [
   {lam x. 
     unfold Times;


### PR DESCRIPTION
This is the first step toward migrating to use the ~immortal pretty printer~ Immortal Pretty Printer. This PR changes the *term printer* to use the ~immortal library~ Immortal Library, and removes our dependency on that fixity unparsing library.

In later stages, we will make the use of the ~immortal library~ Immortal Library pervasive throughout RedPRL. Another thing we'll aim for is that the rendering only ever occur at the edges of RedPRL, so that we never have to compute these documents to a string, which is probably expensive. 