### PR TITLE
[big change] in development calculus, automatically try 'auto'

### DIFF
--- a/src/redprl/machine.fun
+++ b/src/redprl/machine.fun
@@ -55,6 +55,8 @@ struct
 
     fun cut jdg =
       O.MONO O.RULE_CUT $$ [([],[]) \ jdg]
+
+    val autoTac = mtac auto
   end
 
 
@@ -526,14 +528,14 @@ struct
        in
          STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.cut jdg)) [(u, P.HYP tau)] (Tac.each [tac1,tac2])) || (syms, stk)
        end
-     | O.MONO O.DEV_DFUN_INTRO $ [([u],_) \ t] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all Tac.autoStep) [(u, P.HYP O.EXP)] (Tac.each [t])) || (syms, stk)
-     | O.MONO O.DEV_DPROD_INTRO $ [_ \ t1, _ \ t2] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all Tac.autoStep) [] (Tac.each [t1, t2])) || (syms, stk)
-     | O.MONO O.DEV_PATH_INTRO $ [([u], _) \ t] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all Tac.autoStep) [(u, P.DIM)] (Tac.each [t])) || (syms, stk)
+     | O.MONO O.DEV_DFUN_INTRO $ [([u],_) \ t] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all Tac.autoStep) [(u, P.HYP O.EXP)] (Tac.each [t, Tac.autoTac])) || (syms, stk)
+     | O.MONO O.DEV_DPROD_INTRO $ [_ \ t1, _ \ t2] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all Tac.autoStep) [] (Tac.each [t1, t2, Tac.autoTac])) || (syms, stk)
+     | O.MONO O.DEV_PATH_INTRO $ [([u], _) \ t] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all Tac.autoStep) [(u, P.DIM)] (Tac.each [t, Tac.autoTac, Tac.autoTac])) || (syms, stk)
      | O.POLY (O.DEV_BOOL_ELIM z) $ [_ \ t1, _ \ t2] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.elim (z, O.EXP))) [] (Tac.each [t1,t2])) || (syms, stk)
-     | O.POLY (O.DEV_S1_ELIM z) $ [_ \ t1, ([v],_) \ t2] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.elim (z, O.EXP))) [(v, P.DIM)] (Tac.each [t1,t2])) || (syms, stk)
+     | O.POLY (O.DEV_S1_ELIM z) $ [_ \ t1, ([v],_) \ t2] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.elim (z, O.EXP))) [(v, P.DIM)] (Tac.each [t1,t2, Tac.autoTac, Tac.autoTac])) || (syms, stk)
      | O.POLY (O.DEV_DFUN_ELIM z) $ [_ \ t1, ([x,p],_) \ t2] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.elim (z, O.EXP))) [(x, P.HYP O.EXP), (p, P.HYP O.EXP)] (Tac.each [t1,t2])) || (syms, stk)
      | O.POLY (O.DEV_DPROD_ELIM z) $ [([x,y], _) \ t] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.elim (z, O.EXP))) [(x, P.HYP O.EXP), (y, P.HYP O.EXP)] (Tac.each [t])) || (syms, stk)
-     | O.POLY (O.DEV_PATH_ELIM z) $ [_ \ t1, ([x,p],_) \ t2] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.elim (z, O.EXP))) [(x, P.HYP O.EXP), (p, P.HYP O.EXP)] (Tac.each [t1,Tac.mtac Tac.auto, Tac.mtac Tac.auto, t2])) || (syms, stk)
+     | O.POLY (O.DEV_PATH_ELIM z) $ [_ \ t1, ([x,p],_) \ t2] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.elim (z, O.EXP))) [(x, P.HYP O.EXP), (p, P.HYP O.EXP)] (Tac.each [t1, Tac.autoTac, Tac.autoTac, t2])) || (syms, stk)
      | _ => raise Stuck
 
   fun step sign stability (tm || stk) =

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -31,12 +31,23 @@ struct
   fun multitacToTac mt =
     setAnnotation (getAnnotation mt) (O.MONO O.TAC_MTAC $$ [([],[]) \ mt])
 
