### PR TITLE
some experiments with pretypes

### DIFF
--- a/src/redprl/categorical_judgment.sml
+++ b/src/redprl/categorical_judgment.sml
@@ -1,9 +1,11 @@
 structure RedPrlCategoricalJudgment :
 sig
+  datatype type_kind = KAN_TYPE | PRETYPE
+
   datatype 'a redprl_jdg =
      EQ of ('a * 'a) * 'a
    | TRUE of 'a
-   | EQ_TYPE of 'a * 'a
+   | EQ_TYPE of type_kind * 'a * 'a
    | SYNTH of 'a
    | TERM of RedPrlSort.t
 
@@ -13,10 +15,12 @@ sig
   include CATEGORICAL_JUDGMENT where type 'a jdg = 'a redprl_jdg
 end =
 struct
+  datatype type_kind = KAN_TYPE | PRETYPE
+
   datatype 'a redprl_jdg =
      EQ of ('a * 'a) * 'a
    | TRUE of 'a
-   | EQ_TYPE of 'a * 'a
+   | EQ_TYPE of type_kind * 'a * 'a
    | SYNTH of 'a
    | TERM of RedPrlSort.t
 
@@ -24,14 +28,14 @@ struct
     EQ ((m, m), a)
 
   fun TYPE a =
-    EQ_TYPE (a, a)
+    EQ_TYPE (KAN_TYPE, a, a)
 
   type 'a jdg = 'a redprl_jdg
 
   fun map f =
     fn EQ ((m, n), a) => EQ ((f m, f n), f a)
      | TRUE a => TRUE (f a)
-     | EQ_TYPE (a, b) => EQ_TYPE (f a, f b)
+     | EQ_TYPE (k, a, b) => EQ_TYPE (k, f a, f b)
      | SYNTH a => SYNTH (f a)
      | TERM tau => TERM tau
 
@@ -55,10 +59,13 @@ struct
     type abt = abt
     type sort = sort
 
+    fun isKan KAN_TYPE = true
+      | isKan _ = false
+
     val toAbt =
       fn EQ ((m, n), a) => O.MONO O.JDG_EQ $$ [([],[]) \ m, ([],[]) \ n, ([],[]) \ a]
        | TRUE a => O.MONO O.JDG_TRUE $$ [([],[]) \ a]
-       | EQ_TYPE (a, b) => O.MONO O.JDG_EQ_TYPE $$ [([],[]) \ a, ([],[]) \ b]
+       | EQ_TYPE (k, a, b) => O.MONO (O.JDG_EQ_TYPE (isKan k)) $$ [([],[]) \ a, ([],[]) \ b]
        | SYNTH m => O.MONO O.JDG_SYNTH $$ [([],[]) \ m]
        | TERM tau => O.MONO (O.JDG_TERM tau) $$ []
 
@@ -66,7 +73,7 @@ struct
       case RedPrlAbt.out jdg of
          O.MONO O.JDG_EQ $ [_ \ m, _\ n, _ \ a] => EQ ((m, n), a)
        | O.MONO O.JDG_TRUE $ [_ \ a] => TRUE a
-       | O.MONO O.JDG_EQ_TYPE $ [_ \ m, _\ n] => EQ_TYPE (m, n)
+       | O.MONO (O.JDG_EQ_TYPE k) $ [_ \ m, _\ n] => EQ_TYPE (if k then KAN_TYPE else PRETYPE, m, n)
        | O.MONO O.JDG_SYNTH $ [_ \ m] => SYNTH m
        | O.MONO (O.JDG_TERM tau) $ [] => TERM tau
        | _ => raise InvalidJudgment
@@ -77,7 +84,7 @@ struct
   fun pretty f =
     fn EQ ((m, n), a) => Fpp.hsep [f m, Fpp.Atomic.equals, f n, Fpp.text "in", f a]
      | TRUE a => f a
-     | EQ_TYPE (a, b) => Fpp.hsep [f a, Fpp.Atomic.equals, f b, Fpp.text "type"]
+     | EQ_TYPE (k, a, b) => Fpp.hsep [f a, Fpp.Atomic.equals, f b, if isKan k then Fpp.text "type" else Fpp.text "pretype"]
      | SYNTH m => Fpp.hsep [f m, Fpp.text "synth"]
      | TERM tau => TermPrinter.ppSort tau
 

--- a/src/redprl/categorical_judgment.sml
+++ b/src/redprl/categorical_judgment.sml
@@ -10,7 +10,7 @@ sig
    | TERM of RedPrlSort.t
 
   val MEM : 'a * 'a -> 'a redprl_jdg
-  val TYPE : 'a -> 'a redprl_jdg
+  val TYPE : type_kind * 'a -> 'a redprl_jdg
 
   include CATEGORICAL_JUDGMENT where type 'a jdg = 'a redprl_jdg
 end =
@@ -27,8 +27,8 @@ struct
   fun MEM (m, a) =
     EQ ((m, m), a)
 
-  fun TYPE a =
-    EQ_TYPE (KAN_TYPE, a, a)
+  fun TYPE (k, a) =
+    EQ_TYPE (k, a, a)
 
   type 'a jdg = 'a redprl_jdg
 

