### PR TITLE
add flexible unfolding regimes

### DIFF
--- a/src/redprl/lcf_model.fun
+++ b/src/redprl/lcf_model.fun
@@ -38,7 +38,7 @@ struct
       | _ => raise E.error [Fpp.text "Invalid rule", TermPrinter.ppTerm rule]
 
   fun rule (sign, env) rule alpha goal =
-    Debug.wrap (fn _ => interpret (sign, env) (Machine.eval sign Machine.NOMINAL rule) alpha goal)
+    Debug.wrap (fn _ => interpret (sign, env) (Machine.eval sign Machine.NOMINAL Machine.Unfolding.always rule) alpha goal)
     handle exn => raise RedPrlError.annotate (getAnnotation rule) exn
 
   fun printHole (pos : Pos.t, name : string option) (state : Lcf.jdg Lcf.state) =

--- a/src/redprl/lcf_syntax.fun
+++ b/src/redprl/lcf_syntax.fun
@@ -20,7 +20,7 @@ struct
      | _ => t2
 
   fun evalOpen sign t =
-    inheritAnnotation t (Machine.eval sign Machine.NOMINAL t)
+    inheritAnnotation t (Machine.eval sign Machine.NOMINAL Machine.Unfolding.always t)
       handle _ => t
 
   local

--- a/src/redprl/machine.sig
+++ b/src/redprl/machine.sig
@@ -2,6 +2,7 @@ signature REDPRL_MACHINE =
 sig
   type sign
   type abt
+  type opid
 
   exception Unstable
 
@@ -19,6 +20,7 @@ sig
   datatype blocker =
      VAR of RedPrlAbt.variable
    | METAVAR of RedPrlAbt.metavariable
+   | OPERATOR of opid
 
   exception Stuck
   exception Neutral of blocker
@@ -30,10 +32,24 @@ sig
    | STUCK
    | UNSTABLE
 
-  val eval : sign -> stability -> abt -> abt
+  structure Unfolding :
+  sig
+    type regime = opid -> bool
+
+    (* Don't unfold operators for which we have type information! *)
+    val default : sign -> regime
+
+    (* Don't unfold any operators *)
+    val never : regime
+
+    (* Always unfold operators *)
+    val always : regime
+  end
+
+  val eval : sign -> stability -> Unfolding.regime -> abt -> abt
 
   (* Execute a term for 'n' steps; compatibility/congruence steps don't count. *)
-  val steps : sign -> stability -> int -> abt -> abt
+  val steps : sign -> stability -> Unfolding.regime -> int -> abt -> abt
 
-  val canonicity : sign -> stability -> abt -> canonicity
+  val canonicity : sign -> stability -> Unfolding.regime -> abt -> canonicity
 end

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -44,10 +44,13 @@ struct
   val autoTac = multitacToTac autoMtac
 
   fun exact tau m = 
-    then_ (O.MONO (O.RULE_EXACT tau) $$ [([],[]) \ m], autoTac)
+    O.MONO (O.RULE_EXACT tau) $$ [([],[]) \ m]
+
+  fun exactAuto tau m = 
+    then_ (exact tau m, autoTac)
 
   fun exactDim r = 
-    exact O.DIM_EXP (O.POLY (O.DIM_REF r) $$ [])
+    exactAuto O.DIM_EXP (O.POLY (O.DIM_REF r) $$ [])
 end
 
 structure Multi =
@@ -159,6 +162,7 @@ end
  | THEN | ELSE
  | MTAC_REC | MTAC_PROGRESS | MTAC_REPEAT | MTAC_AUTO | MTAC_HOLE
  | RULE_ID | RULE_AUTO_STEP | RULE_SYMMETRY | RULE_ELIM | RULE_HEAD_EXP | RULE_LEMMA | RULE_CUT_LEMMA | RULE_UNFOLD
+ | RULE_EXACT
 
  (* keywords in judgments *)
  | JDG_TRUE | JDG_TYPE | JDG_SYNTH
@@ -523,7 +527,8 @@ atomicRawTac
   | RULE_ELIM VARNAME COLON sort (Ast.$$ (O.POLY (O.RULE_ELIM (VARNAME, sort)), []))
   | RULE_ELIM VARNAME (Ast.$$ (O.POLY (O.RULE_ELIM (VARNAME, O.EXP)), []))
   | RULE_UNFOLD OPNAME (Ast.$$ (O.POLY (O.RULE_UNFOLD OPNAME), []))
-  | BACK_TICK term (Tac.exact O.EXP term)
+  | BACK_TICK term (Tac.exactAuto O.EXP term)
+  | RULE_EXACT term (Tac.exact O.EXP term)
   | AMPERSAND param (Tac.exactDim param)
   | RULE_HEAD_EXP (Ast.$$ (O.MONO O.RULE_HEAD_EXP, []))
 

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -150,6 +150,7 @@ whitespace = [\ \t];
 "lemma"            => (Tokens.RULE_LEMMA (posTuple (size yytext)));
 "cut-lemma"        => (Tokens.RULE_CUT_LEMMA (posTuple (size yytext)));
 "rule"             => (Tokens.RULE_LEMMA (posTuple (size yytext)));
+"exact"            => (Tokens.RULE_EXACT (posTuple (size yytext)));
 
 "true"             => (Tokens.JDG_TRUE (posTuple (size yytext)));
 "type"             => (Tokens.JDG_TYPE (posTuple (size yytext)));


### PR DESCRIPTION
Resolve #286 

Also improves the "typechecking" heuristics to avoid unfolding operators prematurely, and exploit their type information.