### PR TITLE
Refiner improvements, dead code, etc.

### DIFF
--- a/src/redprl/judgment.fun
+++ b/src/redprl/judgment.fun
@@ -7,8 +7,6 @@ struct
   type sort = Tm.valence
   type env = Tm.metaenv
   type jdg = Tm.abt S.jdg
-  type symenv = Tm.symenv
-  type varenv = Tm.varenv
 
   val subst = S.map o Tm.substMetaenv
   val eq = S.eq

--- a/src/redprl/lcf_syntax.fun
+++ b/src/redprl/lcf_syntax.fun
@@ -55,7 +55,6 @@ struct
       go SymCtx.empty
   end
 
-  exception InvalidStatement
   exception InvalidMultitactic (* unused but demanded by the signature *)
 
   open NominalLcfView

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -19,7 +19,7 @@ struct
   infixr @@
   infix 1 || #>
   infix 2 >> >: >:? >:+ $$ $# // \ @>
-  infix orelse_
+  infix orelse_ then_
 
   structure Hyp =
   struct
@@ -261,14 +261,6 @@ struct
       in
         |>: goalEq >:? goalTy0 >: goalTy #> (I, H, trivial)
       end
-
-    fun CapEqR alpha = catJdgFlipWrapper CapEqL alpha
-
-    (* Try all the fcom rules.
-     * Note that the EQ rule is invertible only when the cap rule fails. *)
-    val AutoEqLR = CapEqL orelse_ CapEqR orelse_ Eq
-    val AutoEqL = CapEqL orelse_ Eq
-    val AutoEqR = CapEqR orelse_ Eq
   end
 
   structure Computation =
@@ -451,6 +443,9 @@ struct
   end
 
   local
+    val CatJdgSymmetry : Sym.t Tactical.tactic =
+      Equality.Symmetry orelse_ TypeEquality.Symmetry
+
     fun matchGoal f alpha jdg =
       f jdg alpha jdg
   in
@@ -476,7 +471,7 @@ struct
       fun StepEqType sign (ty1, ty2) =
         case (Machine.canonicity sign ty1, Machine.canonicity sign ty2) of
            (Machine.REDEX, _) => Computation.EqTypeHeadExpansion sign
-         | (_, Machine.REDEX) => catJdgFlipWrapper (Computation.EqTypeHeadExpansion sign)
+         | (_, Machine.REDEX) => CatJdgSymmetry then_ Computation.EqTypeHeadExpansion sign
          | (Machine.CANONICAL, Machine.CANONICAL) => StepEqTypeVal (ty1, ty2)
          | _ => raise E.error [Fpp.text "Could not find type equality rule for", TermPrinter.ppTerm ty1, Fpp.text "and", TermPrinter.ppTerm ty2]
 
@@ -509,7 +504,7 @@ struct
              | _ => raise E.error [Fpp.text "Could not determine critical variable at which to apply sbool elimination"])
          | (_, Syn.S_IF _, _) =>
            (case y of
-               Machine.VAR z => catJdgFlipWrapper (StrictBool.EqElim z)
+               Machine.VAR z => CatJdgSymmetry then_ StrictBool.EqElim z
              | _ => raise E.error [Fpp.text "Could not determine critical variable at which to apply sbool elimination"])
          | (Syn.S1_ELIM _, Syn.S1_ELIM _, _) => S1.ElimEq
          | (Syn.AP _, Syn.AP _, _) => DFun.ApEq
@@ -524,6 +519,48 @@ struct
          | Syn.DFUN _ => DFun.Eta
          | Syn.PATH_TY _ => Path.Eta
          | _ => raise E.error [Fpp.text "Could not expand neutral term of type", TermPrinter.ppTerm ty]