--- a/src/redprl/machine.sml
+++ b/src/redprl/machine.sml
@@ -263,7 +263,7 @@ struct
 
      | O.MONO O.JDG_EQ `$ _ <: _ => S.VAL
      | O.MONO O.JDG_CEQ `$ _ <: _ => S.VAL
-     | O.MONO O.JDG_EQ_TYPE `$ _ <: _ => S.VAL
+     | O.MONO (O.JDG_EQ_TYPE _) `$ _ <: _ => S.VAL
      | O.MONO O.JDG_TRUE `$ _ <: _ => S.VAL
      | O.MONO O.JDG_SYNTH `$ _ <: _ => S.VAL
 

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -134,7 +134,7 @@ struct
    | DEV_DFUN_INTRO | DEV_DPROD_INTRO | DEV_PATH_INTRO
    | DEV_LET of RedPrlSort.t
 
-   | JDG_EQ | JDG_CEQ | JDG_TRUE | JDG_EQ_TYPE | JDG_SYNTH | JDG_TERM of RedPrlSort.t
+   | JDG_EQ | JDG_CEQ | JDG_TRUE | JDG_EQ_TYPE of bool | JDG_SYNTH | JDG_TERM of RedPrlSort.t
 
   type psort = RedPrlArity.Vl.PS.t
   type 'a equation = 'a P.term * 'a P.term
@@ -244,7 +244,7 @@ struct
      | JDG_EQ => [[] * [] <> EXP, [] * [] <> EXP, [] * [] <> EXP] ->> JDG
      | JDG_CEQ => [[] * [] <> EXP, [] * [] <> EXP] ->> JDG
      | JDG_TRUE => [[] * [] <> EXP] ->> JDG
-     | JDG_EQ_TYPE => [[] * [] <> EXP, [] * [] <> EXP] ->> JDG
+     | JDG_EQ_TYPE k => [[] * [] <> EXP, [] * [] <> EXP] ->> JDG
      | JDG_SYNTH => [[] * [] <> EXP] ->> JDG
      | JDG_TERM _ => [] ->> JDG
 
@@ -473,7 +473,7 @@ struct
      | JDG_EQ => "eq"
      | JDG_CEQ => "ceq"
      | JDG_TRUE => "true"
-     | JDG_EQ_TYPE => "eq-type"
+     | JDG_EQ_TYPE k => "eq-type"
      | JDG_SYNTH => "synth"
      | JDG_TERM tau => RedPrlSort.toString tau
 

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -382,8 +382,8 @@ rawTerm
 
 rawJudgment
   : term JDG_TRUE (Ast.$$ (O.MONO O.JDG_TRUE, [\ (([],[]), term)]))
-  | term EQUALS term JDG_TYPE (Ast.$$ (O.MONO O.JDG_EQ_TYPE, [\ (([],[]), term1), \ (([],[]), term2)]))
-  | term JDG_TYPE (Ast.$$ (O.MONO O.JDG_EQ_TYPE, [\ (([],[]), term), \ (([],[]), term)]))
+  | term EQUALS term JDG_TYPE (Ast.$$ (O.MONO (O.JDG_EQ_TYPE true), [\ (([],[]), term1), \ (([],[]), term2)]))
+  | term JDG_TYPE (Ast.$$ (O.MONO (O.JDG_EQ_TYPE true), [\ (([],[]), term), \ (([],[]), term)]))
   | term JDG_SYNTH (Ast.$$ (O.MONO O.JDG_SYNTH, [\ (([],[]), term)]))
   | term SQUIGGLE term (Ast.$$ (O.MONO O.JDG_CEQ, [\ (([],[]), term1), \ (([],[]), term2)]))
   | term EQUALS term IN term (Ast.$$ (O.MONO O.JDG_EQ, [\ (([],[]), term1), \ (([],[]), term2), \ (([],[]), term3)]))
@@ -402,7 +402,7 @@ symBindings
 
 src_catjdg
   : term JDG_TRUE (CJ.TRUE term)
-  | term EQUALS term JDG_TYPE (CJ.EQ_TYPE (term1, term1))
+  | term EQUALS term JDG_TYPE (CJ.EQ_TYPE (CJ.KAN_TYPE, term1, term1))
   | term JDG_TYPE (CJ.TYPE term)
   | term JDG_SYNTH (CJ.SYNTH term)
   | term EQUALS term IN term (CJ.EQ ((term1, term2), term3))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -123,7 +123,7 @@ end
  | MTAC_REC | MTAC_PROGRESS | MTAC_REPEAT | MTAC_AUTO | MTAC_HOLE
  | RULE_ID | RULE_AUTO_STEP | RULE_SYMMETRY | RULE_ELIM | RULE_HEAD_EXP | RULE_LEMMA | RULE_CUT_LEMMA | RULE_UNFOLD
 
- | JDG_TRUE | JDG_TYPE | JDG_SYNTH
+ | JDG_TRUE | JDG_TYPE | JDG_PRETYPE | JDG_SYNTH
 
 %nonassoc SQUIGGLE
 %right LEFT_ARROW RIGHT_ARROW DOUBLE_PIPE SEMI
@@ -382,6 +382,7 @@ rawTerm
 
 rawJudgment
   : term JDG_TRUE (Ast.$$ (O.MONO O.JDG_TRUE, [\ (([],[]), term)]))