-  fun tacToMulitac t =
+  fun tacToMultitac t =
     setAnnotation (getAnnotation t) (O.MONO O.MTAC_ALL $$ [([],[]) \ t])
 
   fun orElse (t1, t2) =
-    multitacToTac (O.MONO O.MTAC_ORELSE $$ [([],[]) \ tacToMulitac t1, ([],[]) \ tacToMulitac t2])
+    multitacToTac (O.MONO O.MTAC_ORELSE $$ [([],[]) \ tacToMultitac t1, ([],[]) \ tacToMultitac t2])
 
+  fun then_ (t1, t2) =
+    multitacToTac (makeSeq (tacToMultitac t1) [] (tacToMultitac t2))
+
+  val autoMtac = O.MONO O.MTAC_AUTO $$ []
+  val autoTac = multitacToTac autoMtac
+
+  fun exact tau m = 
+    then_ (O.MONO (O.RULE_EXACT tau) $$ [([],[]) \ m], autoTac)
+
+  fun exactDim r = 
+    exact O.DIM_EXP (O.POLY (O.DIM_REF r) $$ [])
 end
 
 structure Multi =
@@ -508,8 +519,8 @@ atomicRawTac
   | RULE_ELIM VARNAME COLON sort (Ast.$$ (O.POLY (O.RULE_ELIM (VARNAME, sort)), []))
   | RULE_ELIM VARNAME (Ast.$$ (O.POLY (O.RULE_ELIM (VARNAME, O.EXP)), []))
   | RULE_UNFOLD OPNAME (Ast.$$ (O.POLY (O.RULE_UNFOLD OPNAME), []))
-  | BACK_TICK term (Ast.$$ (O.MONO (O.RULE_EXACT O.EXP), [\ (([],[]), term)]))
-  | AMPERSAND param (Ast.$$ (O.MONO (O.RULE_EXACT O.DIM_EXP), [\ (([],[]), Ast.$$ (O.POLY (O.DIM_REF param), []))]))
+  | BACK_TICK term (Tac.exact O.EXP term)
+  | AMPERSAND param (Tac.exactDim param)
   | RULE_HEAD_EXP (Ast.$$ (O.MONO O.RULE_HEAD_EXP, []))
 
   | atomicTac DOUBLE_PIPE tactic %prec DOUBLE_PIPE (Tac.orElse (atomicTac, tactic))
@@ -549,7 +560,7 @@ atomicRawMultitac
   : LSQUARE tactics RSQUARE (Ast.$$ (O.MONO (O.MTAC_EACH (List.length tactics)), List.map (fn t => \ (([],[]), t)) tactics))
   | HASH NUMERAL LBRACKET tactic RBRACKET (Ast.$$ (O.MONO (O.MTAC_FOCUS (IntInf.toInt NUMERAL)), [\ (([],[]), tactic)]))
   | MTAC_REPEAT LBRACKET multitac RBRACKET (Ast.$$ (O.MONO O.MTAC_REPEAT, [\ (([], []), multitac)]))
-  | MTAC_AUTO (Ast.$$ (O.MONO O.MTAC_AUTO, []))
+  | MTAC_AUTO (Tac.autoMtac)
   | MTAC_PROGRESS LBRACKET multitac RBRACKET (Ast.$$ (O.MONO O.MTAC_PROGRESS, [\ (([], []), multitac)]))
   | MTAC_REC VARNAME IN LBRACKET multitac RBRACKET (Ast.$$ (O.MONO O.MTAC_REC, [\ (([],[VARNAME]), multitac)]))
   | LBRACKET multitac RBRACKET (multitac)

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -1,8 +1,7 @@
 Thm BoolTest : [ 
   (-> wbool wbool)
 ] by [
-  { lam x. if x then `tt else `ff };
-  auto
+  lam x. if x then `tt else `ff
 ].
 
 // RedPRL 
