### PR TITLE
Refactor the refiner.

### DIFF
--- a/src/redprl.cm
+++ b/src/redprl.cm
@@ -63,6 +63,7 @@ is
 
   redprl/refiner_kit.fun
   redprl/refiner_composition_kit.fun
+  redprl/refiner_types.fun
   redprl/refiner.sig
   redprl/refiner.fun
   redprl/lcf.sml

--- a/src/redprl.cm
+++ b/src/redprl.cm
@@ -62,6 +62,7 @@ is
   redprl/machine.sml
 
   redprl/refiner_kit.fun
+  redprl/refiner_composition_kit.fun
   redprl/refiner.sig
   redprl/refiner.fun
   redprl/lcf.sml

--- a/src/redprl.mlb
+++ b/src/redprl.mlb
@@ -49,6 +49,7 @@ local
   ann "nonexhaustiveMatch ignore" in
     redprl/machine.sml
     redprl/refiner_kit.fun
+    redprl/refiner_composition_kit.fun
     redprl/refiner.sig
     redprl/refiner.fun
     redprl/lcf_syntax.fun

--- a/src/redprl.mlb
+++ b/src/redprl.mlb
@@ -50,6 +50,7 @@ local
     redprl/machine.sml
     redprl/refiner_kit.fun
     redprl/refiner_composition_kit.fun
+    redprl/refiner_types.fun
     redprl/refiner.sig
     redprl/refiner.fun
     redprl/lcf_syntax.fun

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -1,7 +1,8 @@
 functor Refiner (Sig : MINI_SIGNATURE) : REFINER =
 struct
   structure Kit = RefinerKit (Sig)
-  open RedPrlAbt Kit
+  structure ComRefinerKit = RefinerCompositionKit (Sig)
+  open RedPrlAbt Kit ComRefinerKit
 
   type sign = Sig.sign
   type rule = (int -> Sym.t) -> Lcf.jdg Lcf.tactic
@@ -9,25 +10,9 @@ struct
   type opid = Sig.opid
 
   infixr @@
-  infix 1 ||
+  infix 1 || #>
   infix 2 >> >: >:+ $$ $# // \ @>
-
-  fun abstractEvidence (I : (sym * psort) list, H) m = 
-    let
-      val (us, sigmas) = ListPair.unzip I
-      val (xs, taus) = Hyps.foldr (fn (x, jdg, (xs, taus)) => (x::xs, CJ.synthesis jdg::taus)) ([],[]) H
-    in
-      checkb ((us, xs) \ m, ((sigmas, taus), sort m))
-    end
-
-  fun #> (psi, (I, H, m)) =
-    Lcf.|> (psi, abstractEvidence (I, H) m)
-
-  infix #>
-
-  val trivial = Syn.into Syn.AX
-
-  fun orelse_ (t1, t2) alpha = Lcf.orelse_ (t1 alpha, t2 alpha)
+  infix orelse_
 
   structure S1 =
   struct
@@ -64,6 +49,17 @@ struct
         val () = assertParamEq "S1.EqLoop" (r1, r2)
       in
         T.empty #> (I, H, trivial)
+      end
+
+    fun EqFCom alpha jdg =
+      let
+        val _ = RedPrlLog.trace "EqFCom"
+        val (I, H) >> CJ.EQ ((lhs, rhs), ty) = jdg
+        val Syn.S1 = Syn.out ty
+        val Syn.FCOM args0 = Syn.out lhs
+        val Syn.FCOM args1 = Syn.out rhs
+      in
+        ComKit.EqFComDelegator alpha (I, H) args0 args1 ty
       end
 
     fun Elim z alpha jdg =
@@ -201,6 +197,17 @@ struct
         val Syn.FF = Syn.out n
       in
         T.empty #> (I, H, trivial)
+      end
+
+    fun EqFCom alpha jdg =
+      let
+        val _ = RedPrlLog.trace "EqFCom"
+        val (I, H) >> CJ.EQ ((lhs, rhs), ty) = jdg
+        val Syn.BOOL = Syn.out ty
+        val Syn.FCOM args0 = Syn.out lhs
+        val Syn.FCOM args1 = Syn.out rhs
+      in
+        ComKit.EqFComDelegator alpha (I, H) args0 args1 ty
       end
 
     fun Elim z _ jdg =
@@ -954,216 +961,6 @@ struct
       end
   end
 