+  | term EQUALS term JDG_PRETYPE (Ast.$$ (O.MONO (O.JDG_EQ_TYPE false), [\ (([],[]), term1), \ (([],[]), term2)]))
   | term EQUALS term JDG_TYPE (Ast.$$ (O.MONO (O.JDG_EQ_TYPE true), [\ (([],[]), term1), \ (([],[]), term2)]))
   | term JDG_TYPE (Ast.$$ (O.MONO (O.JDG_EQ_TYPE true), [\ (([],[]), term), \ (([],[]), term)]))
   | term JDG_SYNTH (Ast.$$ (O.MONO O.JDG_SYNTH, [\ (([],[]), term)]))
@@ -402,8 +403,10 @@ symBindings
 
 src_catjdg
   : term JDG_TRUE (CJ.TRUE term)
+  | term EQUALS term JDG_PRETYPE (CJ.EQ_TYPE (CJ.PRETYPE, term1, term1))
   | term EQUALS term JDG_TYPE (CJ.EQ_TYPE (CJ.KAN_TYPE, term1, term1))
-  | term JDG_TYPE (CJ.TYPE term)
+  | term JDG_PRETYPE (CJ.TYPE (CJ.PRETYPE, term))
+  | term JDG_TYPE (CJ.TYPE (CJ.KAN_TYPE, term))
   | term JDG_SYNTH (CJ.SYNTH term)
   | term EQUALS term IN term (CJ.EQ ((term1, term2), term3))
   | term IN term (CJ.MEM (term1, term2))

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -139,6 +139,7 @@ whitespace = [\ \t];
 
 "true"             => (Tokens.JDG_TRUE (posTuple (size yytext)));
 "type"             => (Tokens.JDG_TYPE (posTuple (size yytext)));
+"pretype"          => (Tokens.JDG_PRETYPE (posTuple (size yytext)));
 "synth"            => (Tokens.JDG_SYNTH (posTuple (size yytext)));
 
 {lower}{identChr}* => (Tokens.VARNAME (posTupleWith (size yytext) yytext));

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -43,8 +43,8 @@ struct
     fun Symmetry _ jdg =
     let
       val _ = RedPrlLog.trace "Equality.Symmetry"
-      val (I, H) >> CJ.EQ_TYPE (ty1, ty2) = jdg
-      val goal = makeEqType (I, H) (ty2, ty1)
+      val (I, H) >> CJ.EQ_TYPE (kind, ty1, ty2) = jdg
+      val goal = makeEqType (I, H) kind (ty2, ty1)
     in
       |>: goal #> (I, H, trivial)
     end
@@ -213,7 +213,7 @@ struct
         (* If the types are identical, there is no need to create a new subgoal (which would amount to proving that 'ty' is a type).
            This is because the semantics of sequents is that by assuming that something is a member of a 'ty', we have
            automatically assumed that 'ty' is a type. *)
