### PR TITLE
Update LICENSE.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Jonathan Sterling, Danny Gratzer
+Copyright (c) 2015-2017 Jonathan Sterling, Danny Gratzer, Kuen-Bang Hou (Favonia)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
@jonsterling Should we just copy-and-paste all the people in the contributor list? This can also be
```
Copyright (c) 2015-2016 Jonathan Sterling, Danny Gratzer
Copyright (c) 2017 Jonathan Sterling, Danny Gratzer, Kuen-Bang Hou (Favonia)
```
though I remember GitHub license detection is not happy about this.