-  structure Restriction :
-  sig
-    (* This structure used to provide functions that automate the
-       restriction judgement rules given in "Dependent Cubical
-       Realizability", page 46.
-
-       On 2017/06/14, favonia implemented a function to handle
-       all cases. We need to generalize the old handling to
-       welcome new hcom operators. (It is true that we still
-       only need to handle context restrictions with at most two
-       equations, but it seems easier to just handle all cases.)
-
-       Such automation is possible because the rules are "syntax
-       directed" on the restriction being performed.
-     *)
-
-    (* Restrict a judgement (as the goal) by a list of equations.
-     * Returns NONE if the resulting judgement is vacuously true.
-     *)
-    val restrict : abt jdg -> (param * param) list -> abt jdg option
-  end
-  =
-  struct
-    (* A helper function which does substitution in a parameter. *)
-    fun substSymInParam (r, v) = P.bind (fn u => if Sym.eq (u, v) then r else P.ret u)
-
-    fun restrict jdg [] = SOME jdg
-      | restrict jdg ((P.APP d1, P.APP d2) :: eqs) =
-          (* The following line is correct because we only have constants
-           * (DIM0 and DIM1). If in the future we want to have connections
-           * or other stuff, then a real unification algorithm might be needed.
-           *)
-          if P.Sig.eq (fn _ => true) (d1, d2) then restrict jdg eqs else NONE
-      | restrict jdg ((r1 as P.VAR v1, r2) :: eqs) =
-          if P.eq Sym.eq (r1, r2) then restrict jdg eqs else substAndRestrict (r2, v1) jdg eqs
-      | restrict jdg ((r1, r2 as P.VAR v2) :: eqs) =
-          substAndRestrict (r1, v2) jdg eqs
-
-    and substAndRestrict rv jdg eqs = restrict
-          (Seq.map (substSymbol rv) jdg)
-          (List.map (fn (r, r') => (substSymInParam rv r, substSymInParam rv r')) eqs)
-  end
-
-  (* code shared by Com, HCom and FCom. *)
-  structure ComKit =
-  struct
-    (* todo: optimizing the restriction process even further. *)
-    (* todo: pre-restrict r=0, r=1, 0=r and 1=r, and open-reduce everything first. *)
-    (* todo: do alpha-renaming only once. *)
-    (* todo: try to minimize substitution. *)
-
-    (* Produce the list of goals requiring that tube aspects agree with each other.
-         forall i <= j.
-           N_i = P_j in A [Psi, y | r_i = r_i', r_j = r_j']
-     *)
-    fun genInterTubeGoals (I, H) w ty tubes0 tubes1 =
-      let
-        fun interTube (eq0, (u, tube0)) (eq1, (v, tube1)) =
-          let
-            val tube0 = substSymbol (P.ret w, u) tube0
-            val tube1 = substSymbol (P.ret w, v) tube1
-            val J = (I, H) >> CJ.EQ ((tube0, tube1), ty)
-          in
-            Option.map 
-              (fn (I, J) >> jdg => #1 (makeGoal @@ (I @ [(w,P.DIM)], H) >> jdg))
-              (Restriction.restrict J [eq0, eq1])
-          end
-        fun goTubePairs [] [] = []
-          | goTubePairs (t0 :: ts0) (t1 :: ts1) =
-              List.mapPartial (interTube t0) (t1 :: ts1) :: goTubePairs ts0 ts1
-          | goTubePairs _ _ = raise Fail "interTubeGoals: the tubes are of different lengths"
-      in
-        List.concat (goTubePairs tubes0 tubes1)
-      end
-
-    (* Produce the list of goals requiring that tube aspects agree with the cap.
-         forall i.
-           N_i<r/y> = M in A [Psi | r_i = r_i']
-     *)
-    fun genTubeCapGoals (I, H) ty r cap tubes =
-      let
-        fun tubeCap (eq, (u, tube)) =
-          let
-            val J = (I, H) >> CJ.EQ ((substSymbol (r,u) tube, cap), ty)
-          in
-            Option.map (#1 o (fn j => makeGoal @@ j)) (Restriction.restrict J [eq])
-          end
-      in
-        List.mapPartial tubeCap tubes
-      end
-  end
-
-  structure HCom =
-  struct
-    fun Eq alpha jdg =
-      let
-        val _ = RedPrlLog.trace "HCom.Eq"
-        val (I, H) >> CJ.EQ ((lhs, rhs), ty) = jdg
-        val Syn.HCOM {dir=(r0, r'0), ty=ty0, cap=cap0, tubes=tubes0} = Syn.out lhs
-        val () = assertAlphaEq (ty0, ty)
-        val Syn.HCOM {dir=(r1, r'1), ty=ty1, cap=cap1, tubes=tubes1} = Syn.out rhs
-        val () = assertParamEq "HCom.Eq source of direction" (r0, r1)
-        val () = assertParamEq "HCom.Eq target of direction" (r'0, r'1)
-        val eqs0 = List.map #1 tubes0
-        val eqs1 = List.map #1 tubes1
-        val _ = ListPair.mapEq (assertEquationEq "HCom.Eq equations") (eqs0, eqs1)
-        val _ = assertTautologicalEquations "HCom.Eq tautology checking" eqs0
-
-        val (goalTy, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (ty0, ty1)
-        val (goalCap, _) = makeGoal @@ (I, H) >> CJ.EQ ((cap0, cap1), ty)
-
-        val w = alpha 0
-      in
-        T.empty
-          >: goalTy >: goalCap
-          >:+ ComKit.genInterTubeGoals (I, H) w ty tubes0 tubes1
-          >:+ ComKit.genTubeCapGoals (I, H) ty r0 cap0 tubes0
-        #> (I, H, trivial)
-      end
-
-    fun CapEqL alpha jdg =
-      let
-        val _ = RedPrlLog.trace "HCom.CapEq"
-        val (I, H) >> CJ.EQ ((hcom, other), ty) = jdg
-        val Syn.HCOM {dir=(r, r'), ty=ty0, cap, tubes} = Syn.out hcom
-        val () = assertParamEq "HCom.CapEq source and target of direction" (r, r')
-        val () = assertAlphaEq (ty0, ty)
-  
-        val (goalTy, _) = makeGoal @@ (I, H) >> CJ.TYPE ty
-        val (goalEq, _) = makeGoal @@ (I, H) >> CJ.EQ ((cap, other), ty)
-  
-        val w = alpha 0
-      in
-        T.empty
-          >: goalTy >: goalEq
-          >:+ ComKit.genInterTubeGoals (I, H) w ty tubes tubes
-          >:+ ComKit.genTubeCapGoals (I, H) ty r cap tubes
-        #> (I, H, trivial)
-      end
-
-    val CapEqR = catJdgFlipWrapper CapEqL
-
-    (* Search for the first satisfied equation in an hcom. *)
-    fun TubeEqL alpha jdg =
-      let
-        val _ = RedPrlLog.trace "HCom.TubeEq"
-        val (I, H) >> CJ.EQ ((hcom, other), ty) = jdg
-        val Syn.HCOM {dir=(r, r'), ty=ty0, cap, tubes} = Syn.out hcom
-        val (eq, (u, tube)) = Option.valOf (List.find (fn (eq, _) => P.eq Sym.eq eq) tubes)
-        val () = assertAlphaEq (ty0, ty)
-  
-        val (goalTy, _) = makeGoal @@ (I, H) >> CJ.TYPE ty
-        val (goalCap, _) = makeGoal @@ (I, H) >> CJ.MEM (cap, ty)
-        val (goalEq, _) = makeGoal @@ (I, H) >> CJ.EQ ((substSymbol (r', u) tube, other), ty)
-  
-        val w = alpha 0
-      in
-        T.empty
-          >: goalTy >: goalCap >: goalEq
-          >:+ ComKit.genInterTubeGoals (I, H) w ty tubes tubes
-          >:+ ComKit.genTubeCapGoals (I, H) ty r cap tubes
-        #> (I, H, trivial)
-      end
-
-    val TubeEqR = catJdgFlipWrapper TubeEqL
-
-    local
-      infix orelse_
-    in
-      (* Try all the hcom rules. *)
-      val AutoEqLR = Eq orelse_ CapEqL orelse_ CapEqR orelse_ TubeEqL orelse_ TubeEqR
-      val AutoEqL = Eq orelse_ CapEqL orelse_ TubeEqL
-      val AutoEqR = Eq orelse_ CapEqR orelse_ TubeEqR
-    end
-  end
-
-  structure FCom =
-  struct
-    fun Eq alpha jdg =
-      let
-        val _ = RedPrlLog.trace "FCom.Eq"
-        val (I, H) >> CJ.EQ ((lhs, rhs), ty) = jdg
-        val Syn.FCOM {dir=(r0, r'0), cap=cap0, tubes=tubes0} = Syn.out lhs
-        val Syn.FCOM {dir=(r1, r'1), cap=cap1, tubes=tubes1} = Syn.out rhs
-        val () = assertParamEq "FCom.Eq source of direction" (r0, r1)
-        val () = assertParamEq "FCom.Eq target of direction" (r'0, r'1)
-        val eqs0 = List.map #1 tubes0
-        val eqs1 = List.map #1 tubes1
-        val _ = ListPair.mapEq (assertEquationEq "FCom.Eq equations") (eqs0, eqs1)
-        val _ = assertTautologicalEquations "FCom.Eq tautology checking" eqs0
-
-        val (goalCap, _) = makeGoal @@ (I, H) >> CJ.EQ ((cap0, cap1), ty)
-
-        val w = alpha 0
-      in
-        T.empty
-          >: goalCap
-          >:+ ComKit.genInterTubeGoals (I, H) w ty tubes0 tubes1
-          >:+ ComKit.genTubeCapGoals (I, H) ty r0 cap0 tubes0
-        #> (I, H, trivial)
-      end
-
-    local
-      infix orelse_
-    in
-      (* Try all the fcom rules. *)
-      val AutoEq = Eq
-    end
-  end
-
   structure Coe =
   struct
     fun Eq alpha jdg =
@@ -1207,14 +1004,11 @@ struct
 
     val CapEqR = catJdgFlipWrapper CapEqL
 
-    local
-      infix orelse_
-    in
-      (* Try all the fcom rules. *)
-      val AutoEqLR = Eq orelse_ CapEqL orelse_ CapEqR
-      val AutoEqL = Eq orelse_ CapEqL
-      val AutoEqR = Eq orelse_ CapEqR
-    end
+    (* Try all the fcom rules.
+     * Note that the EQ rule is invertible only when the cap rule fails. *)
+    val AutoEqLR = CapEqL orelse_ CapEqR orelse_ Eq
+    val AutoEqL = CapEqL orelse_ Eq
+    val AutoEqR = CapEqR orelse_ Eq
   end
 
   structure Computation =
@@ -1435,12 +1229,12 @@ struct
         case (Syn.out m, Syn.out n, Syn.out ty) of
            (Syn.TT, Syn.TT, Syn.BOOL) => Bool.EqTT
          | (Syn.FF, Syn.FF, Syn.BOOL) => Bool.EqFF
-         | (Syn.FCOM _, Syn.FCOM _, Syn.BOOL) => FCom.AutoEq
+         | (Syn.FCOM _, Syn.FCOM _, Syn.BOOL) => Bool.EqFCom
          | (Syn.TT, Syn.TT, Syn.S_BOOL) => StrictBool.EqTT
          | (Syn.FF, Syn.FF, Syn.S_BOOL) => StrictBool.EqFF
          | (Syn.BASE, Syn.BASE, Syn.S1) => S1.EqBase
          | (Syn.LOOP _, Syn.LOOP _, Syn.S1) => S1.EqLoop
-         | (Syn.FCOM _, Syn.FCOM _, Syn.S1) => FCom.AutoEq
+         | (Syn.FCOM _, Syn.FCOM _, Syn.S1) => S1.EqFCom
          | (Syn.LAM _, Syn.LAM _, _) => DFun.Eq
          | (Syn.PAIR _, Syn.PAIR _, _) => DProd.Eq
          | (Syn.PATH_ABS _, Syn.PATH_ABS _, _) => Path.Eq
@@ -1525,7 +1319,7 @@ struct
         else
           raise E.error [E.% "Non-deterministic tactics can only be run on auxiliary goals"]
     in
-      fun AutoStep sign = orelse_ (StepJdg sign, FindHyp)
+      fun AutoStep sign = StepJdg sign orelse_ FindHyp
     end
 
     local

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -2,7 +2,8 @@ functor Refiner (Sig : MINI_SIGNATURE) : REFINER =
 struct
   structure Kit = RefinerKit (Sig)
   structure ComRefinerKit = RefinerCompositionKit (Sig)
-  open RedPrlAbt Kit ComRefinerKit
+  structure TypeRules = RefinerTypeRules (Sig)
+  open RedPrlAbt Kit ComRefinerKit TypeRules
 
   type sign = Sig.sign
   type rule = (int -> Sym.t) -> Lcf.jdg Lcf.tactic
@@ -14,740 +15,95 @@ struct
   infix 2 >> >: >:+ $$ $# // \ @>
   infix orelse_
 
-  structure S1 =
+  structure Equality =
   struct
-    fun EqType _ jdg =
+    fun Hyp alpha jdg =
       let
-        val _ = RedPrlLog.trace "S1.EqType"
-        val (I, H) >> CJ.EQ_TYPE (a, b) = jdg
-        val Syn.S1 = Syn.out a
-        val Syn.S1 = Syn.out b
-      in
-        T.empty #> (I, H, trivial)
-      end
-      handle Bind =>
-        raise E.error [E.% "Expected typehood sequent"]
-
-    fun EqBase _ jdg =
-      let
-        val _ = RedPrlLog.trace "S1.EqBase"
+        val _ = RedPrlLog.trace "Equality.Hyp"
         val (I, H) >> CJ.EQ ((m, n), ty) = jdg
-        val Syn.S1 = Syn.out ty
-        val Syn.BASE = Syn.out m
-        val Syn.BASE = Syn.out n
+        val Syn.VAR (x, _) = Syn.out m
+        val Syn.VAR (y, _) = Syn.out n
+        val _ = assertVarEq (x, y)
+        val catjdg = lookupHyp H x
+        val ty' =
+          case catjdg of
+             CJ.TRUE ty => ty
+           | _ => raise E.error [E.% "Equality.Hyp: expected truth hypothesis"]
       in
-        T.empty #> (I, H, trivial)
+        (* If the types are identical, there is no need to create a new subgoal (which would amount to proving that 'ty' is a type).
+           This is because the semantics of sequents is that by assuming that something is a member of a 'ty', we have
+           automatically assumed that 'ty' is a type. *)
+        if Syn.Tm.eq (ty, ty') then
+          T.empty #> (I, H, trivial)
+        else
+          let
+            val (goalTy, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (ty, ty')
+          in
+            T.empty >: goalTy #> (I, H, trivial)
+          end
       end
+      handle Bind =>
+        raise E.error [E.% "Expected variable-equality sequent"]
 
-    fun EqLoop _ jdg =
+    fun Symmetry alpha jdg =
       let
-        val _ = RedPrlLog.trace "S1.EqLoop"
+        val _ = RedPrlLog.trace "Equality.Symmetry"
         val (I, H) >> CJ.EQ ((m, n), ty) = jdg
-        val Syn.S1 = Syn.out ty
-        val Syn.LOOP r1 = Syn.out m
-        val Syn.LOOP r2 = Syn.out n
-        val () = assertParamEq "S1.EqLoop" (r1, r2)
-      in
-        T.empty #> (I, H, trivial)
-      end
-
-    fun EqFCom alpha jdg =
-      let
-        val _ = RedPrlLog.trace "EqFCom"
-        val (I, H) >> CJ.EQ ((lhs, rhs), ty) = jdg
-        val Syn.S1 = Syn.out ty
-        val Syn.FCOM args0 = Syn.out lhs
-        val Syn.FCOM args1 = Syn.out rhs
-      in
-        ComKit.EqFComDelegator alpha (I, H) args0 args1 ty
-      end
-
-    fun Elim z alpha jdg =
-      let
-        val _ = RedPrlLog.trace "S1.Elim"
-        val (I, H) >> CJ.TRUE cz = jdg
-        val CJ.TRUE ty = lookupHyp H z
-        val Syn.S1 = Syn.out ty
-
-        val u = alpha 0
-        val base = Syn.into Syn.BASE
-        val loop = Syn.into o Syn.LOOP @@ P.ret u
-        val Hbase = Hyps.modifyAfter z (CJ.map (substVar (base, z))) H
-        val cbase = substVar (base, z) cz
-
-        val (goalB, holeB) = makeGoal @@ (I, Hbase) >> CJ.TRUE cbase
-        val (goalL, holeL) = makeGoal @@ (I @ [(u, P.DIM)], Hyps.modifyAfter z (CJ.map (substVar (loop, z))) H) >> CJ.TRUE (substVar (loop, z) cz)
-
-        val l0 = substSymbol (P.APP P.DIM0, u) holeL
-        val l1 = substSymbol (P.APP P.DIM1, u) holeL
-
-        val (goalCoh0, _) = makeGoal @@ (I, Hbase) >> CJ.EQ ((l0, holeB), cbase)
-        val (goalCoh1, _) = makeGoal @@ (I, Hbase) >> CJ.EQ ((l1, holeB), cbase)
-
-        val psi = T.empty >: goalB >: goalL >: goalCoh0 >: goalCoh1
-
-        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
-        val elim = Syn.into @@ Syn.S1_ELIM ((z, cz), ztm, (holeB, (u, holeL)))
-      in
-        psi #> (I, H, elim)
-      end
-      handle Bind =>
-        raise E.error [E.% "Expected circle elimination problem"]
-
-    fun ElimEq alpha jdg =
-      let
-        val _ = RedPrlLog.trace "S1.ElimEq"
-        val (I, H) >> CJ.EQ ((elim0, elim1), c) = jdg
-        val Syn.S1_ELIM ((x, c0x), m0, (b0, (u, l0u))) = Syn.out elim0
-        val Syn.S1_ELIM ((y, c1y), m1, (b1, (v, l1v))) = Syn.out elim1
-
-        val z = alpha 0
-        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
-        val c0z = substVar (ztm, x) c0x
-        val c1z = substVar (ztm, y) c1y
-        val l1u = substSymbol (P.ret u, v) l1v
-
-        val l00 = substSymbol (P.APP P.DIM0, u) l0u
-        val l01 = substSymbol (P.APP P.DIM1, u) l0u
-
-        val cbase = substVar (Syn.into Syn.BASE, x) c0x
-        val cloop = substVar (Syn.into @@ Syn.LOOP (P.ret u), x) c0x
-
-        val S1 = Syn.into Syn.S1
-
-        val (goalCz, _) = makeGoal @@ (I, H @> (z, CJ.TRUE S1)) >> CJ.EQ_TYPE (c0z, c1z)
-        val (goalM, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), S1)
-        val (goalB, _) = makeGoal @@ (I, H) >> CJ.EQ ((b0, b1), cbase)
-        val (goalL, _) = makeGoal @@ (I, H) >> CJ.EQ ((l0u, l1u), cloop)
-        val (goalL00, _) = makeGoal @@ (I, H) >> CJ.EQ ((l00, b0), cbase)
-        val (goalL01, _) = makeGoal @@ (I, H) >> CJ.EQ ((l01, b0), cbase)
-
-        val psi = T.empty >: goalCz >: goalM >: goalB >: goalL >: goalL00 >: goalL01
-      in
-        psi #> (I, H, trivial)
-      end
-  end
-
-  structure Void = 
-  struct
-    fun EqType _ jdg = 
-      let
-        val _ = RedPrlLog.trace "Void.EqType"
-        val (I, H) >> CJ.EQ_TYPE (a, b) = jdg
-        val Syn.VOID = Syn.out a
-        val Syn.VOID = Syn.out b
-      in
-        T.empty #> (I, H, trivial)
-      end
-      handle Bind =>
-        raise E.error [E.% "Expected typehood sequent"]
-
-    fun Elim z _ jdg =
-      let
-        val _ = RedPrlLog.trace "Void.Elim"
-        val (I, H) >> catjdg = jdg
-        val CJ.TRUE ty = lookupHyp H z
-        val Syn.VOID = Syn.out ty
-
-        val evidence = 
-          case catjdg of 
-             CJ.TRUE _ => Syn.into Syn.TT
-           | CJ.EQ _ => trivial
-           | CJ.EQ_TYPE _ => trivial
-           | _ => raise Fail "Void.Elim cannot be called with this kind of goal"
-      in
-        T.empty #> (I, H, evidence)
-      end
-      handle Bind =>
-        raise E.error [E.% "Expected Void elimination problem"]
-
-  end
-
-  structure Bool =
-  struct
-    fun EqType _ jdg =
-      let
-        val _ = RedPrlLog.trace "Bool.EqType"
-        val (I, H) >> CJ.EQ_TYPE (a, b) = jdg
-        val Syn.BOOL = Syn.out a
-        val Syn.BOOL = Syn.out b
-      in
-        T.empty #> (I, H, trivial)
-      end
-      handle Bind =>
-        raise E.error [E.% "Expected typehood sequent"]
-
-    fun EqTT _ jdg =
-      let
-        val _ = RedPrlLog.trace "Bool.EqTT"
-        val (I, H) >> CJ.EQ ((m, n), ty) = jdg
-        val Syn.BOOL = Syn.out ty
-        val Syn.TT = Syn.out m
-        val Syn.TT = Syn.out n
-      in
-        T.empty #> (I, H, trivial)
-      end
-
-    fun EqFF _ jdg =
-      let
-        val _ = RedPrlLog.trace "Bool.EqFF"
-        val (I, H) >> CJ.EQ ((m, n), ty) = jdg
-        val Syn.BOOL = Syn.out ty
-        val Syn.FF = Syn.out m
-        val Syn.FF = Syn.out n
-      in
-        T.empty #> (I, H, trivial)
-      end
-
-    fun EqFCom alpha jdg =
-      let
-        val _ = RedPrlLog.trace "EqFCom"
-        val (I, H) >> CJ.EQ ((lhs, rhs), ty) = jdg
-        val Syn.BOOL = Syn.out ty
-        val Syn.FCOM args0 = Syn.out lhs
-        val Syn.FCOM args1 = Syn.out rhs
-      in
-        ComKit.EqFComDelegator alpha (I, H) args0 args1 ty
-      end
-
-    fun Elim z _ jdg =
-      let
-        val _ = RedPrlLog.trace "Bool.Elim"
-        val (I, H) >> CJ.TRUE cz = jdg
-        val CJ.TRUE ty = lookupHyp H z
-        val Syn.BOOL = Syn.out ty
-
-        val tt = Syn.into Syn.TT
-        val ff = Syn.into Syn.FF
-
-        val (goalT, holeT) = makeGoal @@ (I, Hyps.modifyAfter z (CJ.map (substVar (tt, z))) H) >> CJ.TRUE (substVar (tt, z) cz)
-        val (goalF, holeF) = makeGoal @@ (I, Hyps.modifyAfter z (CJ.map (substVar (ff, z))) H) >> CJ.TRUE (substVar (ff, z) cz)
-
-        val psi = T.empty >: goalT >: goalF
-        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
-        val if_ = Syn.into @@ Syn.IF ((z, cz), ztm, (holeT, holeF))
-      in
-        psi #> (I, H, if_)
-      end
-      handle Bind =>
-        raise E.error [E.% "Expected bool elimination problem"]
-
-    fun ElimEq alpha jdg =
-      let
-        val _ = RedPrlLog.trace "Bool.ElimEq"
-        val (I, H) >> CJ.EQ ((if0, if1), c) = jdg
-        val Syn.IF ((x, c0x), m0, (t0, f0)) = Syn.out if0
-        val Syn.IF ((y, c1y), m1, (t1, f1)) = Syn.out if1
-
-        val z = alpha 0
-        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
-        val c0z = substVar (ztm, x) c0x
-        val c1z = substVar (ztm, y) c1y
-        val c0tt = substVar (Syn.into Syn.TT, x) c0x
-        val c0ff = substVar (Syn.into Syn.FF, x) c0x
-        val c0m0 = substVar (m0, x) c0x
-
-        val (goalTy, _) = makeGoal @@ (I, H @> (z, CJ.TRUE @@ Syn.into Syn.BOOL)) >> CJ.EQ_TYPE (c0z, c1z)
-        val (goalTy', _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (c0m0, c)
-        val (goalM, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), Syn.into Syn.BOOL)
-        val (goalT, _) = makeGoal @@ (I, H) >> CJ.EQ ((t0, t1), c0tt)
-        val (goalF, _) = makeGoal @@ (I, H) >> CJ.EQ ((f0, f1), c0ff)
-        val psi = T.empty >: goalTy >: goalM >: goalT >: goalF
-      in
-        psi #> (I, H, trivial)
-      end
-  end
-
-  structure StrictBool =
-  struct
-    fun EqType _ jdg =
-      let
-        val _ = RedPrlLog.trace "StrictBool.EqType"
-        val (I, H) >> CJ.EQ_TYPE (a, b) = jdg
-        val Syn.S_BOOL = Syn.out a
-        val Syn.S_BOOL = Syn.out b
-      in
-        T.empty #> (I, H, trivial)
-      end
-      handle Bind =>
-        raise E.error [E.% "Expected typehood sequent"]
-
-    fun EqTT _ jdg =
-      let
-        val _ = RedPrlLog.trace "StrictBool.EqTT"
-        val (I, H) >> CJ.EQ ((m, n), ty) = jdg
-        val Syn.S_BOOL = Syn.out ty
-        val Syn.TT = Syn.out m
-        val Syn.TT = Syn.out n
-      in
-        T.empty #> (I, H, trivial)
-      end
-
-    fun EqFF _ jdg =
-      let
-        val _ = RedPrlLog.trace "StrictBool.EqFF"
-        val (I, H) >> CJ.EQ ((m, n), ty) = jdg
-        val Syn.S_BOOL = Syn.out ty
-        val Syn.FF = Syn.out m
-        val Syn.FF = Syn.out n
-      in
-        T.empty #> (I, H, trivial)
-      end
-
-    fun Elim z _ jdg =
-      let
-        val _ = RedPrlLog.trace "StrictBool.Elim"
-        val (I, H) >> CJ.TRUE cz = jdg
-        val CJ.TRUE ty = lookupHyp H z
-        val Syn.S_BOOL = Syn.out ty
-
-        val tt = Syn.into Syn.TT
-        val ff = Syn.into Syn.FF
-
-        val (goalT, holeT) = makeGoal @@ (I, Hyps.modifyAfter z (CJ.map (substVar (tt, z))) H) >> CJ.TRUE (substVar (tt, z) cz)
-        val (goalF, holeF) = makeGoal @@ (I, Hyps.modifyAfter z (CJ.map (substVar (ff, z))) H) >> CJ.TRUE (substVar (ff, z) cz)
-
-        val psi = T.empty >: goalT >: goalF
-        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
-        val if_ = Syn.into @@ Syn.S_IF (ztm, (holeT, holeF))
-      in
-        psi #> (I, H, if_)
-      end
-      handle Bind =>
-        raise E.error [E.% "Expected strict bool elimination problem"]
-
-    fun ElimEq alpha jdg =
-      let
-        val _ = RedPrlLog.trace "StrictBool.ElimEq"
-        val (I, H) >> CJ.EQ ((if0, if1), c) = jdg
-        val Syn.S_IF (m0, (t0, f0)) = Syn.out if0
-        val Syn.S_IF (m1, (t1, f1)) = Syn.out if1
-
-        val (goalM, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), Syn.into Syn.S_BOOL)
-        val (goalT, _) = makeGoal @@ (I, H) >> CJ.EQ ((t0, t1), c)
-        val (goalF, _) = makeGoal @@ (I, H) >> CJ.EQ ((f0, f1), c)
-        val psi = T.empty >: goalM >: goalT >: goalF
-      in
-        psi #> (I, H, trivial)
-      end
-
-    fun EqElim z _ jdg =
-      let
-        val _ = RedPrlLog.trace "StrictBool.EqElim"
-        val (I, H) >> catjdg = jdg
-        val CJ.EQ ((m0z, m1z), cz) = catjdg
-
-        val CJ.TRUE ty = lookupHyp H z
-        val Syn.S_BOOL = Syn.out ty
-
-        val tt = Syn.into Syn.TT
-        val ff = Syn.into Syn.FF
-
-        val (goalM0, _) = makeGoal @@ (I, H) >> CJ.MEM (m0z, cz)
-        val (goalM1, _) = makeGoal @@ (I, H) >> CJ.MEM (m1z, cz)
-        val (goalT, _) = makeGoal @@ (I, Hyps.modifyAfter z (CJ.map (substVar (tt, z))) H) >> CJ.map (substVar (tt, z)) catjdg
-        val (goalF, _) = makeGoal @@ (I, Hyps.modifyAfter z (CJ.map (substVar (ff, z))) H) >> CJ.map (substVar (ff, z)) catjdg
-
-        val psi = T.empty >: goalM0 >: goalM1 >: goalT >: goalF
-      in
-        psi #> (I, H, trivial)
-      end
-      handle Bind =>
-        raise E.error [E.% "Expected strict bool elimination problem"]
-  end
-
-  structure DProd =
-  struct
-    fun EqType alpha jdg =
-      let
-        val _ = RedPrlLog.trace "DProd.EqType"
-        val (I, H) >> CJ.EQ_TYPE (dprod0, dprod1) = jdg
-        val Syn.DPROD (a0, x, b0x) = Syn.out dprod0
-        val Syn.DPROD (a1, y, b1y) = Syn.out dprod1
-
-        val z = alpha 0
-        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
-        val b0z = substVar (ztm, x) b0x
-        val b1z = substVar (ztm, y) b1y
-
-        val (goal1, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (a0, a1)
-        val (goal2, _) = makeGoal @@ (I, H @> (z, CJ.TRUE a0)) >> CJ.EQ_TYPE (b0z, b1z)
-      in
-        T.empty >: goal1 >: goal2
-          #> (I, H, trivial)
-      end
-      handle Bind =>
-        raise E.error [E.% "Expected dprod typehood sequent"]
-
-    fun Eq alpha jdg =
-      let
-        val _ = RedPrlLog.trace "DProd.Eq"
-        val (I, H) >> CJ.EQ ((pair0, pair1), dprod) = jdg
-        val Syn.PAIR (m0, n0) = Syn.out pair0
-        val Syn.PAIR (m1, n1) = Syn.out pair1
-        val Syn.DPROD (a, x, bx) = Syn.out dprod
-
-        val z = alpha 0
-        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
-        val bz = substVar (ztm, x) bx
-
-        val (goal1, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), a)
-        val (goal2, _) = makeGoal @@ (I, H) >> CJ.EQ ((n0, n1), substVar (m0, x) bx)
-        val (goalFam, _) = makeGoal @@ (I, H @> (z, CJ.TRUE a)) >> CJ.TYPE bz
-      in
-        T.empty >: goal1 >: goal2 >: goalFam
-          #> (I, H, trivial)
-      end
-
-    fun Eta alpha jdg =
-      let
-        val _ = RedPrlLog.trace "DProd.Eta"
-        val (I, H) >> CJ.EQ ((m, n), dprod) = jdg
-        val Syn.DPROD (a, x, bx) = Syn.out dprod
-
-        val m' = Syn.into @@ Syn.PAIR (Syn.into @@ Syn.FST m, Syn.into @@ Syn.SND m)
-        val (goal1, _) = makeGoal @@ (I, H) >> CJ.MEM (m, dprod)
-        val (goal2, _) = makeGoal @@ (I, H) >> CJ.EQ ((m', n), dprod)
-      in
-        T.empty >: goal1 >: goal2
-          #> (I, H, trivial)
-      end
-
-    fun FstEq alpha jdg =
-      let
-        val _ = RedPrlLog.trace "DProd.FstEq"
-        val (I, H) >> CJ.EQ ((fst0, fst1), ty) = jdg
-        val Syn.FST m0 = Syn.out fst0
-        val Syn.FST m1 = Syn.out fst1
-
-        val (goalTy, holeTy) = makeGoal @@ (I, H) >> CJ.SYNTH m0
-        val (goalTyA, holeTyA) = makeGoal @@ MATCH (O.MONO O.DPROD, 0, holeTy, [], [])
-        val (goalEq, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), holeTy)
-        val (goalEqTy, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (holeTyA, ty)
-      in
-        T.empty >: goalTy >: goalTyA >: goalEq >: goalEqTy
-          #> (I, H, trivial)
-      end
-
-    fun SndEq alpha jdg =
-      let
-        val _ = RedPrlLog.trace "DProd.SndEq"
-        val (I, H) >> CJ.EQ ((snd0, snd1), ty) = jdg
-        val Syn.SND m0 = Syn.out snd0
-        val Syn.SND m1 = Syn.out snd1
-
-        val (goalTy, holeTy) = makeGoal @@ (I, H) >> CJ.SYNTH m0
-        val (goalTyB, holeTyB) = makeGoal @@ MATCH (O.MONO O.DPROD, 1, holeTy, [], [Syn.into @@ Syn.FST m0])
-        val (goalEq, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), holeTy)
-        val (goalEqTy, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (holeTyB, ty)
-      in
-        T.empty >: goalTy >: goalTyB >: goalEq >: goalEqTy
-          #> (I, H, trivial)
-      end
-
-    fun True alpha jdg =
-      let
-        val _ = RedPrlLog.trace "DProd.True"
-        val (I, H) >> CJ.TRUE dprod = jdg
-        val Syn.DPROD (a, x, bx) = Syn.out dprod
-
-        val z = alpha 0
-        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
-        val bz = substVar (ztm, x) bx
-
-        val (goal1, hole1) = makeGoal @@ (I, H) >> CJ.TRUE a
-        val (goal2, hole2) = makeGoal @@ (I, H) >> CJ.TRUE (substVar (hole1, x) bx)
-        val (goalFam, _) = makeGoal @@ (I, H @> (z, CJ.TRUE a)) >> CJ.TYPE bz
-        val psi = T.empty >: goal1 >: goal2 >: goalFam
-        val pair = Syn.into @@ Syn.PAIR (hole1, hole2)
-      in
-        psi #> (I, H, pair)
-      end
-
-    fun Elim z alpha jdg =
-      let
-        val _ = RedPrlLog.trace "DProd.Elim"
-        val (I, H) >> CJ.TRUE cz = jdg
-        val CJ.TRUE dprod = Hyps.lookup H z
-        val Syn.DPROD (a, x, bx) = Syn.out dprod
-
-        val z1 = alpha 0
-        val z2 = alpha 1
-
-        val z1tm = Syn.into @@ Syn.VAR (z1, O.EXP)
-        val z2tm = Syn.into @@ Syn.VAR (z2, O.EXP)
-
-        val bz1 = substVar (z1tm, x) bx
-        val pair = Syn.into @@ Syn.PAIR (z1tm, z2tm)
-
-        val H' = Hyps.empty @> (z1, CJ.TRUE a) @> (z2, CJ.TRUE bz1)
-        val H'' = Hyps.interposeAfter H z H'
-
-        val (goal, hole) =
-          makeGoal
-            @@ (I, Hyps.modifyAfter z (CJ.map (substVar (pair, z))) H'')
-            >> CJ.TRUE (substVar (pair, z) cz)
-
-        val psi = T.empty >: goal
-
-        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
-        val fstz = Syn.into @@ Syn.FST ztm
-        val sndz = Syn.into @@ Syn.SND ztm
-        val rho = Var.Ctx.insert (Var.Ctx.insert Var.Ctx.empty z1 fstz) z2 sndz
-        val hole' = substVarenv rho hole
+        val (goal, hole) = makeGoal @@ (I, H) >> CJ.EQ ((n, m), ty)
       in
         T.empty >: goal
-          #> (I, H, hole')
+          #> (I, H, trivial)
       end
   end
 
-  structure DFun =
+  structure Coe =
   struct
-    fun EqType alpha jdg =
-      let
-        val _ = RedPrlLog.trace "DFun.EqType"
-        val (I, H) >> CJ.EQ_TYPE (dfun0, dfun1) = jdg
-        val Syn.DFUN (a0, x, b0x) = Syn.out dfun0
-        val Syn.DFUN (a1, y, b1y) = Syn.out dfun1
-
-        val z = alpha 0
-        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
-        val b0z = substVar (ztm, x) b0x
-        val b1z = substVar (ztm, y) b1y
-
-        val (goal1, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (a0, a1)
-        val (goal2, _) = makeGoal @@ (I, H @> (z, CJ.TRUE a0)) >> CJ.EQ_TYPE (b0z, b1z)
-      in
-        T.empty >: goal1 >: goal2
-          #> (I, H, trivial)
-      end
-      handle Bind =>
-        raise E.error [E.% "Expected dfun typehood sequent"]
-
     fun Eq alpha jdg =
       let
-        val _ = RedPrlLog.trace "DFun.Eq"
-        val (I, H) >> CJ.EQ ((lam0, lam1), dfun) = jdg
-        val Syn.LAM (x, m0x) = Syn.out lam0
-        val Syn.LAM (y, m1y) = Syn.out lam1
-        val Syn.DFUN (a, z, bz) = Syn.out dfun
+        val _ = RedPrlLog.trace "Coe.Eq"
+        val (I, H) >> CJ.EQ ((lhs, rhs), ty) = jdg
+        val Syn.COE {dir=(r0, r'0), ty=(u, ty0u), coercee=m0} = Syn.out lhs
+        val Syn.COE {dir=(r1, r'1), ty=(v, ty1v), coercee=m1} = Syn.out rhs
+        val () = assertParamEq "Coe.Eq source of direction" (r0, r1)
+        val () = assertParamEq "Coe.Eq target of direction" (r'0, r'1)
+
+        val ty01 = substSymbol (r'0, u) ty0u
+        val (goalTy1, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (ty01, ty)
 
         val w = alpha 0
-        val wtm = Syn.into @@ Syn.VAR (w, O.EXP)
+        val ty0w = substSymbol (P.ret w, u) ty0u
+        val ty1w = substSymbol (P.ret w, v) ty1v
+        val (goalTy, _) = makeGoal @@ (I @ [(w, P.DIM)], H) >> CJ.EQ_TYPE (ty0w, ty1w)
 
-        val m0w = substVar (wtm, x) m0x
-        val m1w = substVar (wtm, y) m1y
-        val bw = substVar (wtm, z) bz
-
-        val (goal1, _) = makeGoal @@ (I, H @> (w, CJ.TRUE a)) >> CJ.EQ ((m0w, m1w), bw)
-        val (goal2, _) = makeGoal @@ (I, H) >> CJ.TYPE a
+        val ty00 = substSymbol (r0, u) ty0u
+        val (goalCoercees, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), ty00)
       in
-        T.empty >: goal1 >: goal2
-          #> (I, H, trivial)
+        T.empty >: goalTy1 >: goalTy >: goalCoercees #> (I, H, trivial)
       end
 
-    fun True alpha jdg =
+    fun CapEqL alpha jdg =
       let
-        val _ = RedPrlLog.trace "DFun.True"
-        val (I, H) >> CJ.TRUE dfun = jdg
-        val Syn.DFUN (a, x, bx) = Syn.out dfun
+        val _ = RedPrlLog.trace "Coe.CapEq"
+        val (I, H) >> CJ.EQ ((coe, other), ty) = jdg
+        val Syn.COE {dir=(r, r'), ty=(u, tyu), coercee=m} = Syn.out coe
+        val () = assertParamEq "Coe.CapEq source and target of direction" (r, r')
 
-        val z = alpha 0
-        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
-        val bz = substVar (ztm, x) bx
+        val ty0 = substSymbol (r, u) tyu
+        val (goalTy0, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (ty0, ty)
 
-        val (tyGoal, _) = makeGoal @@ (I, H) >> CJ.TYPE a
-        val (goal, hole) = makeGoal @@ (I, H @> (z, CJ.TRUE a)) >> CJ.TRUE bz
-
-        val psi = T.empty >: goal >: tyGoal
-        val lam = Syn.into @@ Syn.LAM (z, substVar (ztm, z) hole)
+        val (goalTy, _) = makeGoal @@ (I @ [(u, P.DIM)], H) >> CJ.TYPE tyu
+        val (goalEq, _) = makeGoal @@ (I, H) >> CJ.EQ ((m, other), ty)
       in
-        psi #> (I, H, lam)
-      end
-      handle Bind =>
-        raise E.error [E.% "Expected dfun truth sequent"]
-
-    fun Eta alpha jdg =
-      let
-        val _ = RedPrlLog.trace "DFun.Eta"
-        val (I, H) >> CJ.EQ ((m, n), dfun) = jdg
-        val Syn.DFUN (a, x, bx) = Syn.out dfun
-
-        val xtm = Syn.into @@ Syn.VAR (x, O.EXP)
-        val m' = Syn.into @@ Syn.LAM (x, Syn.into @@ Syn.AP (m, xtm))
-        val (goal1, _) = makeGoal @@ (I, H) >> CJ.MEM (m, dfun)
-        val (goal2, _) = makeGoal @@ (I, H) >> CJ.EQ ((m', n), dfun)
-      in
-        T.empty >: goal1 >: goal2
-          #> (I, H, trivial)
+        T.empty >: goalTy0 >: goalTy >: goalEq #> (I, H, trivial)
       end
 
-    fun Elim z alpha jdg =
-      let
-        val _ = RedPrlLog.trace "DFun.Elim"
-        val (I, H) >> CJ.TRUE cz = jdg
-        val CJ.TRUE dfun = Hyps.lookup H z
-        val Syn.DFUN (a, x, bx) = Syn.out dfun
-        val (goal1, hole1) = makeGoal @@ (I, H) >> CJ.TRUE a
+    fun CapEqR alpha = catJdgFlipWrapper CapEqL alpha
 
-        val u = alpha 0
-        val v = alpha 1
-
-        val b' = substVar (hole1, x) bx
-
-        val utm = Syn.into @@ Syn.VAR (u, O.EXP)
-        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
-        val aptm = Syn.into @@ Syn.AP (ztm, hole1)
-        val H' = Hyps.empty @> (u, CJ.TRUE b') @> (v, CJ.EQ ((utm, aptm), b'))
-        val H'' = Hyps.interposeAfter H z H'
-
-        val (goal2, hole2) = makeGoal @@ (I, H'') >> CJ.TRUE cz
-
-        val psi = T.empty >: goal1 >: goal2
-        val aptm = Syn.into @@ Syn.AP (ztm, hole1)
-        val rho = Var.Ctx.insert (Var.Ctx.insert Var.Ctx.empty u aptm) v (Syn.into Syn.AX)
-        val hole2' = substVarenv rho hole2
-      in
-        psi #> (I, H, hole2')
-      end
-
-    fun ApEq alpha jdg =
-      let
-        val _ = RedPrlLog.trace "DFun.ApEq"
-        val (I, H) >> CJ.EQ ((ap0, ap1), c) = jdg
-        val Syn.AP (m0, n0) = Syn.out ap0
-        val Syn.AP (m1, n1) = Syn.out ap1
-
-        val (goalDFun0, holeDFun0) = makeGoal @@ (I, H) >> CJ.SYNTH m0
-        val (goalDFun1, holeDFun1) = makeGoal @@ (I, H) >> CJ.SYNTH m1
-        val (goalDFunEq, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (holeDFun0, holeDFun1)
-        val (goalDom, holeDom) = makeGoal @@ MATCH (O.MONO O.DFUN, 0, holeDFun0, [], [])
-        val (goalM, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), holeDFun0)
-        val (goalN, _) = makeGoal @@ (I, H) >> CJ.EQ ((n0, n1), holeDom)
-      in
-        T.empty >: goalDFun0 >: goalDFun1 >: goalDFunEq >: goalDom >: goalM >: goalN
-          #> (I, H, trivial)
-      end
-  end
-
-  structure Path =
-  struct
-    fun EqType alpha jdg =
-      let
-        val _ = RedPrlLog.trace "Path.EqType"
-        val (I, H) >> CJ.EQ_TYPE (ty0, ty1) = jdg
-        val Syn.PATH_TY ((u, a0u), m0, n0) = Syn.out ty0
-        val Syn.PATH_TY ((v, a1v), m1, n1) = Syn.out ty1
-
-        val a1u = substSymbol (P.ret u, v) a1v
-
-        val a00 = substSymbol (P.APP P.DIM0, u) a0u
-        val a01 = substSymbol (P.APP P.DIM1, u) a0u
-
-        val (tyGoal, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (a0u, a1u)
-        val (goal0, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), a00)
-        val (goal1, _) = makeGoal @@ (I, H) >> CJ.EQ ((n0, n1), a01)
-      in
-        T.empty >: tyGoal >: goal0 >: goal1
-          #> (I, H, trivial)
-      end
-
-    fun True alpha jdg =
-      let
-        val _ = RedPrlLog.trace "Path.True"
-        val (I, H) >> CJ.TRUE ty = jdg
-        val Syn.PATH_TY ((u, a), p0, p1) = Syn.out ty
-        val a0 = substSymbol (P.APP P.DIM0, u) a
-        val a1 = substSymbol (P.APP P.DIM1, u) a
-
-        val v = alpha 0
-
-        val (mainGoal, mhole) = makeGoal @@ (I @ [(v, P.DIM)], H) >> CJ.TRUE (substSymbol (P.ret v, u) a)
-
-        val m0 = substSymbol (P.APP P.DIM0, v) mhole
-        val m1 = substSymbol (P.APP P.DIM1, v) mhole
-        val (cohGoal0, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, p0), a0)
-        val (cohGoal1, _) = makeGoal @@ (I, H) >> CJ.EQ ((m1, p1), a1)
-
-        val psi = T.empty >: mainGoal >: cohGoal0 >: cohGoal1
-        val abstr = Syn.into @@ Syn.PATH_ABS (v, mhole)
-      in
-        psi #> (I, H, abstr)
-      end
-
-    fun Eq alpha jdg =
-      let
-        val _ = RedPrlLog.trace "Path.Eq"
-        val (I, H) >> CJ.EQ ((abs0, abs1), ty) = jdg
-        val Syn.PATH_TY ((u, au), p0, p1) = Syn.out ty
-        val Syn.PATH_ABS (v, m0v) = Syn.out abs0
-        val Syn.PATH_ABS (w, m1w) = Syn.out abs1
-
-        val z = alpha 0
-        val az = substSymbol (P.ret z, u) au
-        val m0z = substSymbol (P.ret z, v) m0v
-        val m1z = substSymbol (P.ret z, w) m1w
-
-        val a0 = substSymbol (P.APP P.DIM0, u) au
-        val a1 = substSymbol (P.APP P.DIM1, u) au
-        val m00 = substSymbol (P.APP P.DIM0, v) m0v
-        val m01 = substSymbol (P.APP P.DIM1, v) m0v
-
-        val (goalM, _) = makeGoal @@ (I @ [(z, P.DIM)], H) >> CJ.EQ ((m0z, m1z), az)
-        val (goalM00, _) = makeGoal @@ (I, H) >> CJ.EQ ((m00, p0), a0)
-        val (goalM01, _) = makeGoal @@ (I, H) >> CJ.EQ ((m01, p1), a1)
-      in
-        T.empty >: goalM >: goalM00 >: goalM01
-          #> (I, H, trivial)
-      end
-
-    fun ApEq alpha jdg =
-      let
-        val _ = RedPrlLog.trace "Path.ApEq"
-        val (I, H) >> CJ.EQ ((ap0, ap1), ty) = jdg
-        val Syn.PATH_AP (m0, r0) = Syn.out ap0
-        val Syn.PATH_AP (m1, r1) = Syn.out ap1
-        val () = assertParamEq "Path.ApEq" (r0, r1)
-        val (goalSynth, holeSynth) = makeGoal @@ (I, H) >> CJ.SYNTH m0
-        val (goalMem, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), holeSynth)
-        val (goalLine, holeLine) = makeGoal @@ MATCH (O.MONO O.PATH_TY, 0, holeSynth, [r0], [])
-        val (goalTy, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (ty, holeLine)
-      in
-        T.empty >: goalSynth >: goalMem >: goalLine >: goalTy
-          #> (I, H, trivial)
-      end
-
-    fun ApConstCompute alpha jdg =
-      let
-        val _ = RedPrlLog.trace "Path.ApConstCompute"
-        val (I, H) >> CJ.EQ ((ap, p), a) = jdg
-        val Syn.PATH_AP (m, P.APP r) = Syn.out ap
-        val (goalSynth, holeSynth) = makeGoal @@ (I, H) >> CJ.SYNTH m
-
-        val dimAddr = case r of P.DIM0 => 1 | P.DIM1 => 2
-        val (goalLine, holeLine) = makeGoal @@ MATCH (O.MONO O.PATH_TY, 0, holeSynth, [P.APP r], [])
-        val (goalEndpoint, holeEndpoint) = makeGoal @@ MATCH (O.MONO O.PATH_TY, dimAddr, holeSynth, [], [])
-        val (goalTy, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (a, holeLine)
-        val (goalEq, _) = makeGoal @@ (I, H) >> CJ.EQ ((holeEndpoint, p), a)
-      in
-        T.empty >: goalSynth >: goalLine >: goalEndpoint >: goalTy >: goalEq
-          #> (I, H, trivial)
-      end
-
-    fun Eta alpha jdg =
-      let
-        val _ = RedPrlLog.trace "Path.Eta"
-        val (I, H) >> CJ.EQ ((m, n), pathTy) = jdg
-        val Syn.PATH_TY ((u, a), p0, p1) = Syn.out pathTy
-
-        val m' = Syn.into @@ Syn.PATH_ABS (u, Syn.into @@ Syn.PATH_AP (m, P.ret u))
-        val (goal1, _) = makeGoal @@ (I, H) >> CJ.MEM (m, pathTy)
-        val (goal2, _) = makeGoal @@ (I, H) >> CJ.EQ ((m', n), pathTy)
-      in
-        T.empty >: goal1 >: goal2
-          #> (I, H, trivial)
-      end
-
+    (* Try all the fcom rules.
+     * Note that the EQ rule is invertible only when the cap rule fails. *)
+    val AutoEqLR = CapEqL orelse_ CapEqR orelse_ Eq
+    val AutoEqL = CapEqL orelse_ Eq
+    val AutoEqR = CapEqR orelse_ Eq
   end
 
   structure Hyp =
@@ -799,7 +155,7 @@ struct
   struct
     fun FromWfHyp z alpha jdg =
       let
-        val _ = RedPrlLog.trace "Synth.Switch"
+        val _ = RedPrlLog.trace "Synth.FromWfHyp"
         val (I, H) >> CJ.SYNTH tm = jdg
         val CJ.EQ ((a, b), ty) = Hyps.lookup H z
       in
@@ -819,18 +175,17 @@ struct
         T.empty #> (I, H, a)
       end
 
-    fun Ap alpha jdg =
+    fun If alpha jdg =
       let
-        val _ = RedPrlLog.trace "Synth.Ap"
+        val _ = RedPrlLog.trace "Synth.If"
         val (I, H) >> CJ.SYNTH tm = jdg
-        val Syn.AP (m, n) = Syn.out tm
-        val (goalDFun, holeDFun) = makeGoal @@ (I, H) >> CJ.SYNTH m
-        val (goalDom, holeDom) = makeGoal @@ MATCH (O.MONO O.DFUN, 0, holeDFun, [], [])
-        val (goalCod, holeCod) = makeGoal @@ MATCH (O.MONO O.DFUN, 1, holeDFun, [], [n])
-        val (goalN, _) = makeGoal @@ (I, H) >> CJ.MEM (n, holeDom)
+        val Syn.IF ((x,cx), m, _) = Syn.out tm
+
+        val cm = substVar (m, x) cx
+        val (goal, _) = makeGoal @@ (I, H) >> CJ.MEM (tm, cm)
       in
-        T.empty >: goalDFun >: goalDom >: goalCod >: goalN
-          #> (I, H, holeCod)
+        T.empty >: goal
+          #> (I, H, cm)
       end
 
     fun S1Elim alpha jdg =
@@ -846,17 +201,18 @@ struct
           #> (I, H, cm)
       end
 
-    fun If alpha jdg =
+    fun Ap alpha jdg =
       let
-        val _ = RedPrlLog.trace "Synth.If"
+        val _ = RedPrlLog.trace "Synth.Ap"
         val (I, H) >> CJ.SYNTH tm = jdg
-        val Syn.IF ((x,cx), m, _) = Syn.out tm
-
-        val cm = substVar (m, x) cx
-        val (goal, _) = makeGoal @@ (I, H) >> CJ.MEM (tm, cm)
+        val Syn.AP (m, n) = Syn.out tm
+        val (goalDFun, holeDFun) = makeGoal @@ (I, H) >> CJ.SYNTH m
+        val (goalDom, holeDom) = makeGoal @@ MATCH (O.MONO O.DFUN, 0, holeDFun, [], [])
+        val (goalCod, holeCod) = makeGoal @@ MATCH (O.MONO O.DFUN, 1, holeDFun, [], [n])
+        val (goalN, _) = makeGoal @@ (I, H) >> CJ.MEM (n, holeDom)
       in
-        T.empty >: goal
-          #> (I, H, cm)
+        T.empty >: goalDFun >: goalDom >: goalCod >: goalN
+          #> (I, H, holeCod)
       end
 
     fun PathAp alpha jdg =
@@ -1002,7 +358,7 @@ struct
         T.empty >: goalTy0 >: goalTy >: goalEq #> (I, H, trivial)
       end
 
-    val CapEqR = catJdgFlipWrapper CapEqL
+    fun CapEqR alpha = catJdgFlipWrapper CapEqL alpha
 
     (* Try all the fcom rules.
      * Note that the EQ rule is invertible only when the cap rule fails. *)

--- a/src/redprl/refiner_composition_kit.fun
+++ b/src/redprl/refiner_composition_kit.fun
@@ -1,0 +1,214 @@
+functor RefinerCompositionKit (Sig : MINI_SIGNATURE) =
+struct
+  structure Kit = RefinerKit (Sig)
+  open RedPrlAbt Kit
+
+  type sign = Sig.sign
+  type rule = (int -> Sym.t) -> Lcf.jdg Lcf.tactic
+  type catjdg = abt CJ.jdg
+  type opid = Sig.opid
+
+  infixr @@
+  infix 1 || #>
+  infix 2 >> >: >:+ $$ $# // \ @>
+  infix orelse_
+
+  structure Restriction :
+  sig
+    (* This structure used to provide functions that automate the
+       restriction judgement rules given in "Dependent Cubical
+       Realizability", page 46.
+
+       On 2017/06/14, favonia implemented a function to handle
+       all cases. We need to generalize the old handling to
+       welcome new hcom operators. (It is true that we still
+       only need to handle context restrictions with at most two
+       equations, but it seems easier to just handle all cases.)
+
+       Such automation is possible because the rules are "syntax
+       directed" on the restriction being performed.
+     *)
+
+    (* Restrict a judgement (as the goal) by a list of equations.
+     * Returns NONE if the resulting judgement is vacuously true.
+     *)
+    val restrict : abt jdg -> (param * param) list -> abt jdg option
+  end
+  =
+  struct
+    (* A helper function which does substitution in a parameter. *)
+    fun substSymInParam (r, v) = P.bind (fn u => if Sym.eq (u, v) then r else P.ret u)
+
+    fun restrict jdg [] = SOME jdg
+      | restrict jdg ((P.APP d1, P.APP d2) :: eqs) =
+          (* The following line is correct because we only have constants
+           * (DIM0 and DIM1). If in the future we want to have connections
+           * or other stuff, then a real unification algorithm might be needed.
+           *)
+          if P.Sig.eq (fn _ => true) (d1, d2) then restrict jdg eqs else NONE
+      | restrict jdg ((r1 as P.VAR v1, r2) :: eqs) =
+          if P.eq Sym.eq (r1, r2) then restrict jdg eqs else substAndRestrict (r2, v1) jdg eqs
+      | restrict jdg ((r1, r2 as P.VAR v2) :: eqs) =
+          substAndRestrict (r1, v2) jdg eqs
+
+    and substAndRestrict rv jdg eqs = restrict
+          (Seq.map (substSymbol rv) jdg)
+          (List.map (fn (r, r') => (substSymInParam rv r, substSymInParam rv r')) eqs)
+  end
+
+  (* code shared by Com, HCom and FCom. *)
+  structure ComKit =
+  struct
+    (* todo: optimizing the restriction process even further. *)
+    (* todo: pre-restrict r=0, r=1, 0=r and 1=r, and open-reduce everything first. *)
+    (* todo: do alpha-renaming only once. *)
+    (* todo: try to reduce substitution. *)
+
+    (* Produce the list of goals requiring that tube aspects agree with each other.
+         forall i <= j.
+           N_i = P_j in A [Psi, y | r_i = r_i', r_j = r_j']
+     *)
+    fun genInterTubeGoals (I, H) w ty tubes0 tubes1 =
+      let
+        fun interTube (eq0, (u, tube0)) (eq1, (v, tube1)) =
+          let
+            val tube0 = substSymbol (P.ret w, u) tube0
+            val tube1 = substSymbol (P.ret w, v) tube1
+            val J = (I, H) >> CJ.EQ ((tube0, tube1), ty)
+          in
+            Option.map 
+              (fn (I, J) >> jdg => #1 (makeGoal @@ (I @ [(w,P.DIM)], H) >> jdg))
+              (Restriction.restrict J [eq0, eq1])
+          end
+        fun goTubePairs [] [] = []
+          | goTubePairs (t0 :: ts0) (t1 :: ts1) =
+              List.mapPartial (interTube t0) (t1 :: ts1) :: goTubePairs ts0 ts1
+          | goTubePairs _ _ = raise
+              E.error [E.% "interTubeGoals: the tubes are of different lengths"]
+      in
+        List.concat (goTubePairs tubes0 tubes1)
+      end
+
+    (* Produce the list of goals requiring that tube aspects agree with the cap.
+         forall i.
+           N_i<r/y> = M in A [Psi | r_i = r_i']
+     *)
+    fun genTubeCapGoals (I, H) ty r cap tubes =
+      let
+        fun tubeCap (eq, (u, tube)) =
+          let
+            val J = (I, H) >> CJ.EQ ((substSymbol (r,u) tube, cap), ty)
+          in
+            Option.map (#1 o (fn j => makeGoal @@ j)) (Restriction.restrict J [eq])
+          end
+      in
+        List.mapPartial tubeCap tubes
+      end
+
+    (* Note that this does not check whether the 'ty' is a base type.
+     * It's caller's responsibility to check whether the type 'ty'
+     * recognizes FCOM as values. *)
+    fun EqFComDelegator alpha (I, H) args0 args1 ty =
+      let
+        val {dir=(r0, r'0), cap=cap0, tubes=tubes0} = args0
+        val {dir=(r1, r'1), cap=cap1, tubes=tubes1} = args1
+        val () = assertParamEq "genFcomGoals source of direction" (r0, r1)
+        val () = assertParamEq "genFcomGoals target of direction" (r'0, r'1)
+        val eqs0 = List.map #1 tubes0
+        val eqs1 = List.map #1 tubes1
+        val _ = ListPair.mapEq (assertEquationEq "genFcomGoals equations") (eqs0, eqs1)
+        val _ = assertTautologicalEquations "genFcomGoals tautology checking" eqs0
+
+        val (goalCap, _) = makeGoal @@ (I, H) >> CJ.EQ ((cap0, cap1), ty)
+
+        val w = alpha 0
+      in
+        T.empty
+          >: goalCap
+          >:+ genInterTubeGoals (I, H) w ty tubes0 tubes1
+          >:+ genTubeCapGoals (I, H) ty r0 cap0 tubes0
+        #> (I, H, trivial)
+      end
+  end
+
+  structure HCom =
+  struct
+    fun Eq alpha jdg =
+      let
+        val _ = RedPrlLog.trace "HCom.Eq"
+        val (I, H) >> CJ.EQ ((lhs, rhs), ty) = jdg
+        val Syn.HCOM {dir=(r0, r'0), ty=ty0, cap=cap0, tubes=tubes0} = Syn.out lhs
+        val () = assertAlphaEq (ty0, ty)
+        val Syn.HCOM {dir=(r1, r'1), ty=ty1, cap=cap1, tubes=tubes1} = Syn.out rhs
+        val () = assertParamEq "HCom.Eq source of direction" (r0, r1)
+        val () = assertParamEq "HCom.Eq target of direction" (r'0, r'1)
+        val eqs0 = List.map #1 tubes0
+        val eqs1 = List.map #1 tubes1
+        val _ = ListPair.mapEq (assertEquationEq "HCom.Eq equations") (eqs0, eqs1)
+        val _ = assertTautologicalEquations "HCom.Eq tautology checking" eqs0
+
+        val (goalTy, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (ty0, ty1)
+        val (goalCap, _) = makeGoal @@ (I, H) >> CJ.EQ ((cap0, cap1), ty)
+
+        val w = alpha 0
+      in
+        T.empty
+          >: goalTy >: goalCap
+          >:+ ComKit.genInterTubeGoals (I, H) w ty tubes0 tubes1
+          >:+ ComKit.genTubeCapGoals (I, H) ty r0 cap0 tubes0
+        #> (I, H, trivial)
+      end
+
+    fun CapEqL alpha jdg =
+      let
+        val _ = RedPrlLog.trace "HCom.CapEq"
+        val (I, H) >> CJ.EQ ((hcom, other), ty) = jdg
+        val Syn.HCOM {dir=(r, r'), ty=ty0, cap, tubes} = Syn.out hcom
+        val () = assertParamEq "HCom.CapEq source and target of direction" (r, r')
+        val () = assertAlphaEq (ty0, ty)
+  
+        val (goalTy, _) = makeGoal @@ (I, H) >> CJ.TYPE ty
+        val (goalEq, _) = makeGoal @@ (I, H) >> CJ.EQ ((cap, other), ty)
+  
+        val w = alpha 0
+      in
+        T.empty
+          >: goalTy >: goalEq
+          >:+ ComKit.genInterTubeGoals (I, H) w ty tubes tubes
+          >:+ ComKit.genTubeCapGoals (I, H) ty r cap tubes
+        #> (I, H, trivial)
+      end
+
+    val CapEqR = catJdgFlipWrapper CapEqL
+
+    (* Search for the first satisfied equation in an hcom. *)
+    fun TubeEqL alpha jdg =
+      let
+        val _ = RedPrlLog.trace "HCom.TubeEq"
+        val (I, H) >> CJ.EQ ((hcom, other), ty) = jdg
+        val Syn.HCOM {dir=(r, r'), ty=ty0, cap, tubes} = Syn.out hcom
+        val (eq, (u, tube)) = Option.valOf (List.find (fn (eq, _) => P.eq Sym.eq eq) tubes)
+        val () = assertAlphaEq (ty0, ty)
+  
+        val (goalTy, _) = makeGoal @@ (I, H) >> CJ.TYPE ty
+        val (goalCap, _) = makeGoal @@ (I, H) >> CJ.MEM (cap, ty)
+        val (goalEq, _) = makeGoal @@ (I, H) >> CJ.EQ ((substSymbol (r', u) tube, other), ty)
+  
+        val w = alpha 0
+      in
+        T.empty
+          >: goalTy >: goalCap >: goalEq
+          >:+ ComKit.genInterTubeGoals (I, H) w ty tubes tubes
+          >:+ ComKit.genTubeCapGoals (I, H) ty r cap tubes
+        #> (I, H, trivial)
+      end
+
+    val TubeEqR = catJdgFlipWrapper TubeEqL
+
+    (* Try all the hcom rules.
+     * Note that the EQ rule is invertible only when the cap and tube rules fail. *)
+    val AutoEqLR = CapEqL orelse_ CapEqR orelse_ TubeEqL orelse_ TubeEqR orelse_ Eq
+    val AutoEqL = CapEqL orelse_ TubeEqL orelse_ Eq
+    val AutoEqR = CapEqR orelse_ TubeEqR orelse_ Eq
+  end
+end

--- a/src/redprl/refiner_kit.fun
+++ b/src/redprl/refiner_kit.fun
@@ -31,14 +31,30 @@ struct
       end
   end
 
+  fun abstractEvidence (I : (sym * psort) list, H) m =
+    let
+      val (us, sigmas) = ListPair.unzip I
+      val (xs, taus) = Hyps.foldr (fn (x, jdg, (xs, taus)) => (x::xs, CJ.synthesis jdg::taus)) ([],[]) H
+    in
+      Abt.checkb (Abt.\ ((us, xs), m), ((sigmas, taus), Abt.sort m))
+    end
+
+  fun #> (psi, (I, H, m)) =
+    Lcf.|> (psi, abstractEvidence (I, H) m)
+  infix #>
+
+  val trivial = Syn.into Syn.AX
+
+  fun orelse_ (t1, t2) alpha = Lcf.orelse_ (t1 alpha, t2 alpha)
+  infix orelse_
 
   fun >:+ (tel, (l : (label * 'a) list)) : 'a telescope =
     List.foldl (fn (g, t) => t >: g) tel l
   infix 5 >:+
 
+  (* this is a hack till we have a nice way to pre-compose Equality.Symmetry *)
   fun catJdgFlip (CJ.EQ_TYPE (a, b)) = CJ.EQ_TYPE (b, a)
     | catJdgFlip (CJ.EQ ((a, b), ty)) = CJ.EQ ((b, a), ty)
-
   fun catJdgFlipWrapper tactic alpha (IH >> jdg) =
     tactic alpha (IH >> catJdgFlip jdg)
 

--- a/src/redprl/refiner_kit.fun
+++ b/src/redprl/refiner_kit.fun
@@ -32,8 +32,15 @@ struct
   end
 
 
-  fun appendListOfGoals (tel, (l : (label * 'a) list)) : 'a telescope =
-    List.foldl (fn (g, l) => l >: g) tel l
+  fun >:+ (tel, (l : (label * 'a) list)) : 'a telescope =
+    List.foldl (fn (g, t) => t >: g) tel l
+  infix 5 >:+
+
+  fun catJdgFlip (CJ.EQ_TYPE (a, b)) = CJ.EQ_TYPE (b, a)
+    | catJdgFlip (CJ.EQ ((a, b), ty)) = CJ.EQ ((b, a), ty)
+
+  fun catJdgFlipWrapper tactic alpha (IH >> jdg) =
+    tactic alpha (IH >> catJdgFlip jdg)
 
   fun hypsToSpine H =
     Hyps.foldr (fn (x, jdg, r) => Abt.check (Abt.`x, CJ.synthesis jdg) :: r) [] H

--- a/src/redprl/refiner_types.fun
+++ b/src/redprl/refiner_types.fun
@@ -1,0 +1,922 @@
+(* type-specific modules *)
+functor RefinerTypeRules (Sig : MINI_SIGNATURE) =
+struct
+  structure Kit = RefinerKit (Sig)
+  structure ComRefinerKit = RefinerCompositionKit (Sig)
+  open RedPrlAbt Kit ComRefinerKit
+
+  type sign = Sig.sign
+  type rule = (int -> Sym.t) -> Lcf.jdg Lcf.tactic
+  type catjdg = abt CJ.jdg
+  type opid = Sig.opid
+
+  infixr @@
+  infix 1 || #>
+  infix 2 >> >: >:+ $$ $# // \ @>
+  infix orelse_
+
+  structure Bool =
+  struct
+    fun EqType _ jdg =
+      let
+        val _ = RedPrlLog.trace "Bool.EqType"
+        val (I, H) >> CJ.EQ_TYPE (a, b) = jdg
+        val Syn.BOOL = Syn.out a
+        val Syn.BOOL = Syn.out b
+      in
+        T.empty #> (I, H, trivial)
+      end
+      handle Bind =>
+        raise E.error [E.% "Expected typehood sequent"]
+
+    fun EqTT _ jdg =
+      let
+        val _ = RedPrlLog.trace "Bool.EqTT"
+        val (I, H) >> CJ.EQ ((m, n), ty) = jdg
+        val Syn.BOOL = Syn.out ty
+        val Syn.TT = Syn.out m
+        val Syn.TT = Syn.out n
+      in
+        T.empty #> (I, H, trivial)
+      end
+
+    fun EqFF _ jdg =
+      let
+        val _ = RedPrlLog.trace "Bool.EqFF"
+        val (I, H) >> CJ.EQ ((m, n), ty) = jdg
+        val Syn.BOOL = Syn.out ty
+        val Syn.FF = Syn.out m
+        val Syn.FF = Syn.out n
+      in
+        T.empty #> (I, H, trivial)
+      end
+
+    fun EqFCom alpha jdg =
+      let
+        val _ = RedPrlLog.trace "EqFCom"
+        val (I, H) >> CJ.EQ ((lhs, rhs), ty) = jdg
+        val Syn.BOOL = Syn.out ty
+        val Syn.FCOM args0 = Syn.out lhs
+        val Syn.FCOM args1 = Syn.out rhs
+      in
+        ComKit.EqFComDelegator alpha (I, H) args0 args1 ty
+      end
+
+    fun Elim z _ jdg =
+      let
+        val _ = RedPrlLog.trace "Bool.Elim"
+        val (I, H) >> CJ.TRUE cz = jdg
+        val CJ.TRUE ty = lookupHyp H z
+        val Syn.BOOL = Syn.out ty
+
+        val tt = Syn.into Syn.TT
+        val ff = Syn.into Syn.FF
+
+        val (goalT, holeT) = makeGoal @@ (I, Hyps.modifyAfter z (CJ.map (substVar (tt, z))) H) >> CJ.TRUE (substVar (tt, z) cz)
+        val (goalF, holeF) = makeGoal @@ (I, Hyps.modifyAfter z (CJ.map (substVar (ff, z))) H) >> CJ.TRUE (substVar (ff, z) cz)
+
+        val psi = T.empty >: goalT >: goalF
+        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
+        val if_ = Syn.into @@ Syn.IF ((z, cz), ztm, (holeT, holeF))
+      in
+        psi #> (I, H, if_)
+      end
+      handle Bind =>
+        raise E.error [E.% "Expected bool elimination problem"]
+
+    fun ElimEq alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Bool.ElimEq"
+        val (I, H) >> CJ.EQ ((if0, if1), c) = jdg
+        val Syn.IF ((x, c0x), m0, (t0, f0)) = Syn.out if0
+        val Syn.IF ((y, c1y), m1, (t1, f1)) = Syn.out if1
+
+        val z = alpha 0
+        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
+        val c0z = substVar (ztm, x) c0x
+        val c1z = substVar (ztm, y) c1y
+        val c0tt = substVar (Syn.into Syn.TT, x) c0x
+        val c0ff = substVar (Syn.into Syn.FF, x) c0x
+        val c0m0 = substVar (m0, x) c0x
+
+        val (goalTy, _) = makeGoal @@ (I, H @> (z, CJ.TRUE @@ Syn.into Syn.BOOL)) >> CJ.EQ_TYPE (c0z, c1z)
+        val (goalTy', _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (c0m0, c)
+        val (goalM, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), Syn.into Syn.BOOL)
+        val (goalT, _) = makeGoal @@ (I, H) >> CJ.EQ ((t0, t1), c0tt)
+        val (goalF, _) = makeGoal @@ (I, H) >> CJ.EQ ((f0, f1), c0ff)
+        val psi = T.empty >: goalTy >: goalM >: goalT >: goalF
+      in
+        psi #> (I, H, trivial)
+      end
+  end
+
+  structure StrictBool =
+  struct
+    fun EqType _ jdg =
+      let
+        val _ = RedPrlLog.trace "StrictBool.EqType"
+        val (I, H) >> CJ.EQ_TYPE (a, b) = jdg
+        val Syn.S_BOOL = Syn.out a
+        val Syn.S_BOOL = Syn.out b
+      in
+        T.empty #> (I, H, trivial)
+      end
+      handle Bind =>
+        raise E.error [E.% "Expected typehood sequent"]
+
+    fun EqTT _ jdg =
+      let
+        val _ = RedPrlLog.trace "StrictBool.EqTT"
+        val (I, H) >> CJ.EQ ((m, n), ty) = jdg
+        val Syn.S_BOOL = Syn.out ty
+        val Syn.TT = Syn.out m
+        val Syn.TT = Syn.out n
+      in
+        T.empty #> (I, H, trivial)
+      end
+
+    fun EqFF _ jdg =
+      let
+        val _ = RedPrlLog.trace "StrictBool.EqFF"
+        val (I, H) >> CJ.EQ ((m, n), ty) = jdg
+        val Syn.S_BOOL = Syn.out ty
+        val Syn.FF = Syn.out m
+        val Syn.FF = Syn.out n
+      in
+        T.empty #> (I, H, trivial)
+      end
+
+    fun Elim z _ jdg =
+      let
+        val _ = RedPrlLog.trace "StrictBool.Elim"
+        val (I, H) >> CJ.TRUE cz = jdg
+        val CJ.TRUE ty = lookupHyp H z
+        val Syn.S_BOOL = Syn.out ty
+
+        val tt = Syn.into Syn.TT
+        val ff = Syn.into Syn.FF
+
+        val (goalT, holeT) = makeGoal @@ (I, Hyps.modifyAfter z (CJ.map (substVar (tt, z))) H) >> CJ.TRUE (substVar (tt, z) cz)
+        val (goalF, holeF) = makeGoal @@ (I, Hyps.modifyAfter z (CJ.map (substVar (ff, z))) H) >> CJ.TRUE (substVar (ff, z) cz)
+
+        val psi = T.empty >: goalT >: goalF
+        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
+        val if_ = Syn.into @@ Syn.S_IF (ztm, (holeT, holeF))
+      in
+        psi #> (I, H, if_)
+      end
+      handle Bind =>
+        raise E.error [E.% "Expected strict bool elimination problem"]
+
+    fun ElimEq alpha jdg =
+      let
+        val _ = RedPrlLog.trace "StrictBool.ElimEq"
+        val (I, H) >> CJ.EQ ((if0, if1), c) = jdg
+        val Syn.S_IF (m0, (t0, f0)) = Syn.out if0
+        val Syn.S_IF (m1, (t1, f1)) = Syn.out if1
+
+        val (goalM, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), Syn.into Syn.S_BOOL)
+        val (goalT, _) = makeGoal @@ (I, H) >> CJ.EQ ((t0, t1), c)
+        val (goalF, _) = makeGoal @@ (I, H) >> CJ.EQ ((f0, f1), c)
+        val psi = T.empty >: goalM >: goalT >: goalF
+      in
+        psi #> (I, H, trivial)
+      end
+
+    fun EqElim z _ jdg =
+      let
+        val _ = RedPrlLog.trace "StrictBool.EqElim"
+        val (I, H) >> catjdg = jdg
+        val CJ.EQ ((m0z, m1z), cz) = catjdg
+
+        val CJ.TRUE ty = lookupHyp H z
+        val Syn.S_BOOL = Syn.out ty
+
+        val tt = Syn.into Syn.TT
+        val ff = Syn.into Syn.FF
+
+        val (goalM0, _) = makeGoal @@ (I, H) >> CJ.MEM (m0z, cz)
+        val (goalM1, _) = makeGoal @@ (I, H) >> CJ.MEM (m1z, cz)
+        val (goalT, _) = makeGoal @@ (I, Hyps.modifyAfter z (CJ.map (substVar (tt, z))) H) >> CJ.map (substVar (tt, z)) catjdg
+        val (goalF, _) = makeGoal @@ (I, Hyps.modifyAfter z (CJ.map (substVar (ff, z))) H) >> CJ.map (substVar (ff, z)) catjdg
+
+        val psi = T.empty >: goalM0 >: goalM1 >: goalT >: goalF
+      in
+        psi #> (I, H, trivial)
+      end
+      handle Bind =>
+        raise E.error [E.% "Expected strict bool elimination problem"]
+  end
+
+  structure Void = 
+  struct
+    fun EqType _ jdg = 
+      let
+        val _ = RedPrlLog.trace "Void.EqType"
+        val (I, H) >> CJ.EQ_TYPE (a, b) = jdg
+        val Syn.VOID = Syn.out a
+        val Syn.VOID = Syn.out b
+      in
+        T.empty #> (I, H, trivial)
+      end
+      handle Bind =>
+        raise E.error [E.% "Expected typehood sequent"]
+
+    fun Elim z _ jdg =
+      let
+        val _ = RedPrlLog.trace "Void.Elim"
+        val (I, H) >> catjdg = jdg
+        val CJ.TRUE ty = lookupHyp H z
+        val Syn.VOID = Syn.out ty
+
+        val evidence = 
+          case catjdg of 
+             CJ.TRUE _ => Syn.into Syn.TT
+           | CJ.EQ _ => trivial
+           | CJ.EQ_TYPE _ => trivial
+           | _ => raise Fail "Void.Elim cannot be called with this kind of goal"
+      in
+        T.empty #> (I, H, evidence)
+      end
+      handle Bind =>
+        raise E.error [E.% "Expected Void elimination problem"]
+  end
+
+  structure S1 =
+  struct
+    fun EqType _ jdg =
+      let
+        val _ = RedPrlLog.trace "S1.EqType"
+        val (I, H) >> CJ.EQ_TYPE (a, b) = jdg
+        val Syn.S1 = Syn.out a
+        val Syn.S1 = Syn.out b
+      in
+        T.empty #> (I, H, trivial)
+      end
+      handle Bind =>
+        raise E.error [E.% "Expected typehood sequent"]
+
+    fun EqBase _ jdg =
+      let
+        val _ = RedPrlLog.trace "S1.EqBase"
+        val (I, H) >> CJ.EQ ((m, n), ty) = jdg
+        val Syn.S1 = Syn.out ty
+        val Syn.BASE = Syn.out m
+        val Syn.BASE = Syn.out n
+      in
+        T.empty #> (I, H, trivial)
+      end
+
+    fun EqLoop _ jdg =
+      let
+        val _ = RedPrlLog.trace "S1.EqLoop"
+        val (I, H) >> CJ.EQ ((m, n), ty) = jdg
+        val Syn.S1 = Syn.out ty
+        val Syn.LOOP r1 = Syn.out m
+        val Syn.LOOP r2 = Syn.out n
+        val () = assertParamEq "S1.EqLoop" (r1, r2)
+      in
+        T.empty #> (I, H, trivial)
+      end
+
+    fun EqFCom alpha jdg =
+      let
+        val _ = RedPrlLog.trace "EqFCom"
+        val (I, H) >> CJ.EQ ((lhs, rhs), ty) = jdg
+        val Syn.S1 = Syn.out ty
+        val Syn.FCOM args0 = Syn.out lhs
+        val Syn.FCOM args1 = Syn.out rhs
+      in
+        ComKit.EqFComDelegator alpha (I, H) args0 args1 ty
+      end
+
+    fun Elim z alpha jdg =
+      let
+        val _ = RedPrlLog.trace "S1.Elim"
+        val (I, H) >> CJ.TRUE cz = jdg
+        val CJ.TRUE ty = lookupHyp H z
+        val Syn.S1 = Syn.out ty
+
+        val u = alpha 0
+        val base = Syn.into Syn.BASE
+        val loop = Syn.into o Syn.LOOP @@ P.ret u
+        val Hbase = Hyps.modifyAfter z (CJ.map (substVar (base, z))) H
+        val cbase = substVar (base, z) cz
+
+        val (goalB, holeB) = makeGoal @@ (I, Hbase) >> CJ.TRUE cbase
+        val (goalL, holeL) = makeGoal @@ (I @ [(u, P.DIM)], Hyps.modifyAfter z (CJ.map (substVar (loop, z))) H) >> CJ.TRUE (substVar (loop, z) cz)
+
+        val l0 = substSymbol (P.APP P.DIM0, u) holeL
+        val l1 = substSymbol (P.APP P.DIM1, u) holeL
+
+        val (goalCoh0, _) = makeGoal @@ (I, Hbase) >> CJ.EQ ((l0, holeB), cbase)
+        val (goalCoh1, _) = makeGoal @@ (I, Hbase) >> CJ.EQ ((l1, holeB), cbase)
+
+        val psi = T.empty >: goalB >: goalL >: goalCoh0 >: goalCoh1
+
+        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
+        val elim = Syn.into @@ Syn.S1_ELIM ((z, cz), ztm, (holeB, (u, holeL)))
+      in
+        psi #> (I, H, elim)
+      end
+      handle Bind =>
+        raise E.error [E.% "Expected circle elimination problem"]
+
+    fun ElimEq alpha jdg =
+      let
+        val _ = RedPrlLog.trace "S1.ElimEq"
+        val (I, H) >> CJ.EQ ((elim0, elim1), c) = jdg
+        val Syn.S1_ELIM ((x, c0x), m0, (b0, (u, l0u))) = Syn.out elim0
+        val Syn.S1_ELIM ((y, c1y), m1, (b1, (v, l1v))) = Syn.out elim1
+
+        val z = alpha 0
+        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
+        val c0z = substVar (ztm, x) c0x
+        val c1z = substVar (ztm, y) c1y
+        val l1u = substSymbol (P.ret u, v) l1v
+
+        val l00 = substSymbol (P.APP P.DIM0, u) l0u
+        val l01 = substSymbol (P.APP P.DIM1, u) l0u
+
+        val cbase = substVar (Syn.into Syn.BASE, x) c0x
+        val cloop = substVar (Syn.into @@ Syn.LOOP (P.ret u), x) c0x
+
+        val S1 = Syn.into Syn.S1
+
+        val (goalCz, _) = makeGoal @@ (I, H @> (z, CJ.TRUE S1)) >> CJ.EQ_TYPE (c0z, c1z)
+        val (goalM, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), S1)
+        val (goalB, _) = makeGoal @@ (I, H) >> CJ.EQ ((b0, b1), cbase)
+        val (goalL, _) = makeGoal @@ (I, H) >> CJ.EQ ((l0u, l1u), cloop)
+        val (goalL00, _) = makeGoal @@ (I, H) >> CJ.EQ ((l00, b0), cbase)
+        val (goalL01, _) = makeGoal @@ (I, H) >> CJ.EQ ((l01, b0), cbase)
+
+        val psi = T.empty >: goalCz >: goalM >: goalB >: goalL >: goalL00 >: goalL01
+      in
+        psi #> (I, H, trivial)
+      end
+  end
+
+  structure DFun =
+  struct
+    fun EqType alpha jdg =
+      let
+        val _ = RedPrlLog.trace "DFun.EqType"
+        val (I, H) >> CJ.EQ_TYPE (dfun0, dfun1) = jdg
+        val Syn.DFUN (a0, x, b0x) = Syn.out dfun0
+        val Syn.DFUN (a1, y, b1y) = Syn.out dfun1
+
+        val z = alpha 0
+        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
+        val b0z = substVar (ztm, x) b0x
+        val b1z = substVar (ztm, y) b1y
+
+        val (goal1, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (a0, a1)
+        val (goal2, _) = makeGoal @@ (I, H @> (z, CJ.TRUE a0)) >> CJ.EQ_TYPE (b0z, b1z)
+      in
+        T.empty >: goal1 >: goal2
+          #> (I, H, trivial)
+      end
+      handle Bind =>
+        raise E.error [E.% "Expected dfun typehood sequent"]
+
+    fun Eq alpha jdg =
+      let
+        val _ = RedPrlLog.trace "DFun.Eq"
+        val (I, H) >> CJ.EQ ((lam0, lam1), dfun) = jdg
+        val Syn.LAM (x, m0x) = Syn.out lam0
+        val Syn.LAM (y, m1y) = Syn.out lam1
+        val Syn.DFUN (a, z, bz) = Syn.out dfun
+
+        val w = alpha 0
+        val wtm = Syn.into @@ Syn.VAR (w, O.EXP)
+
+        val m0w = substVar (wtm, x) m0x
+        val m1w = substVar (wtm, y) m1y
+        val bw = substVar (wtm, z) bz
+
+        val (goal1, _) = makeGoal @@ (I, H @> (w, CJ.TRUE a)) >> CJ.EQ ((m0w, m1w), bw)
+        val (goal2, _) = makeGoal @@ (I, H) >> CJ.TYPE a
+      in
+        T.empty >: goal1 >: goal2
+          #> (I, H, trivial)
+      end
+
+    fun True alpha jdg =
+      let
+        val _ = RedPrlLog.trace "DFun.True"
+        val (I, H) >> CJ.TRUE dfun = jdg
+        val Syn.DFUN (a, x, bx) = Syn.out dfun
+
+        val z = alpha 0
+        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
+        val bz = substVar (ztm, x) bx
+
+        val (tyGoal, _) = makeGoal @@ (I, H) >> CJ.TYPE a
+        val (goal, hole) = makeGoal @@ (I, H @> (z, CJ.TRUE a)) >> CJ.TRUE bz
+
+        val psi = T.empty >: goal >: tyGoal
+        val lam = Syn.into @@ Syn.LAM (z, substVar (ztm, z) hole)
+      in
+        psi #> (I, H, lam)
+      end
+      handle Bind =>
+        raise E.error [E.% "Expected dfun truth sequent"]
+
+    fun Eta alpha jdg =
+      let
+        val _ = RedPrlLog.trace "DFun.Eta"
+        val (I, H) >> CJ.EQ ((m, n), dfun) = jdg
+        val Syn.DFUN (a, x, bx) = Syn.out dfun
+
+        val xtm = Syn.into @@ Syn.VAR (x, O.EXP)
+        val m' = Syn.into @@ Syn.LAM (x, Syn.into @@ Syn.AP (m, xtm))
+        val (goal1, _) = makeGoal @@ (I, H) >> CJ.MEM (m, dfun)
+        val (goal2, _) = makeGoal @@ (I, H) >> CJ.EQ ((m', n), dfun)
+      in
+        T.empty >: goal1 >: goal2
+          #> (I, H, trivial)
+      end
+
+    fun Elim z alpha jdg =
+      let
+        val _ = RedPrlLog.trace "DFun.Elim"
+        val (I, H) >> CJ.TRUE cz = jdg
+        val CJ.TRUE dfun = Hyps.lookup H z
+        val Syn.DFUN (a, x, bx) = Syn.out dfun
+        val (goal1, hole1) = makeGoal @@ (I, H) >> CJ.TRUE a
+
+        val u = alpha 0
+        val v = alpha 1
+
+        val b' = substVar (hole1, x) bx
+
+        val utm = Syn.into @@ Syn.VAR (u, O.EXP)
+        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
+        val aptm = Syn.into @@ Syn.AP (ztm, hole1)
+        val H' = Hyps.empty @> (u, CJ.TRUE b') @> (v, CJ.EQ ((utm, aptm), b'))
+        val H'' = Hyps.interposeAfter H z H'
+
+        val (goal2, hole2) = makeGoal @@ (I, H'') >> CJ.TRUE cz
+
+        val psi = T.empty >: goal1 >: goal2
+        val aptm = Syn.into @@ Syn.AP (ztm, hole1)
+        val rho = Var.Ctx.insert (Var.Ctx.insert Var.Ctx.empty u aptm) v (Syn.into Syn.AX)
+        val hole2' = substVarenv rho hole2
+      in
+        psi #> (I, H, hole2')
+      end
+
+    fun ApEq alpha jdg =
+      let
+        val _ = RedPrlLog.trace "DFun.ApEq"
+        val (I, H) >> CJ.EQ ((ap0, ap1), c) = jdg
+        val Syn.AP (m0, n0) = Syn.out ap0
+        val Syn.AP (m1, n1) = Syn.out ap1
+
+        val (goalDFun0, holeDFun0) = makeGoal @@ (I, H) >> CJ.SYNTH m0
+        val (goalDFun1, holeDFun1) = makeGoal @@ (I, H) >> CJ.SYNTH m1
+        val (goalDFunEq, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (holeDFun0, holeDFun1)
+        val (goalDom, holeDom) = makeGoal @@ MATCH (O.MONO O.DFUN, 0, holeDFun0, [], [])
+        val (goalM, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), holeDFun0)
+        val (goalN, _) = makeGoal @@ (I, H) >> CJ.EQ ((n0, n1), holeDom)
+      in
+        T.empty >: goalDFun0 >: goalDFun1 >: goalDFunEq >: goalDom >: goalM >: goalN
+          #> (I, H, trivial)
+      end
+  end
+
+  structure DProd =
+  struct
+    fun EqType alpha jdg =
+      let
+        val _ = RedPrlLog.trace "DProd.EqType"
+        val (I, H) >> CJ.EQ_TYPE (dprod0, dprod1) = jdg
+        val Syn.DPROD (a0, x, b0x) = Syn.out dprod0
+        val Syn.DPROD (a1, y, b1y) = Syn.out dprod1
+
+        val z = alpha 0
+        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
+        val b0z = substVar (ztm, x) b0x
+        val b1z = substVar (ztm, y) b1y
+
+        val (goal1, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (a0, a1)
+        val (goal2, _) = makeGoal @@ (I, H @> (z, CJ.TRUE a0)) >> CJ.EQ_TYPE (b0z, b1z)
+      in
+        T.empty >: goal1 >: goal2
+          #> (I, H, trivial)
+      end
+      handle Bind =>
+        raise E.error [E.% "Expected dprod typehood sequent"]
+
+    fun Eq alpha jdg =
+      let
+        val _ = RedPrlLog.trace "DProd.Eq"
+        val (I, H) >> CJ.EQ ((pair0, pair1), dprod) = jdg
+        val Syn.PAIR (m0, n0) = Syn.out pair0
+        val Syn.PAIR (m1, n1) = Syn.out pair1
+        val Syn.DPROD (a, x, bx) = Syn.out dprod
+
+        val z = alpha 0
+        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
+        val bz = substVar (ztm, x) bx
+
+        val (goal1, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), a)
+        val (goal2, _) = makeGoal @@ (I, H) >> CJ.EQ ((n0, n1), substVar (m0, x) bx)
+        val (goalFam, _) = makeGoal @@ (I, H @> (z, CJ.TRUE a)) >> CJ.TYPE bz
+      in
+        T.empty >: goal1 >: goal2 >: goalFam
+          #> (I, H, trivial)
+      end
+
+    fun Eta alpha jdg =
+      let
+        val _ = RedPrlLog.trace "DProd.Eta"
+        val (I, H) >> CJ.EQ ((m, n), dprod) = jdg
+        val Syn.DPROD (a, x, bx) = Syn.out dprod
+
+        val m' = Syn.into @@ Syn.PAIR (Syn.into @@ Syn.FST m, Syn.into @@ Syn.SND m)
+        val (goal1, _) = makeGoal @@ (I, H) >> CJ.MEM (m, dprod)
+        val (goal2, _) = makeGoal @@ (I, H) >> CJ.EQ ((m', n), dprod)
+      in
+        T.empty >: goal1 >: goal2
+          #> (I, H, trivial)
+      end
+
+    fun FstEq alpha jdg =
+      let
+        val _ = RedPrlLog.trace "DProd.FstEq"
+        val (I, H) >> CJ.EQ ((fst0, fst1), ty) = jdg
+        val Syn.FST m0 = Syn.out fst0
+        val Syn.FST m1 = Syn.out fst1
+
+        val (goalTy, holeTy) = makeGoal @@ (I, H) >> CJ.SYNTH m0
+        val (goalTyA, holeTyA) = makeGoal @@ MATCH (O.MONO O.DPROD, 0, holeTy, [], [])
+        val (goalEq, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), holeTy)
+        val (goalEqTy, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (holeTyA, ty)
+      in
+        T.empty >: goalTy >: goalTyA >: goalEq >: goalEqTy
+          #> (I, H, trivial)
+      end
+
+    fun SndEq alpha jdg =
+      let
+        val _ = RedPrlLog.trace "DProd.SndEq"
+        val (I, H) >> CJ.EQ ((snd0, snd1), ty) = jdg
+        val Syn.SND m0 = Syn.out snd0
+        val Syn.SND m1 = Syn.out snd1
+
+        val (goalTy, holeTy) = makeGoal @@ (I, H) >> CJ.SYNTH m0
+        val (goalTyB, holeTyB) = makeGoal @@ MATCH (O.MONO O.DPROD, 1, holeTy, [], [Syn.into @@ Syn.FST m0])
+        val (goalEq, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), holeTy)
+        val (goalEqTy, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (holeTyB, ty)
+      in
+        T.empty >: goalTy >: goalTyB >: goalEq >: goalEqTy
+          #> (I, H, trivial)
+      end
+
+    fun True alpha jdg =
+      let
+        val _ = RedPrlLog.trace "DProd.True"
+        val (I, H) >> CJ.TRUE dprod = jdg
+        val Syn.DPROD (a, x, bx) = Syn.out dprod
+
+        val z = alpha 0
+        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
+        val bz = substVar (ztm, x) bx
+
+        val (goal1, hole1) = makeGoal @@ (I, H) >> CJ.TRUE a
+        val (goal2, hole2) = makeGoal @@ (I, H) >> CJ.TRUE (substVar (hole1, x) bx)
+        val (goalFam, _) = makeGoal @@ (I, H @> (z, CJ.TRUE a)) >> CJ.TYPE bz
+        val psi = T.empty >: goal1 >: goal2 >: goalFam
+        val pair = Syn.into @@ Syn.PAIR (hole1, hole2)
+      in
+        psi #> (I, H, pair)
+      end
+
+    fun Elim z alpha jdg =
+      let
+        val _ = RedPrlLog.trace "DProd.Elim"
+        val (I, H) >> CJ.TRUE cz = jdg
+        val CJ.TRUE dprod = Hyps.lookup H z
+        val Syn.DPROD (a, x, bx) = Syn.out dprod
+
+        val z1 = alpha 0
+        val z2 = alpha 1
+
+        val z1tm = Syn.into @@ Syn.VAR (z1, O.EXP)
+        val z2tm = Syn.into @@ Syn.VAR (z2, O.EXP)
+
+        val bz1 = substVar (z1tm, x) bx
+        val pair = Syn.into @@ Syn.PAIR (z1tm, z2tm)
+
+        val H' = Hyps.empty @> (z1, CJ.TRUE a) @> (z2, CJ.TRUE bz1)
+        val H'' = Hyps.interposeAfter H z H'
+
+        val (goal, hole) =
+          makeGoal
+            @@ (I, Hyps.modifyAfter z (CJ.map (substVar (pair, z))) H'')
+            >> CJ.TRUE (substVar (pair, z) cz)
+
+        val psi = T.empty >: goal
+
+        val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
+        val fstz = Syn.into @@ Syn.FST ztm
+        val sndz = Syn.into @@ Syn.SND ztm
+        val rho = Var.Ctx.insert (Var.Ctx.insert Var.Ctx.empty z1 fstz) z2 sndz
+        val hole' = substVarenv rho hole
+      in
+        T.empty >: goal
+          #> (I, H, hole')
+      end
+  end
+
+  structure Path =
+  struct
+    fun EqType alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Path.EqType"
+        val (I, H) >> CJ.EQ_TYPE (ty0, ty1) = jdg
+        val Syn.PATH_TY ((u, a0u), m0, n0) = Syn.out ty0
+        val Syn.PATH_TY ((v, a1v), m1, n1) = Syn.out ty1
+
+        val a1u = substSymbol (P.ret u, v) a1v
+
+        val a00 = substSymbol (P.APP P.DIM0, u) a0u
+        val a01 = substSymbol (P.APP P.DIM1, u) a0u
+
+        val (tyGoal, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (a0u, a1u)
+        val (goal0, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), a00)
+        val (goal1, _) = makeGoal @@ (I, H) >> CJ.EQ ((n0, n1), a01)
+      in
+        T.empty >: tyGoal >: goal0 >: goal1
+          #> (I, H, trivial)
+      end
+
+    fun True alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Path.True"
+        val (I, H) >> CJ.TRUE ty = jdg
+        val Syn.PATH_TY ((u, a), p0, p1) = Syn.out ty
+        val a0 = substSymbol (P.APP P.DIM0, u) a
+        val a1 = substSymbol (P.APP P.DIM1, u) a
+
+        val v = alpha 0
+
+        val (mainGoal, mhole) = makeGoal @@ (I @ [(v, P.DIM)], H) >> CJ.TRUE (substSymbol (P.ret v, u) a)
+
+        val m0 = substSymbol (P.APP P.DIM0, v) mhole
+        val m1 = substSymbol (P.APP P.DIM1, v) mhole
+        val (cohGoal0, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, p0), a0)
+        val (cohGoal1, _) = makeGoal @@ (I, H) >> CJ.EQ ((m1, p1), a1)
+
+        val psi = T.empty >: mainGoal >: cohGoal0 >: cohGoal1
+        val abstr = Syn.into @@ Syn.PATH_ABS (v, mhole)
+      in
+        psi #> (I, H, abstr)
+      end
+
+    fun Eq alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Path.Eq"
+        val (I, H) >> CJ.EQ ((abs0, abs1), ty) = jdg
+        val Syn.PATH_TY ((u, au), p0, p1) = Syn.out ty
+        val Syn.PATH_ABS (v, m0v) = Syn.out abs0
+        val Syn.PATH_ABS (w, m1w) = Syn.out abs1
+
+        val z = alpha 0
+        val az = substSymbol (P.ret z, u) au
+        val m0z = substSymbol (P.ret z, v) m0v
+        val m1z = substSymbol (P.ret z, w) m1w
+
+        val a0 = substSymbol (P.APP P.DIM0, u) au
+        val a1 = substSymbol (P.APP P.DIM1, u) au
+        val m00 = substSymbol (P.APP P.DIM0, v) m0v
+        val m01 = substSymbol (P.APP P.DIM1, v) m0v
+
+        val (goalM, _) = makeGoal @@ (I @ [(z, P.DIM)], H) >> CJ.EQ ((m0z, m1z), az)
+        val (goalM00, _) = makeGoal @@ (I, H) >> CJ.EQ ((m00, p0), a0)
+        val (goalM01, _) = makeGoal @@ (I, H) >> CJ.EQ ((m01, p1), a1)
+      in
+        T.empty >: goalM >: goalM00 >: goalM01
+          #> (I, H, trivial)
+      end
+
+    fun ApEq alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Path.ApEq"
+        val (I, H) >> CJ.EQ ((ap0, ap1), ty) = jdg
+        val Syn.PATH_AP (m0, r0) = Syn.out ap0
+        val Syn.PATH_AP (m1, r1) = Syn.out ap1
+        val () = assertParamEq "Path.ApEq" (r0, r1)
+        val (goalSynth, holeSynth) = makeGoal @@ (I, H) >> CJ.SYNTH m0
+        val (goalMem, _) = makeGoal @@ (I, H) >> CJ.EQ ((m0, m1), holeSynth)
+        val (goalLine, holeLine) = makeGoal @@ MATCH (O.MONO O.PATH_TY, 0, holeSynth, [r0], [])
+        val (goalTy, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (ty, holeLine)
+      in
+        T.empty >: goalSynth >: goalMem >: goalLine >: goalTy
+          #> (I, H, trivial)
+      end
+
+    fun ApConstCompute alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Path.ApConstCompute"
+        val (I, H) >> CJ.EQ ((ap, p), a) = jdg
+        val Syn.PATH_AP (m, P.APP r) = Syn.out ap
+        val (goalSynth, holeSynth) = makeGoal @@ (I, H) >> CJ.SYNTH m
+
+        val dimAddr = case r of P.DIM0 => 1 | P.DIM1 => 2
+        val (goalLine, holeLine) = makeGoal @@ MATCH (O.MONO O.PATH_TY, 0, holeSynth, [P.APP r], [])
+        val (goalEndpoint, holeEndpoint) = makeGoal @@ MATCH (O.MONO O.PATH_TY, dimAddr, holeSynth, [], [])
+        val (goalTy, _) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (a, holeLine)
+        val (goalEq, _) = makeGoal @@ (I, H) >> CJ.EQ ((holeEndpoint, p), a)
+      in
+        T.empty >: goalSynth >: goalLine >: goalEndpoint >: goalTy >: goalEq
+          #> (I, H, trivial)
+      end
+
+    fun Eta alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Path.Eta"
+        val (I, H) >> CJ.EQ ((m, n), pathTy) = jdg
+        val Syn.PATH_TY ((u, a), p0, p1) = Syn.out pathTy
+
+        val m' = Syn.into @@ Syn.PATH_ABS (u, Syn.into @@ Syn.PATH_AP (m, P.ret u))
+        val (goal1, _) = makeGoal @@ (I, H) >> CJ.MEM (m, pathTy)
+        val (goal2, _) = makeGoal @@ (I, H) >> CJ.EQ ((m', n), pathTy)
+      in
+        T.empty >: goal1 >: goal2
+          #> (I, H, trivial)
+      end
+
+  end
+
+  structure Hyp =
+  struct
+    fun Project z alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Hyp.Project"
+        val (I, H) >> catjdg = jdg
+        val catjdg' = lookupHyp H z
+      in
+        if CJ.eq (catjdg, catjdg') then
+          T.empty #> (I, H, Syn.into (Syn.VAR (z, CJ.synthesis catjdg)))
+        else
+          raise E.error [E.% "Hypothesis does not match goal"]
+      end
+      handle Bind =>
+        raise E.error [E.% "Expected sequent judgment"]
+  end
+
+  structure TypeEquality =
+  struct
+    fun Symmetry alpha jdg =
+    let
+      val _ = RedPrlLog.trace "Equality.Symmetry"
+      val (I, H) >> CJ.EQ_TYPE (ty1, ty2) = jdg
+      val (goal, hole) = makeGoal @@ (I, H) >> CJ.EQ_TYPE (ty2, ty1)
+    in
+      T.empty >: goal
+        #> (I, H, trivial)
+    end
+  end
+
+  structure Truth =
+  struct
+    fun Witness tm alpha jdg =
+      let
+        val _ = RedPrlLog.trace "True.Witness"
+        val (I, H) >> CJ.TRUE ty = jdg
+        val (goal, _) = makeGoal @@ (I, H) >> CJ.MEM (tm, ty)
+      in
+        T.empty >: goal
+          #> (I, H, tm)
+      end
+      handle Bind =>
+        raise E.error [E.% @@ "Expected truth sequent but got " ^ J.toString jdg]
+  end
+
+  structure Synth =
+  struct
+    fun FromWfHyp z alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Synth.Switch"
+        val (I, H) >> CJ.SYNTH tm = jdg
+        val CJ.EQ ((a, b), ty) = Hyps.lookup H z
+      in
+        if Abt.eq (a, tm) orelse Abt.eq (b, tm) then
+          T.empty #> (I, H, ty)
+        else
+          raise Fail "Did not match"
+      end
+
+    fun Hyp alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Synth.Hyp"
+        val (I, H) >> CJ.SYNTH tm = jdg
+        val Syn.VAR (z, O.EXP) = Syn.out tm
+        val CJ.TRUE a = Hyps.lookup H z
+      in
+        T.empty #> (I, H, a)
+      end
+
+    fun Ap alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Synth.Ap"
+        val (I, H) >> CJ.SYNTH tm = jdg
+        val Syn.AP (m, n) = Syn.out tm
+        val (goalDFun, holeDFun) = makeGoal @@ (I, H) >> CJ.SYNTH m
+        val (goalDom, holeDom) = makeGoal @@ MATCH (O.MONO O.DFUN, 0, holeDFun, [], [])
+        val (goalCod, holeCod) = makeGoal @@ MATCH (O.MONO O.DFUN, 1, holeDFun, [], [n])
+        val (goalN, _) = makeGoal @@ (I, H) >> CJ.MEM (n, holeDom)
+      in
+        T.empty >: goalDFun >: goalDom >: goalCod >: goalN
+          #> (I, H, holeCod)
+      end
+
+    fun S1Elim alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Synth.S1Elim"
+        val (I, H) >> CJ.SYNTH tm = jdg
+        val Syn.S1_ELIM ((x,cx), m, _) = Syn.out tm
+
+        val cm = substVar (m, x) cx
+        val (goal, _) = makeGoal @@ (I, H) >> CJ.MEM (tm, cm)
+      in
+        T.empty >: goal
+          #> (I, H, cm)
+      end
+
+    fun If alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Synth.If"
+        val (I, H) >> CJ.SYNTH tm = jdg
+        val Syn.IF ((x,cx), m, _) = Syn.out tm
+
+        val cm = substVar (m, x) cx
+        val (goal, _) = makeGoal @@ (I, H) >> CJ.MEM (tm, cm)
+      in
+        T.empty >: goal
+          #> (I, H, cm)
+      end
+
+    fun PathAp alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Synth.PathAp"
+        val (I, H) >> CJ.SYNTH tm = jdg
+        val Syn.PATH_AP (m, r) = Syn.out tm
+        val (goalPathTy, holePathTy) = makeGoal @@ (I, H) >> CJ.SYNTH m
+        val (goalLine, holeLine) = makeGoal @@ MATCH (O.MONO O.PATH_TY, 0, holePathTy, [r], [])
+        val psi = T.empty >: goalPathTy >: goalLine
+      in
+        T.empty >: goalPathTy >: goalLine
+          #> (I, H, holeLine)
+      end
+
+    fun Fst alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Synth.Fst"
+        val (I, H) >> CJ.SYNTH tm = jdg
+        val Syn.FST m = Syn.out tm
+        val (goalTy, holeTy) = makeGoal @@ (I, H) >> CJ.SYNTH m
+        val (goalA, holeA) = makeGoal @@ MATCH (O.MONO O.DPROD, 0, holeTy, [], [])
+      in
+        T.empty >: goalTy >: goalA
+          #> (I, H, holeA)
+      end
+
+    fun Snd alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Synth.Snd"
+        val (I, H) >> CJ.SYNTH tm = jdg
+        val Syn.SND m = Syn.out tm
+        val (goalTy, holeTy) = makeGoal @@ (I, H) >> CJ.SYNTH m
+        val (goalB, holeB) = makeGoal @@ MATCH (O.MONO O.DPROD, 1, holeTy, [], [Syn.into @@ Syn.FST m])
+      in
+        T.empty >: goalTy >: goalB
+          #> (I, H, holeB)
+      end
+  end
+
+  structure Match =
+  struct
+    fun MatchOperator alpha jdg =
+      let
+        val _ = RedPrlLog.trace "Match.MatchOperator"
+        val MATCH (th, k, tm, ps, ms) = jdg
+
+        val Abt.$ (th', args) = Abt.out tm
+        val true = Abt.O.eq Sym.eq (th, th')
+
+        val (vls, _) = Abt.O.arity th
+        val (us, xs) \ arg = List.nth (args, k)
+        val srho = ListPair.foldrEq (fn (u,p,rho) => Sym.Ctx.insert rho u p) Sym.Ctx.empty (us, ps)
+        val vrho = ListPair.foldrEq (fn (x,m,rho) => Var.Ctx.insert rho x m) Var.Ctx.empty (xs, ms)
+
+        val arg' = substSymenv srho (substVarenv vrho arg)
+      in
+        Lcf.|> (T.empty, abtToAbs arg')
+      end
+      handle _ =>
+        raise E.error [E.% "MATCH judgment failed to unify"]
+  end
+end


### PR DESCRIPTION
@jonsterling Currently I am not working on this. I would like to hear your comments.

- [x] Rewrite the goal-appending process in `ComKit`.
- [x] Partition the refiners into more modules. Possibly one to for composition, ~~one for structural rules, one for base types, and another one for functions, pairs and identifications etc.~~ another one for type-specific modules.
- [x] Fix the wrong `HCom` and `Coe` tactics which wrongly assume the structural equality rule is invertible.
- [x] Fix the wrong `FCom` rule which does not check whether the type is a (weak) base types.

Needs more thinking:
- [ ] ~~Each base type should provides an `EqVal`, if appropriate, and that `Auto` should not dispatch on value terms. Leave the value determination to each `EqVal` rule. I also doubt the usefulness of exposing `EqTT` and `EqFF` when `EqVal` is available.~~ Needs discussion.
- [ ] ~~Use the `flipWrapper` hack to skip all `Equality.Symmetry`.~~ An ill-concieved idea.

Dream:
- [ ] Investigate why `Telescope.Internal.ConsView.out` is taking so much time.