-        val goalTy = makeEqTypeIfDifferent (I, H) (ty, ty')
+        val goalTy = makeEqTypeIfDifferent (I, H) CJ.PRETYPE (ty, ty')
       in
         |>:? goalTy #> (I, H, trivial)
       end
@@ -245,10 +245,10 @@ struct
         val w = alpha 0
         val ty0w = substSymbol (P.ret w, u0) ty0
         val ty1w = substSymbol (P.ret w, u1) ty1
-        val goalTy = makeEqType (I @ [(w, P.DIM)], H) (ty0w, ty1w)
+        val goalTy = makeEqType (I @ [(w, P.DIM)], H) CJ.KAN_TYPE (ty0w, ty1w)
         (* after proving the above goal, [ty0r] must be a type *)
         val ty0r' = substSymbol (r'0, u0) ty0
-        val goalTy0 = makeEqTypeIfDifferent (I, H) (ty0r', ty)
+        val goalTy0 = makeEqTypeIfDifferent (I, H) CJ.KAN_TYPE (ty0r', ty)
 
         (* coercee *)
         val ty0r = substSymbol (r0, u0) ty0
@@ -265,10 +265,10 @@ struct
         val () = Assert.paramEq "Coe.CapEq source and target of direction" (r, r')
 
         (* type *)
-        val goalTy = makeType (I @ [(u0, P.DIM)], H) ty0
+        val goalTy = makeType (I @ [(u0, P.DIM)], H) CJ.KAN_TYPE ty0
         (* after proving the above goal, [ty0r] must be a type *)
         val ty0r = substSymbol (r, u0) ty0
-        val goalTy0 = makeEqTypeIfDifferent (I, H) (ty0r, ty)
+        val goalTy0 = makeEqTypeIfDifferent (I, H) CJ.KAN_TYPE (ty0r, ty)
 
         (* eq *)
         val goalEq = makeEq (I, H) ((m, other), ty)
@@ -340,10 +340,10 @@ struct
     fun EqTypeHeadExpansion sign _ jdg =
       let
         val _ = RedPrlLog.trace "Computation.EqTypeHeadExpansion"
-        val (I, H) >> CJ.EQ_TYPE (ty1, ty2) = jdg
+        val (I, H) >> CJ.EQ_TYPE (kind, ty1, ty2) = jdg
         val Abt.$ _ = Abt.out ty1 (* is this needed? *)
         val ty1' = Machine.unload sign (safeEval sign (Machine.load ty1))
-        val goal = makeEqType (I, H) (ty1', ty2)
+        val goal = makeEqType (I, H) kind (ty1', ty2)
       in
         |>: goal #> (I, H, trivial)
       end
@@ -635,7 +635,7 @@ struct
 
       fun StepJdg sign = matchGoal
         (fn _ >> CJ.TRUE ty => StepTrue sign ty
-          | _ >> CJ.EQ_TYPE tys => StepEqType sign tys
+          | _ >> CJ.EQ_TYPE (_, a, b) => StepEqType sign (a, b)
           | _ >> CJ.EQ ((m, n), ty) => StepEq sign ((m, n), ty)
           | _ >> CJ.SYNTH m => StepSynth sign m
           | MATCH _ => Misc.MatchOperator)

--- a/src/redprl/refiner_composition_kit.fun
+++ b/src/redprl/refiner_composition_kit.fun
@@ -146,8 +146,8 @@ struct
         val _ = Assert.tautologicalEquations "HCom.Eq tautology checking" eqs0
 
         (* type *)
-        val goalTy = makeEqType (I, H) (ty0, ty1)
-        val goalTy0 = makeEqTypeIfDifferent (I, H) (ty0, ty)
+        val goalTy = makeEqType (I, H) CJ.KAN_TYPE (ty0, ty1)
+        val goalTy0 = makeEqTypeIfDifferent (I, H) CJ.KAN_TYPE (ty0, ty)
 
         (* cap *)
         val goalCap = makeEq (I, H) ((cap0, cap1), ty)
@@ -172,7 +172,7 @@ struct
         val _ = Assert.tautologicalEquations "HCom.CapEq tautology checking" (List.map #1 tubes)
 
         (* type *)
-        val goalTy0 = makeEqType (I, H) (ty0, ty)
+        val goalTy0 = makeEqType (I, H) CJ.KAN_TYPE (ty0, ty)
 
         (* eq *)
         val goalEq = makeEq (I, H) ((cap, other), ty)
@@ -202,7 +202,7 @@ struct
         (* the cap-tube adjacency premise guarantees that [ty] is a type
          * because one of the equations is true, and thus alpha-equivalence
          * is sufficient. *)
-        val goalTy0 = makeEqTypeIfDifferent (I, H) (ty0, ty)
+        val goalTy0 = makeEqTypeIfDifferent (I, H) CJ.KAN_TYPE (ty0, ty)
 
         (* cap *)
         (* the cap-tube adjacency premise guarantees that [cap] is in [ty],
@@ -245,11 +245,10 @@ struct
         (* type *)
         val ty0w = substSymbol (P.ret w, u0) ty0
         val ty1w = substSymbol (P.ret w, u1) ty1
-        val goalTy = makeEqType (I @ [(w,P.DIM)], H) (ty0w, ty1w)
+        val goalTy = makeEqType (I @ [(w,P.DIM)], H) CJ.KAN_TYPE (ty0w, ty1w)
         (* after proving the above goal, we know [ty0] under any substitution is
          * still a type, and thus alpha-equivalence is sufficient. *)
-        val goalTy0 = makeEqTypeIfAllDifferent (I, H)
-              (substSymbol (r'0, u0) ty0, ty) [substSymbol (r'1, u1) ty1]
+        val goalTy0 = makeEqTypeIfAllDifferent (I, H) CJ.KAN_TYPE (substSymbol (r'0, u0) ty0, ty) [substSymbol (r'1, u1) ty1]
 
         (* cap *)
         val ty0r = substSymbol (r0, u0) ty0
@@ -273,11 +272,11 @@ struct
         val _ = Assert.tautologicalEquations "Com.CapEq tautology checking" (List.map #1 tubes)
 
         (* type *)
-        val goalTy = makeType (I @ [(u0,P.DIM)], H) ty0
+        val goalTy = makeType (I @ [(u0,P.DIM)], H) CJ.KAN_TYPE ty0
         (* after proving the above goal, we know [ty0] under any substitution is
          * still a type, and thus alpha-equivalence is sufficient. *)
         val ty0r = substSymbol (r, u0) ty0
-        val goalTy0 = makeEqTypeIfDifferent (I, H) (ty0r, ty)
+        val goalTy0 = makeEqTypeIfDifferent (I, H) CJ.KAN_TYPE (ty0r, ty)
 
         (* eq *)
         (* the reason to choose [ty] not [ty0r] is because [ty] is more likely
@@ -305,11 +304,11 @@ struct
         val (_, (u, tube)) = Option.valOf (List.find (fn (eq, _) => P.eq Sym.eq eq) tubes)
 
         (* type *)
-        val goalTy = makeType (I @ [(u0,P.DIM)], H) ty0
+        val goalTy = makeType (I @ [(u0,P.DIM)], H) CJ.KAN_TYPE ty0
         (* after proving the above goal, we know [ty0] under any substitution is
          * still a type, and thus alpha-equivalence is sufficient. *)
         val ty0r' = substSymbol (r', u0) ty0
-        val goalTy0 = makeEqTypeIfDifferent (I, H) (ty0r', ty)
+        val goalTy0 = makeEqTypeIfDifferent (I, H) CJ.KAN_TYPE (ty0r', ty)
 
         (* cap *)
         (* the cap-tube adjacency premise guarantees that [cap] is in [ty],

--- a/src/redprl/refiner_kit.fun
+++ b/src/redprl/refiner_kit.fun
@@ -99,7 +99,7 @@ struct
   fun makeMatch part = makeGoal @@ MATCH part
 
   (* ignoring the trivial realizer *)
-  fun makeType (I, H) k a = makeGoal' @@ (I, H) >> CJ.TYPE a
+  fun makeType (I, H) k a = makeGoal' @@ (I, H) >> CJ.TYPE (k, a)
   fun makeEqType (I, H) k (a, b) = makeGoal' @@ (I, H) >> CJ.EQ_TYPE (k, a, b)
   fun makeEq (I, H) ((m, n), ty) = makeGoal' @@ (I, H) >> CJ.EQ ((m, n), ty)
   fun makeMem (I, H) (m, ty) = makeGoal' @@ (I, H) >> CJ.MEM (m, ty)

--- a/src/redprl/refiner_kit.fun
+++ b/src/redprl/refiner_kit.fun
@@ -99,19 +99,19 @@ struct
   fun makeMatch part = makeGoal @@ MATCH part
 
   (* ignoring the trivial realizer *)
-  fun makeType (I, H) a = makeGoal' @@ (I, H) >> CJ.TYPE a
-  fun makeEqType (I, H) (a, b) = makeGoal' @@ (I, H) >> CJ.EQ_TYPE (a, b)
+  fun makeType (I, H) k a = makeGoal' @@ (I, H) >> CJ.TYPE a
+  fun makeEqType (I, H) k (a, b) = makeGoal' @@ (I, H) >> CJ.EQ_TYPE (k, a, b)
   fun makeEq (I, H) ((m, n), ty) = makeGoal' @@ (I, H) >> CJ.EQ ((m, n), ty)
   fun makeMem (I, H) (m, ty) = makeGoal' @@ (I, H) >> CJ.MEM (m, ty)
 
   (* conditional goal making *)
-  fun makeEqTypeIfDifferent (I, H) (m, n) =
-    if Abt.eq (m, n) then NONE
-    else SOME (makeGoal' @@ (I, H) >> CJ.EQ_TYPE (m, n))
+  fun makeEqTypeIfDifferent (I, H) k (a, b) =
+    if Abt.eq (a, b) then NONE
+    else SOME (makeGoal' @@ (I, H) >> CJ.EQ_TYPE (k, a, b))
 
-  fun makeEqTypeIfAllDifferent (I, H) (m, n) ns =
+  fun makeEqTypeIfAllDifferent (I, H) k (m, n) ns =
     if List.exists (fn n' => Abt.eq (m, n')) ns then NONE
-    else makeEqTypeIfDifferent (I, H) (m, n)
+    else makeEqTypeIfDifferent (I, H) k (m, n)
 
   fun makeEqIfDifferent (I, H) ((m, n), ty) =
     if Abt.eq (m, n) then NONE

--- a/src/redprl/refiner_types.fun
+++ b/src/redprl/refiner_types.fun
@@ -20,7 +20,7 @@ struct
     fun EqType _ jdg =
       let
         val _ = RedPrlLog.trace "Bool.EqType"
-        val (I, H) >> CJ.EQ_TYPE (a, b) = jdg
+        val (I, H) >> CJ.EQ_TYPE (kind, a, b) = jdg
         val Syn.BOOL = Syn.out a
         val Syn.BOOL = Syn.out b
       in
@@ -98,9 +98,9 @@ struct
         val c0ff = substVar (Syn.into Syn.FF, x) c0x
         val c0m0 = substVar (m0, x) c0x
 
-        val goalTy = makeEqType (I, H @> (z, CJ.TRUE @@ Syn.into Syn.BOOL)) (c0z, c1z)
+        val goalTy = makeEqType (I, H @> (z, CJ.TRUE @@ Syn.into Syn.BOOL)) CJ.KAN_TYPE (c0z, c1z)
         val goalM = makeEq (I, H) ((m0, m1), Syn.into Syn.BOOL)
-        val goalTy0 = makeEqTypeIfDifferent (I, H) (c0m0, c) (* c0m0 type *)
+        val goalTy0 = makeEqTypeIfDifferent (I, H) CJ.KAN_TYPE (c0m0, c) (* c0m0 type *)
         val goalT = makeEq (I, H) ((t0, t1), c0tt)
         val goalF = makeEq (I, H) ((f0, f1), c0ff)
       in
@@ -113,7 +113,7 @@ struct
     fun EqType _ jdg =
       let
         val _ = RedPrlLog.trace "StrictBool.EqType"
-        val (I, H) >> CJ.EQ_TYPE (a, b) = jdg
+        val (I, H) >> CJ.EQ_TYPE (kind, a, b) = jdg
         val Syn.S_BOOL = Syn.out a
         val Syn.S_BOOL = Syn.out b
       in
@@ -208,7 +208,7 @@ struct
     fun EqType _ jdg =
       let
         val _ = RedPrlLog.trace "Void.EqType"
-        val (I, H) >> CJ.EQ_TYPE (a, b) = jdg
+        val (I, H) >> CJ.EQ_TYPE (kind, a, b) = jdg
         val Syn.VOID = Syn.out a
         val Syn.VOID = Syn.out b
       in
@@ -242,7 +242,7 @@ struct
     fun EqType _ jdg =
       let
         val _ = RedPrlLog.trace "S1.EqType"
-        val (I, H) >> CJ.EQ_TYPE (a, b) = jdg
+        val (I, H) >> CJ.EQ_TYPE (kind, a, b) = jdg
         val Syn.S1 = Syn.out a
         val Syn.S1 = Syn.out b
       in
@@ -339,9 +339,9 @@ struct
 
         val S1 = Syn.into Syn.S1
 
-        val goalCz = makeEqType (I, H @> (z, CJ.TRUE S1)) (c0z, c1z)
+        val goalCz = makeEqType (I, H @> (z, CJ.TRUE S1)) CJ.KAN_TYPE (c0z, c1z)
         val goalM = makeEq (I, H) ((m0, m1), S1)
-        val goalCM = makeEqTypeIfDifferent (I, H) (c0m0, c) (* c0m0 type *)
+        val goalCM = makeEqTypeIfDifferent (I, H) CJ.KAN_TYPE (c0m0, c) (* c0m0 type *)
         val goalB = makeEq (I, H) ((b0, b1), cbase)
         val goalL = makeEq (I @ [(u,P.DIM)], H) ((l0u, l1u), cloop)
         val goalL00 = makeEqIfAllDifferent (I, H) ((l00, b0), cbase) [b1]
@@ -358,7 +358,7 @@ struct
     fun EqType alpha jdg =
       let
         val _ = RedPrlLog.trace "DFun.EqType"
-        val (I, H) >> CJ.EQ_TYPE (dfun0, dfun1) = jdg
+        val (I, H) >> CJ.EQ_TYPE (kind, dfun0, dfun1) = jdg
         val Syn.DFUN (a0, x, b0x) = Syn.out dfun0
         val Syn.DFUN (a1, y, b1y) = Syn.out dfun1
 
@@ -367,8 +367,8 @@ struct
         val b0z = substVar (ztm, x) b0x
         val b1z = substVar (ztm, y) b1y
 
-        val goalA = makeEqType (I, H) (a0, a1)
-        val goalB = makeEqType (I, H @> (z, CJ.TRUE a0)) (b0z, b1z)
+        val goalA = makeEqType (I, H) kind (a0, a1)
+        val goalB = makeEqType (I, H @> (z, CJ.TRUE a0)) kind (b0z, b1z)
       in
         |>: goalA >: goalB #> (I, H, trivial)
       end
@@ -391,7 +391,7 @@ struct
         val bw = substVar (wtm, z) bz
 
         val goalM = makeEq (I, H @> (w, CJ.TRUE a)) ((m0w, m1w), bw)
-        val goalA = makeType (I, H) a
+        val goalA = makeType (I, H) CJ.PRETYPE a
       in
         |>: goalM >: goalA #> (I, H, trivial)
       end
@@ -406,7 +406,7 @@ struct
         val ztm = Syn.into @@ Syn.VAR (z, O.EXP)
         val bz = substVar (ztm, x) bx
 
-        val goalA = makeType (I, H) a
+        val goalA = makeType (I, H) CJ.PRETYPE a
         val (goalLam, hole) = makeTrue (I, H @> (z, CJ.TRUE a)) bz
 
         val lam = Syn.into @@ Syn.LAM (z, substVar (ztm, z) hole)
@@ -468,7 +468,7 @@ struct
 
         val (goalDFun0, holeDFun0) = makeSynth (I, H) m0
         val (goalDFun1, holeDFun1) = makeSynth (I, H) m1
-        val goalDFunEq = makeEqTypeIfDifferent (I, H) (holeDFun0, holeDFun1)
+        val goalDFunEq = makeEqTypeIfDifferent (I, H) CJ.PRETYPE (holeDFun0, holeDFun1)
         val (goalDom, holeDom) = makeMatch (O.MONO O.DFUN, 0, holeDFun0, [], [])
         val goalN = makeEq (I, H) ((n0, n1), holeDom)
       in
@@ -482,7 +482,7 @@ struct
     fun EqType alpha jdg =
       let
         val _ = RedPrlLog.trace "DProd.EqType"
-        val (I, H) >> CJ.EQ_TYPE (dprod0, dprod1) = jdg
+        val (I, H) >> CJ.EQ_TYPE (kind, dprod0, dprod1) = jdg
         val Syn.DPROD (a0, x, b0x) = Syn.out dprod0
         val Syn.DPROD (a1, y, b1y) = Syn.out dprod1
 
@@ -491,8 +491,8 @@ struct
         val b0z = substVar (ztm, x) b0x
         val b1z = substVar (ztm, y) b1y
 
-        val goalA = makeEqType (I, H) (a0, a1)
-        val goalB = makeEqType (I, H @> (z, CJ.TRUE a0)) (b0z, b1z)
+        val goalA = makeEqType (I, H) kind (a0, a1)
+        val goalB = makeEqType (I, H @> (z, CJ.TRUE a0)) kind (b0z, b1z)
       in
         |>: goalA >: goalB #> (I, H, trivial)
       end
@@ -513,7 +513,7 @@ struct
 
         val goal1 = makeEq (I, H) ((m0, m1), a)
         val goal2 = makeEq (I, H) ((n0, n1), substVar (m0, x) bx)
-        val goalFam = makeType (I, H @> (z, CJ.TRUE a)) bz
+        val goalFam = makeType (I, H @> (z, CJ.TRUE a)) CJ.PRETYPE bz
       in
         |>: goal1 >: goal2 >: goalFam #> (I, H, trivial)
       end
@@ -541,7 +541,7 @@ struct
         val (goalTy, holeTy) = makeSynth (I, H) m0
         val (goalTyA, holeTyA) = makeMatch (O.MONO O.DPROD, 0, holeTy, [], [])
         val goalEq = makeEqIfDifferent (I, H) ((m0, m1), holeTy) (* m0 well-typed *)
-        val goalEqTy = makeEqTypeIfDifferent (I, H) (holeTyA, ty) (* holeTyA type *)
+        val goalEqTy = makeEqTypeIfDifferent (I, H) CJ.PRETYPE (holeTyA, ty) (* holeTyA type *)
       in
         |>: goalTy >: goalTyA >:? goalEq >:? goalEqTy
         #> (I, H, trivial)
@@ -557,7 +557,7 @@ struct
         val (goalTy, holeTy) = makeSynth (I, H) m0
         val (goalTyB, holeTyB) = makeMatch (O.MONO O.DPROD, 1, holeTy, [], [Syn.into @@ Syn.FST m0])
         val goalEq = makeEqIfDifferent (I, H) ((m0, m1), holeTy) (* m0 well-typed *)
-        val goalEqTy = makeEqTypeIfDifferent (I, H) (holeTyB, ty) (* holeTyB type *)
+        val goalEqTy = makeEqTypeIfDifferent (I, H) CJ.PRETYPE (holeTyB, ty) (* holeTyB type *)
       in
         |>: goalTy >: goalTyB >:? goalEq >:? goalEqTy
         #> (I, H, trivial)
@@ -575,7 +575,7 @@ struct
 
         val (goal1, hole1) = makeTrue (I, H) a
         val (goal2, hole2) = makeTrue (I, H) (substVar (hole1, x) bx)
-        val goalFam = makeType (I, H @> (z, CJ.TRUE a)) bz
+        val goalFam = makeType (I, H @> (z, CJ.TRUE a)) CJ.PRETYPE bz
         val pair = Syn.into @@ Syn.PAIR (hole1, hole2)
       in
         |>: goal1 >: goal2 >: goalFam #> (I, H, pair)
@@ -620,7 +620,7 @@ struct
     fun EqType _ jdg =
       let
         val _ = RedPrlLog.trace "Path.EqType"
-        val (I, H) >> CJ.EQ_TYPE (ty0, ty1) = jdg
+        val (I, H) >> CJ.EQ_TYPE (kind, ty0, ty1) = jdg
         val Syn.PATH_TY ((u, a0u), m0, n0) = Syn.out ty0
         val Syn.PATH_TY ((v, a1v), m1, n1) = Syn.out ty1
 
@@ -629,7 +629,7 @@ struct
         val a00 = substSymbol (P.APP P.DIM0, u) a0u
         val a01 = substSymbol (P.APP P.DIM1, u) a0u
 
-        val tyGoal = makeEqType (I, H) (a0u, a1u)
+        val tyGoal = makeEqType (I, H) CJ.KAN_TYPE (a0u, a1u) (* kind? *)
         val goal0 = makeEq (I, H) ((m0, m1), a00)
         val goal1 = makeEq (I, H) ((n0, n1), a01)
       in
@@ -696,7 +696,7 @@ struct
         val (goalSynth, holeSynth) = makeSynth (I, H) m0
         val goalMem = makeEqIfDifferent (I, H) ((m0, m1), holeSynth) (* m0 well-typed *)
         val (goalLine, holeLine) = makeMatch (O.MONO O.PATH_TY, 0, holeSynth, [r0], [])
-        val goalTy = makeEqTypeIfDifferent (I, H) (holeLine, ty) (* holeLine type *)
+        val goalTy = makeEqTypeIfDifferent (I, H) CJ.KAN_TYPE (holeLine, ty) (* holeLine type *)
       in
         |>: goalSynth >:? goalMem >: goalLine >:? goalTy #> (I, H, trivial)
       end
@@ -711,7 +711,7 @@ struct
         val dimAddr = case r of P.DIM0 => 1 | P.DIM1 => 2
         val (goalLine, holeLine) = makeMatch (O.MONO O.PATH_TY, 0, holeSynth, [P.APP r], [])
         val (goalEndpoint, holeEndpoint) = makeMatch (O.MONO O.PATH_TY, dimAddr, holeSynth, [], [])
-        val goalTy = makeEqType (I, H) (a, holeLine)
+        val goalTy = makeEqType (I, H) CJ.KAN_TYPE (a, holeLine)
         val goalEq = makeEq (I, H) ((holeEndpoint, p), a)
       in
         |>: goalSynth >: goalLine >: goalEndpoint >: goalTy >: goalEq

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -151,7 +151,9 @@ Thm Not : [(-> [_ bool] bool)] by [
 
 Thm FunExt(#A; #B) : [
   type/A : #A type,
-  type/B : #B type
+  type/B : #B type,
+  pretype/A : #A pretype,
+  pretype/B : #B pretype
   >>
   (->
    [f (-> #A #B)]

--- a/test/success/connection.prl
+++ b/test/success/connection.prl
@@ -1,5 +1,6 @@
 Thm Connection(#A) : [
-  a/type : #A type >>
+  a/type : #A type,
+  a/pretype : #A pretype >>
   (->
    [a b #A]
    [p (path {_} #A a b)]

--- a/test/success/hcom.prl
+++ b/test/success/hcom.prl
@@ -7,6 +7,7 @@
 // which witnesses that #A = #A type. We could add a generic tactic that applies a lemma and 
 // *asserts* all its hypotheses, or tries to unify these with the context, etc.
 Thm Hcom/Poly(#A) : [
+  a/pretype : #A pretype,
   a/type : #A type
   >>
   (->
@@ -29,6 +30,7 @@ Thm Hcom/Poly(#A) : [
 Extract Hcom/Poly.
 
 Thm Hcom/trans(#A) : [
+  a/pretype : #A pretype,
   a/type : #A type
   >>
   (->
@@ -47,6 +49,7 @@ Thm Hcom/trans(#A) : [
 ].
 
 Thm Hcom/symm(#A) : [
+  a/pretype : #A pretype,
   a/type : #A type
   >> 
   (->
@@ -64,6 +67,7 @@ Thm Hcom/symm(#A) : [
 ].
 
 Thm Cap{i : dim}(#A) : [ 
+  a/pretype : #A pretype,
   a/type : #A type,
   x : #A
   >> (hcom{0 ~> 0} #A x [i=0 {_} x] [i=1 {_} x]) = x in #A
@@ -72,6 +76,7 @@ Thm Cap{i : dim}(#A) : [
 ].
 
 Thm Tube(#A) : [
+  a/pretype : #A pretype,
   a/type : #A type,
   x : #A
   >> (hcom{0 ~> 1} #A x [1=1 {_} x] [0=0 {_} x]) = x in #A

--- a/test/success/logical-investigations.prl
+++ b/test/success/logical-investigations.prl
@@ -10,8 +10,8 @@
 //
 // Once we have a universe, this will be much simpler.
 Thm Thm1(#A; #B) : [
-  type/A : #A type,
-  type/B : #B type
+  type/A : #A pretype,
+  type/B : #B pretype
   >> (-> #A #B #A)
 ] by [
   // The main part of the theorem is the following expression; but in RedPRL, this induces some
@@ -23,9 +23,9 @@ Thm Thm1(#A; #B) : [
 ].
 
 Thm Thm2(#A; #B; #C) : [
-  type/A : #A type,
-  type/B : #B type,
-  type/C : #C type
+  type/A : #A pretype,
+  type/B : #B pretype,
+  type/C : #C pretype
   >> (-> (-> #A #B) (-> #A #B #C) #A #C)
 ] by [
   {lam f. lam g. lam a.
@@ -43,9 +43,9 @@ Extract Thm2.
 
 // here's a proof using lower-level scripting
 Thm Thm3/low-level(#A; #B; #C) : [
-  type/A : #A type,
-  type/B : #B type,
-  type/C : #C type
+  type/A : #A pretype,
+  type/B : #B pretype,
+  type/C : #C pretype
   >> (->
       (-> #A #B)
       (-> #B #C)
@@ -62,9 +62,9 @@ Extract Thm3/low-level.
 // programming calculus may be longer, but they are often easier to engineer, 
 // and nicely segregate main goals from auxiliary goals.
 Thm Thm3/high-level(#A; #B; #C) : [
-  type/A : #A type,
-  type/B : #B type,
-  type/C : #C type
+  type/A : #A pretype,
+  type/B : #B pretype,
+  type/C : #C pretype
   >> (->
       (-> #A #B)
       (-> #B #C)
@@ -90,7 +90,7 @@ Thm Not/wf(#A) : [
 ].
 
 Thm Thm4(#A; #B) : [
-  type/A : #A type
+  type/A : #A pretype
   >> (-> (Not #A) #A #B)
 ] by [
   { lam r. lam a.
@@ -102,7 +102,7 @@ Thm Thm4(#A; #B) : [
 ].
 
 Thm Thm5(#A) : [
-  type/A : #A type
+  type/A : #A pretype
   >> (-> #A (Not (Not #A)))
 ] by [
   { lam a.
@@ -118,8 +118,8 @@ Print Thm4.
 Print Thm5.
 
 Thm Thm6(#A;#B) : [
-  type/A : #A type,
-  type/B : #B type
+  type/A : #A pretype,
+  type/B : #B pretype
   >> (-> (-> #A #B) (Not #B) (Not #A))
 ] by [
   { lam ab. lam nb.

--- a/test/success/unfold.prl
+++ b/test/success/unfold.prl
@@ -3,7 +3,7 @@ Def Times(#A; #B) = [
 ].
 
 Thm Times/Proj(#A) : [
-  a/type : #A type 
+  a/type : #A pretype 
   >> (-> (Times bool #A) #A)
 ] by [
   {lam x. 


### PR DESCRIPTION
Highly experimental. Since everything in RedPRL is currently Kan, this shouldn't break anything semantically. But this might give us the opportunity to start experimenting with non-Kan types ("cubical pretypes")—we would have subgoals for demonstrating that a type is Kan in (e.g.) the elimination rules for weak bool and S1.