+
+
+      structure HCom = 
+      struct
+        open HCom
+
+        val AutoEqL = CapEqL orelse_ TubeEqL orelse_ Eq
+
+        (* Try all the hcom rules.
+         * Note that the EQ rule is invertible only when the cap and tube rules fail. *)
+        val AutoEqLR = 
+          CapEqL 
+            orelse_ (CatJdgSymmetry then_ HCom.CapEqL)
+            orelse_ HCom.TubeEqL
+            orelse_ (CatJdgSymmetry then_ HCom.TubeEqL)
+            orelse_ HCom.Eq
+      end
+
+      structure Com = 
+      struct
+        open Com
+
+        val AutoEqL = CapEqL orelse_ TubeEqL orelse_ Eq
+        (* Try all the com rules.
+         * Note that the EQ rule is invertible only when the cap and tube rules fail. *)
+        val AutoEqLR =
+          CapEqL
+            orelse_ (CatJdgSymmetry then_ CapEqL)
+            orelse_ TubeEqL 
+            orelse_ (CatJdgSymmetry then_ TubeEqL)
+            orelse_ Eq
+      end
+
+      structure Coe = 
+      struct
+       open Coe
+
+       val CapEqR = CatJdgSymmetry then_ CapEqL
+       val AutoEqLR = CapEqL orelse_ CapEqR orelse_ Eq
+       val AutoEqL = CapEqL orelse_ Eq
+       val AutoEqR = CapEqR orelse_ Eq
+      end
 
       (* these are special rules which are not beta or eta,
        * and we have to check them against the neutral terms.
@@ -540,16 +577,17 @@ struct
          | (Syn.COM _, _) => Com.AutoEqL
          | (_, Syn.COM _) => Com.AutoEqLR
          | (Syn.PATH_AP (_, P.APP _), _) => Path.ApConstCompute
-         | (_, Syn.PATH_AP (_, P.APP _)) => catJdgFlipWrapper Path.ApConstCompute
-         | _ => case canonicity of
-                   (Machine.NEUTRAL x, Machine.NEUTRAL y) => StepEqNeu (x, y) ((m, n), ty)
-                 | (Machine.NEUTRAL _, Machine.CANONICAL) => StepEqNeuExpand ty
-                 | (Machine.CANONICAL, Machine.NEUTRAL _) => catJdgFlipWrapper @@ StepEqNeuExpand ty
+         | (_, Syn.PATH_AP (_, P.APP _)) => CatJdgSymmetry then_ Path.ApConstCompute
+         | _ => 
+           (case canonicity of
+               (Machine.NEUTRAL x, Machine.NEUTRAL y) => StepEqNeu (x, y) ((m, n), ty)
+             | (Machine.NEUTRAL _, Machine.CANONICAL) => StepEqNeuExpand ty
+             | (Machine.CANONICAL, Machine.NEUTRAL _) => CatJdgSymmetry then_ StepEqNeuExpand ty)
 
       fun StepEq sign ((m, n), ty) =
         case (Machine.canonicity sign m, Machine.canonicity sign n) of
            (Machine.REDEX, _) => Computation.EqHeadExpansion sign
-         | (_, Machine.REDEX) => catJdgFlipWrapper @@ Computation.EqHeadExpansion sign
+         | (_, Machine.REDEX) => CatJdgSymmetry then_ Computation.EqHeadExpansion sign
          | (Machine.CANONICAL, Machine.CANONICAL) => StepEqVal ((m, n), ty)
          | canonicity => StepEqStuck sign ((m, n), ty) canonicity
 

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -521,7 +521,7 @@ struct
          | _ => raise E.error [Fpp.text "Could not expand neutral term of type", TermPrinter.ppTerm ty]
 
 
-      structure HCom = 
+      structure HCom =
       struct
         open HCom
 
@@ -529,15 +529,15 @@ struct
 
         (* Try all the hcom rules.
          * Note that the EQ rule is invertible only when the cap and tube rules fail. *)
-        val AutoEqLR = 
-          CapEqL 
+        val AutoEqLR =
+          CapEqL
             orelse_ (CatJdgSymmetry then_ HCom.CapEqL)
             orelse_ HCom.TubeEqL
             orelse_ (CatJdgSymmetry then_ HCom.TubeEqL)
             orelse_ HCom.Eq
       end
 
-      structure Com = 
+      structure Com =
       struct
         open Com
 
@@ -547,12 +547,12 @@ struct
         val AutoEqLR =
           CapEqL
             orelse_ (CatJdgSymmetry then_ CapEqL)
-            orelse_ TubeEqL 
+            orelse_ TubeEqL
             orelse_ (CatJdgSymmetry then_ TubeEqL)
             orelse_ Eq
       end
 
-      structure Coe = 
+      structure Coe =
       struct
        open Coe
 
@@ -578,7 +578,7 @@ struct
          | (_, Syn.COM _) => Com.AutoEqLR
          | (Syn.PATH_AP (_, P.APP _), _) => Path.ApConstCompute
          | (_, Syn.PATH_AP (_, P.APP _)) => CatJdgSymmetry then_ Path.ApConstCompute
-         | _ => 
+         | _ =>
            (case canonicity of
                (Machine.NEUTRAL x, Machine.NEUTRAL y) => StepEqNeu (x, y) ((m, n), ty)
              | (Machine.NEUTRAL _, Machine.CANONICAL) => StepEqNeuExpand ty

--- a/src/redprl/refiner_composition_kit.fun
+++ b/src/redprl/refiner_composition_kit.fun
@@ -186,7 +186,7 @@ struct
         #> (I, H, trivial)
       end
 
-    val CapEqR = catJdgFlipWrapper CapEqL
+    (*val CapEqR = catJdgFlipWrapper CapEqL*)
 
     (* Search for the first satisfied equation in an hcom. *)
     fun TubeEqL alpha jdg =
@@ -221,14 +221,6 @@ struct
          >:? goalTy0
         #> (I, H, trivial)
       end
-
-    val TubeEqR = catJdgFlipWrapper TubeEqL
-
-    (* Try all the hcom rules.
-     * Note that the EQ rule is invertible only when the cap and tube rules fail. *)
-    val AutoEqLR = CapEqL orelse_ CapEqR orelse_ TubeEqL orelse_ TubeEqR orelse_ Eq
-    val AutoEqL = CapEqL orelse_ TubeEqL orelse_ Eq
-    val AutoEqR = CapEqR orelse_ TubeEqR orelse_ Eq
   end
 
   structure Com =
@@ -302,8 +294,6 @@ struct
         #> (I, H, trivial)
       end
 
-    val CapEqR = catJdgFlipWrapper CapEqL
-
     (* Search for the first satisfied equation in an hcom. *)
     fun TubeEqL alpha jdg =
       let
@@ -340,13 +330,5 @@ struct
          >:? goalTy0 >: goalTy
         #> (I, H, trivial)
       end
-
-    val TubeEqR = catJdgFlipWrapper TubeEqL
-
-    (* Try all the hcom rules.
-     * Note that the EQ rule is invertible only when the cap and tube rules fail. *)
-    val AutoEqLR = CapEqL orelse_ CapEqR orelse_ TubeEqL orelse_ TubeEqR orelse_ Eq
-    val AutoEqL = CapEqL orelse_ TubeEqL orelse_ Eq
-    val AutoEqR = CapEqR orelse_ TubeEqR orelse_ Eq
   end
 end

--- a/src/redprl/refiner_composition_kit.fun
+++ b/src/redprl/refiner_composition_kit.fun
@@ -170,7 +170,7 @@ struct
 
         (* equations *)
         val _ = Assert.tautologicalEquations "HCom.CapEq tautology checking" (List.map #1 tubes)
-  
+
         (* type *)
         val goalTy0 = makeEqType (I, H) (ty0, ty)
 
@@ -212,7 +212,7 @@ struct
         (* the tube-tube adjacency premise guarantees that this particular tube
          * is unconditionally in [ty], and thus alpha-equivalence is sufficient. *)
         val goalEq = makeEqIfDifferent (I, H) ((substSymbol (r', u) tube, other), ty)
-  
+
         val w = alpha 0
       in
         |>:? goalEq

--- a/src/redprl/refiner_kit.fun
+++ b/src/redprl/refiner_kit.fun
@@ -1,5 +1,9 @@
 functor RefinerKit (Sig : MINI_SIGNATURE) =
 struct
+  structure Tactical = NominalLcfTactical (structure Lcf = Lcf and Spr = UniversalSpread)
+  open Tactical
+  infix orelse_ then_
+
   structure E = RedPrlError and O = RedPrlOpData and T = TelescopeUtil (Lcf.Tl) and Abt = RedPrlAbt and Syn = Syntax and Seq = RedPrlSequent and J = RedPrlJudgment
   structure Env = RedPrlAbt.Metavar.Ctx
   structure Machine = AbtMachineUtil (RedPrlMachine (Sig))
@@ -45,16 +49,7 @@ struct
 
   val trivial = Syn.into Syn.AX
 
-  fun orelse_ (t1, t2) alpha = Lcf.orelse_ (t1 alpha, t2 alpha)
-  infix orelse_
-
-  (* this is a hack till we have a nice way to pre-compose Equality.Symmetry *)
-  fun catJdgFlip (CJ.EQ_TYPE (a, b)) = CJ.EQ_TYPE (b, a)
-    | catJdgFlip (CJ.EQ ((a, b), ty)) = CJ.EQ ((b, a), ty)
-  fun catJdgFlipWrapper tactic alpha (IH >> jdg) =
-    tactic alpha (IH >> catJdgFlip jdg)
-
-  (* combinators *)
+  (* telescope combinators *)
 
   fun |>: g = T.empty >: g
 

--- a/src/redprl/refiner_types.fun
+++ b/src/redprl/refiner_types.fun
@@ -416,11 +416,11 @@ struct
       handle Bind =>
         raise E.error [Fpp.text "Expected dfun truth sequent"]
 
-    fun Eta alpha jdg =
+    fun Eta _ jdg =
       let
         val _ = RedPrlLog.trace "DFun.Eta"
         val (I, H) >> CJ.EQ ((m, n), dfun) = jdg
-        val Syn.DFUN (a, x, bx) = Syn.out dfun
+        val Syn.DFUN (_, x, _) = Syn.out dfun
 
         val xtm = Syn.into @@ Syn.VAR (x, O.EXP)
         val m' = Syn.into @@ Syn.LAM (x, Syn.into @@ Syn.AP (m, xtm))
@@ -459,10 +459,10 @@ struct
         |>: goalA >: goal2 #> (I, H, hole2')
       end
 
-    fun ApEq alpha jdg =
+    fun ApEq _ jdg =
       let
         val _ = RedPrlLog.trace "DFun.ApEq"
-        val (I, H) >> CJ.EQ ((ap0, ap1), c) = jdg
+        val (I, H) >> CJ.EQ ((ap0, ap1), _) = jdg
         val Syn.AP (m0, n0) = Syn.out ap0
         val Syn.AP (m1, n1) = Syn.out ap1
 
@@ -518,11 +518,11 @@ struct
         |>: goal1 >: goal2 >: goalFam #> (I, H, trivial)
       end
 
-    fun Eta alpha jdg =
+    fun Eta _ jdg =
       let
         val _ = RedPrlLog.trace "DProd.Eta"
         val (I, H) >> CJ.EQ ((m, n), dprod) = jdg
-        val Syn.DPROD (a, x, bx) = Syn.out dprod
+        val Syn.DPROD _ = Syn.out dprod
 
         val m' = Syn.into @@ Syn.PAIR (Syn.into @@ Syn.FST m, Syn.into @@ Syn.SND m)
         val goal1 = makeMem (I, H) (m, dprod)
@@ -531,7 +531,7 @@ struct
         |>: goal1 >:? goal2 #> (I, H, trivial)
       end
 
-    fun FstEq alpha jdg =
+    fun FstEq _ jdg =
       let
         val _ = RedPrlLog.trace "DProd.FstEq"
         val (I, H) >> CJ.EQ ((fst0, fst1), ty) = jdg
@@ -547,7 +547,7 @@ struct
         #> (I, H, trivial)
       end
 
-    fun SndEq alpha jdg =
+    fun SndEq _ jdg =
       let
         val _ = RedPrlLog.trace "DProd.SndEq"
         val (I, H) >> CJ.EQ ((snd0, snd1), ty) = jdg
@@ -617,7 +617,7 @@ struct
 
   structure Path =
   struct
-    fun EqType alpha jdg =
+    fun EqType _ jdg =
       let
         val _ = RedPrlLog.trace "Path.EqType"
         val (I, H) >> CJ.EQ_TYPE (ty0, ty1) = jdg
@@ -686,7 +686,7 @@ struct
         |>: goalM >:? goalM00 >:? goalM01 #> (I, H, trivial)
       end
 
-    fun ApEq alpha jdg =
+    fun ApEq _ jdg =
       let
         val _ = RedPrlLog.trace "Path.ApEq"
         val (I, H) >> CJ.EQ ((ap0, ap1), ty) = jdg
@@ -701,7 +701,7 @@ struct
         |>: goalSynth >:? goalMem >: goalLine >:? goalTy #> (I, H, trivial)
       end
 
-    fun ApConstCompute alpha jdg =
+    fun ApConstCompute _ jdg =
       let
         val _ = RedPrlLog.trace "Path.ApConstCompute"
         val (I, H) >> CJ.EQ ((ap, p), a) = jdg
@@ -718,11 +718,11 @@ struct
         #> (I, H, trivial)
       end
 
-    fun Eta alpha jdg =
+    fun Eta _ jdg =
       let
         val _ = RedPrlLog.trace "Path.Eta"
         val (I, H) >> CJ.EQ ((m, n), pathTy) = jdg
-        val Syn.PATH_TY ((u, a), p0, p1) = Syn.out pathTy
+        val Syn.PATH_TY ((u, _), _, _) = Syn.out pathTy
 
         val m' = Syn.into @@ Syn.PATH_ABS (u, Syn.into @@ Syn.PATH_AP (m, P.ret u))
         val goal1 = makeMem (I, H) (m, pathTy)

--- a/src/redprl/sequent.sml
+++ b/src/redprl/sequent.sml
@@ -95,7 +95,7 @@ struct
 
 
   val rec eq =
-    fn (jdg1 as (I1, H1) >> catjdg1, jdg2 as (I2, H2) >> catjdg2) =>
+    fn ((I1, H1) >> catjdg1, (I2, H2) >> catjdg2) =>
        (let
 
          fun unifyPsorts (sigma1, sigma2) =
@@ -116,14 +116,11 @@ struct
          val H2' = Hyps.map (CJ.map (CJ.Tm.substSymenv srho2)) (relabelHyps H2 xrho2)
          val catjdg1' = CJ.map (CJ.Tm.substSymenv srho1 o renameHypsInTerm xrho1) catjdg1
          val catjdg2' = CJ.map (CJ.Tm.substSymenv srho2 o renameHypsInTerm xrho2) catjdg2
-
-         val jdg1' = (I, H1') >> catjdg1'
-         val jdg2' = (I, H2') >> catjdg2'
        in
          telescopeEq (H1', H2')
            andalso CJ.eq (catjdg1', catjdg2')
        end
-       handle exn => false)
+       handle _ => false)
      | (MATCH (th1, k1, a1, ps1, ms1), MATCH (th2, k2, a2, ps2, ms2)) =>
           CJ.Tm.O.eq CJ.Tm.Sym.eq (th1, th2)
             andalso k1 = k2

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -143,7 +143,7 @@ struct
     structure MetaCtx = Tm.Metavar.Ctx
 
     structure LcfModel = LcfModel (MiniSig)
-    structure Refiner = NominalLcfSemantics (LcfModel)
+    structure LcfSemantics = NominalLcfSemantics (LcfModel)
 
     fun elabDeclArguments args =
       List.foldr
@@ -361,7 +361,7 @@ struct
           val (_, tau) = RedPrlJudgment.sort seqjdg
           val pos = getAnnotation script
         in
-          E.wrap (pos, fn _ => Refiner.tactic (sign, Var.Ctx.empty) script names seqjdg)
+          E.wrap (pos, fn _ => LcfSemantics.tactic (sign, Var.Ctx.empty) script names seqjdg)
         end
 
       structure Tl = TelescopeUtil (Lcf.Tl)

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -489,7 +489,7 @@ struct
       let
         val sign' = Telescope.truncateFrom sign opid
       in
-        Telescope.snoc sign opid (decl, pos)
+        Telescope.snoc sign' opid (decl, pos)
       end
       handle Telescope.Duplicate l => error pos [Fpp.text "Duplicate identitifier:", Fpp.text l]
 

--- a/src/redprl/signature_mini.sml
+++ b/src/redprl/signature_mini.sml
@@ -10,7 +10,6 @@ struct
   type valence = RedPrlArity.valence
   type symbol = Tm.symbol
   type opid = Tm.symbol
-  type proof_state = Lcf.jdg Lcf.state
   type jdg = RedPrlJudgment.jdg
 
   type 'a params = ('a * psort) list
@@ -137,10 +136,8 @@ struct
     fun resuscitateTheorem sign opid ps args =
       let
         val entry = lookup sign opid
-        val paramsSig = #params entry
-        val argsSig = #arguments entry
         val goal = case #spec entry of SOME goal => goal | _ => raise Fail "Reviving theorem failed: goal missing"
-        val state as Lcf.|> (subgoals, validation) = #state entry
+        val Lcf.|> (subgoals, validation) = #state entry
 
         val (mrho, srho) = unifyCustomOperator entry ps args
         val vrho = hypothesisRenaming entry ps
@@ -157,7 +154,7 @@ struct
         (goal', state')
       end
 
-      fun extract (Lcf.|> (subgoals, validation)) =
+      fun extract (Lcf.|> (_, validation)) =
         case outb validation of
            _ \ term => term
     end


### PR DESCRIPTION
This addresses, among other things, the issue where we couldn't write a composite tactic inside the refiner; so now we directly compose `Symmetry` with various rules in the tactics.