@@ -10,7 +9,7 @@ Thm BoolTest : [
 Thm PathTest : [
   (path {_} S1 base base)
 ] by [
-  { <x> `(loop x) }; auto
+  <x> `(loop x)
 ].
 
 Thm LowLevel : [
@@ -20,8 +19,7 @@ Thm LowLevel : [
 ] by [
   fresh f <- auto;
   fresh x, x/eq <- elim f;
-  [ `tt, hyp x];
-  auto
+  [ `tt, hyp x]
 ].
 
 Extract LowLevel.
@@ -31,19 +29,14 @@ Thm FunElimTest : [
     (-> wbool wbool)
     wbool)
 ] by [
-  { lam f. let x = f {`tt}. hyp x };
-
-  auto
+  lam f. let x = f {`tt}. hyp x
 ].
 
 Thm S1ElimTest : [ (-> S1 S1) ] by [
-  { lam s.
+  lam s.
     case s of
        base => `base
      | loop x => `(loop x)
-  };
-
-  auto
 ].
 
 Tac Try(#t : tac) = [
@@ -59,10 +52,7 @@ Thm ApEqTest : [
    [f : (-> wbool wbool)]
    (path {_} wbool ($ f tt) ($ f tt)))
 ] by [
-  { lam f. <_> `($ ,f tt) };
-
-  // Try commenting out the following line, and stepping through the proof with TryStep.
-  auto
+  lam f. <_> `($ ,f tt)
 ].
 
 Def BoolEta(#M) = [
@@ -84,12 +74,9 @@ Thm PathTest2 : [
     (lam [b] b)
     (lam [b] (BoolEta b)))
 ] by [
-  { let h : [(-> [b : wbool] (path {_} wbool b (BoolEta b))) ] =
+  let h : [(-> [b : wbool] (path {_} wbool b (BoolEta b))) ] =
       lam b. if b then <y> `tt else <y> `ff.
     <x> lam c. let p = h {hyp c}. let px = p @ &x. hyp px
-  };
-
-  auto
 ].
 
 // It turns out that it is just as good to figure out what the witness program for this path is
@@ -107,8 +94,7 @@ Thm PathTest3 : [
   `(abs {x} 
     (lam [b]
      (@ (wbool-rec [b] (path {_} wbool b (BoolEta b)) b (abs {_} tt) (abs {_} ff))
-        x)));
-  auto
+        x)))
 ].
 
 Print PathTest3.
@@ -116,8 +102,7 @@ Print PathTest3.
 Thm PairTest : [ (* [a : S1] (path {_} S1 a base)) ] by [
   < `base
   , <x> `(loop x)
-  >;
-  auto
+  >
 ].
 
 
@@ -145,8 +130,7 @@ Thm StrictBoolTest : [ SNot = (Cmp SNot (Cmp SNot SNot)) in (-> bool bool) ] by 
 ].
 
 Thm Not : [(-> [_ : wbool] wbool)] by [
-  {lam x. if x then `ff else `tt};
-  auto
+  lam x. if x then `ff else `tt
 ].
 
 Thm FunExt(#A; #B) : [
@@ -159,9 +143,8 @@ Thm FunExt(#A; #B) : [
    [p : (-> [y : #A] (path {_} #B ($ f y) ($ g y)))]
    (path {_} (-> #A #B) f g))
 ] by [
-  {lam f. lam g. lam p.
+  lam f. lam g. lam p.
     <i> lam a. let q = p hyp a. let qi = q @ &i. hyp qi
-  }; auto
 ].
 
 Print FunExt.
@@ -169,16 +152,13 @@ Print FunExt.
 
 Tac FunExtTac(#A; #B; #F; #G) = [
   let p : [(-> [x : #A] (path {_} wbool ($ #F x) ($ #G x)))] = {}.
-  {<i> lam a. let q = p hyp a. let qi = q @ &i. hyp qi};
-  auto
+  <i> lam a. let q = p hyp a. let qi = q @ &i. hyp qi
 ].
 
 Thm NotNotPath : [(path {_} (-> wbool wbool) (Cmp Not Not) (lam [x] x))] by [
   (FunExtTac wbool wbool (Cmp Not Not) (lam [x] x));
-  { lam x.
+  lam x.
     if x then <_> `tt else <_> `ff
-  };
-  auto
 ].
 
 Extract NotNotPath.
@@ -186,14 +166,12 @@ Print FunExtTac.
 Print NotNotPath.
 
 Thm Singleton : [(* [x : wbool] (path {_} wbool x tt))] by [
-  < `tt, <x> `tt >;
-  auto
+  < `tt, <x> `tt >
 ].
 
 
 Thm PathElimTest : [(-> (path {_} bool tt tt) bool)] by [
-  { lam x. let y = x @ &0. hyp y
-  }; auto
+  lam x. let y = x @ &0. hyp y
 ].
 
 Print PathElimTest.

--- a/test/success/bool-fhcom-without-open-eval.prl
+++ b/test/success/bool-fhcom-without-open-eval.prl
@@ -5,11 +5,9 @@ Thm FHcom/trans3 : [
    (path {_} wbool b d)
    (path {_} wbool c d))
 ] by [
-  { <a> lam b. lam c. lam d.
+  <a> lam b. lam c. lam d.
     lam pab. lam pac. lam pbd.
     <i> `(fcom{0~>1} (@ ,pab i) [i=0 {j} (@ ,pac j)] [i=1 {j} (@ ,pbd j)])
-  };
-  auto
 ].
 
 Print FHcom/trans3.
@@ -20,10 +18,8 @@ Thm FHcom/trans2 : [
    (path {_} wbool b c)
    (path {_} wbool a c))
 ] by [
-  { lam a. lam b. lam c. lam pab. lam pbc.
+  lam a. lam b. lam c. lam pab. lam pbc.
     <i> `(fcom{0~>1} (@ ,pab i) [i=0 {_} ,a] [i=1 {j} (@ ,pbc j)])
-  };
-  auto
 ].
 
 Thm FHcom/symm : [
@@ -31,10 +27,8 @@ Thm FHcom/symm : [
    (path {_} wbool a b)
    (path {_} wbool b a))
 ] by [
-  { lam a. lam b. lam pab.
+  lam a. lam b. lam pab.
     <i> `(fcom{0~>1} ,a [i=0 {j} (@,pab j)] [i=1 {_} ,a])
-  };
-  auto
 ].
 
 Thm Tube : [

--- a/test/success/conflict.prl
+++ b/test/success/conflict.prl
@@ -2,5 +2,5 @@
 // string parses as `all(id)`. For example `[]` could mean each() or
 // each(all(id)). The current parser arbitrarily chooses the latter.
 Thm Square-bracket : [ (-> (-> bool bool) bool) ] by [
-  {lam f. `tt}; []; auto
+  {lam f. `tt}; []
 ].

--- a/test/success/connection.prl
+++ b/test/success/connection.prl
@@ -5,7 +5,7 @@ Thm Connection(#A) : [
    [p : (path {_} #A a b)]
    (path {i} (path {_} #A a (@ p i)) (abs {_} a) p))
 ] by [
-  { lam a. lam b. lam p.
+  lam a. lam b. lam p.
     <i> <j> 
       `(hcom{0~>1} #A ,a
         [i=0 {k}
@@ -30,8 +30,6 @@ Thm Connection(#A) : [
          (hcom{1~>i} #A (@ ,p k)
           [k=0 {_} ,a]
           [k=1 {l} (@ ,p l)])])
-  };
-  auto
 ].
 
 Print Connection.

--- a/test/success/dashes-n-slashes.prl
+++ b/test/success/dashes-n-slashes.prl
@@ -1,5 +1,4 @@
 // Identifiers can contain hyphens and slashes
 Thm Ident-test/ : [ bool ] by [
   { `tt };
-  auto
 ].

--- a/test/success/hcom.prl
+++ b/test/success/hcom.prl
@@ -16,14 +16,12 @@ Thm Hcom/Poly(#A) : [
    (path {_} #A b d)
    (path {_} #A c d))
 ] by [
-  { lam a. lam b. lam c. lam d.
-    lam pab. lam pac. lam pbd.
+  lam a. lam b. lam c. lam d.
+  lam pab. lam pac. lam pbd.
     <i> 
       `(hcom{0 ~> 1} #A (@ ,pab i) 
         [i=0 {j} (@ ,pac j)]
         [i=1 {j} (@ ,pbd j)])
-  };
-  auto
 ].
 
 Extract Hcom/Poly.
@@ -37,13 +35,11 @@ Thm Hcom/trans(#A) : [
    (path {_} #A b c)
    (path {_} #A a c))
 ] by [
-  { lam a. lam b. lam c. lam pab. lam pbc.
+  lam a. lam b. lam c. lam pab. lam pbc.
     <i>
       `(hcom{0 ~> 1} #A (@ ,pab i) 
         [i=0 {_} ,a] 
         [i=1 {j} (@ ,pbc j)])
-  };
-  auto
 ].
 
 Thm Hcom/symm(#A) : [
@@ -54,13 +50,11 @@ Thm Hcom/symm(#A) : [
    (path {_} #A a b)
    (path {_} #A b a))
 ] by [
-  { lam a. lam b. lam pab.
+  lam a. lam b. lam pab.
     <i>
       `(hcom{0 ~> 1} #A ,a 
         [i=0 {j} (@ ,pab j)]
         [i=1 {_} ,a])
-  };
-  auto
 ].
 
 Thm Cap{i : dim}(#A) : [ 

--- a/test/success/path-ap-const.prl
+++ b/test/success/path-ap-const.prl
@@ -1,8 +1,7 @@
 Thm PathApConst : [
   (-> (path {_} bool tt tt) bool)
 ] by [
-  { lam p. let p0 = p @ &0. hyp p0};
-  auto;
+  lam p. let p0 = p @ &0. hyp p0
 ].
 
 Print PathApConst.

--- a/test/success/path-ap-const.prl
+++ b/test/success/path-ap-const.prl
@@ -1,7 +1,7 @@
 Thm PathApConst : [
   (-> (path {_} bool tt tt) bool)
 ] by [
-  { lam p. let p0 = p @ &0. hyp p0 };
+  { lam p. let p0 = p @ &0. hyp p0};
   auto;
 ].
 

--- a/test/success/record.prl
+++ b/test/success/record.prl
@@ -41,6 +41,5 @@ Thm RecordTest6 : [
     [p : (record [a : bool] [b c : record])]
     bool)
 ] by [
-  { lam p. `(! a ,p) };
-  auto
+  lam p. `(! a ,p)
 ].

--- a/test/success/strict-bool.prl
+++ b/test/success/strict-bool.prl
@@ -18,8 +18,7 @@ Thm SBool/Not-Not-Id-Path : [
     (Cmp Bool/Not Bool/Not)
     (lam [x] x))
 ] by [
-  {<i> lam x. hyp x};
-  auto
+  <i> lam x. hyp x
 ].
 
 Extract SBool/Not-Not-Id-Path.

--- a/test/success/unfold.prl
+++ b/test/success/unfold.prl
@@ -6,13 +6,10 @@ Thm Times/Proj(#A) : [
   a/type : #A type 
   >> (-> (Times bool #A) #A)
 ] by [
-  {lam x. 
+  lam x. 
     unfold Times;
     let <y, z> = x.
     hyp z
-  };
-
-  auto
 ].
 
 Extract Times/Proj.


### PR DESCRIPTION
Currently, when you use the development calculus, you write the "important" parts of your program and the remainder are left as holes that must be filled. For example:

```
lam x. hyp x
```

leaves behind an extra subgoal, that the domain of your function type is itself a type. This can be confusing to users, as now you have to add braces and a call to `auto`, as follows:

```
{lam x. hyp x}; auto
```

I did it this way because originally, I expected that `auto` might be poorly-behaved (and possibly loop, etc.). But what I've found in practice is that it works really well, and pretty much always succeeds in resolving auxiliary subgoals. So, it makes sense to automatically insert it rather than leaving behind these silly holes.

This change means that as we continue to develop `auto`, we should do our very best to ensure that it doesn't loop. In practice, this may mean adding an amount of "gas" that it is allowed to spend before giving up. But I only want to address that once it becomes an issue in practice, *not before*.

In the case that a user doesn't want `auto` to be applied automatically, they can use the low-level scripting instead of the development calculus terms. Later on, maybe we would add some special syntax to the development calculus for explicitly supplying scripts to be used instead of `auto`, etc. But that's for later.