### PR TITLE
Primitive rule registry

### DIFF
--- a/src/redprl/lcf_model.fun
+++ b/src/redprl/lcf_model.fun
@@ -35,6 +35,7 @@ struct
       | O.POLY (O.RULE_LEMMA (opid, ps)) $ _ => Rules.Lemma sign opid (List.map #1 ps)
       | O.POLY (O.RULE_CUT_LEMMA (opid, ps)) $ _ => Rules.CutLemma sign opid (List.map #1 ps)
       | O.POLY (O.RULE_UNFOLD opid) $ _ => Rules.Computation.Unfold sign opid
+      | O.MONO (O.RULE_PRIM ruleName) $ _ => Rules.lookupRule ruleName
       | _ => raise E.error [Fpp.text "Invalid rule", TermPrinter.ppTerm rule]
 
   fun rule (sign, env) rule alpha goal =

--- a/src/redprl/machine.fun
+++ b/src/redprl/machine.fun
@@ -523,6 +523,7 @@ struct
      | O.MONO (O.MTAC_HOLE _) $ _ || (_, []) => raise Final
      | O.MONO O.TAC_MTAC $ _ || (_, []) => raise Final
      | O.MONO O.RULE_ID $ _ || (_, []) => raise Final
+     | O.MONO (O.RULE_PRIM _) $ _ || (_, []) => raise Final
      | O.MONO (O.RULE_EXACT _) $ _ || (_, []) => raise Final
      | O.MONO O.RULE_SYMMETRY $ _ || (_, []) => raise Final
      | O.MONO O.RULE_AUTO_STEP $ _ || (_, []) => raise Final

--- a/src/redprl/machine.fun
+++ b/src/redprl/machine.fun
@@ -58,6 +58,9 @@ struct
       O.MONO O.RULE_CUT $$ [([],[]) \ jdg]
 
     val autoTac = mtac auto
+
+    fun prim name = 
+      O.MONO (O.RULE_PRIM name) $$ []
   end
 
 
@@ -550,9 +553,9 @@ struct
        in
          STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.cut jdg)) [(u, P.HYP tau)] (Tac.each [tac1,tac2])) || (syms, stk)
        end
-     | O.MONO O.DEV_DFUN_INTRO $ [([u],_) \ t] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all Tac.autoStep) [(u, P.HYP O.EXP)] (Tac.each [t, Tac.autoTac])) || (syms, stk)
-     | O.MONO O.DEV_DPROD_INTRO $ [_ \ t1, _ \ t2] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all Tac.autoStep) [] (Tac.each [t1, t2, Tac.autoTac])) || (syms, stk)
-     | O.MONO O.DEV_PATH_INTRO $ [([u], _) \ t] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all Tac.autoStep) [(u, P.DIM)] (Tac.each [t, Tac.autoTac, Tac.autoTac])) || (syms, stk)
+     | O.MONO O.DEV_DFUN_INTRO $ [([u],_) \ t] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.prim "dfun/intro")) [(u, P.HYP O.EXP)] (Tac.each [t, Tac.autoTac])) || (syms, stk)
+     | O.MONO O.DEV_DPROD_INTRO $ [_ \ t1, _ \ t2] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.prim "dpair/intro")) [] (Tac.each [t1, t2, Tac.autoTac])) || (syms, stk)
+     | O.MONO O.DEV_PATH_INTRO $ [([u], _) \ t] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.prim "path/intro")) [(u, P.DIM)] (Tac.each [t, Tac.autoTac, Tac.autoTac])) || (syms, stk)
      | O.POLY (O.DEV_BOOL_ELIM z) $ [_ \ t1, _ \ t2] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.elim (z, O.EXP))) [] (Tac.each [t1,t2])) || (syms, stk)
      | O.POLY (O.DEV_S1_ELIM z) $ [_ \ t1, ([v],_) \ t2] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.elim (z, O.EXP))) [(v, P.DIM)] (Tac.each [t1,t2, Tac.autoTac, Tac.autoTac])) || (syms, stk)
      | O.POLY (O.DEV_DFUN_ELIM z) $ [_ \ t1, ([x,p],_) \ t2] || (syms, stk) => STEP @@ Tac.mtac (Tac.seq (Tac.all (Tac.elim (z, O.EXP))) [(x, P.HYP O.EXP), (p, P.HYP O.EXP)] (Tac.each [t1,t2])) || (syms, stk)

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -137,6 +137,7 @@ struct
    (* primitive rules *)
    | RULE_ID | RULE_AUTO_STEP | RULE_SYMMETRY | RULE_EXACT of RedPrlSort.t | RULE_HEAD_EXP
    | RULE_CUT
+   | RULE_PRIM of string
 
    (* development calculus terms *)
    | DEV_DFUN_INTRO | DEV_DPROD_INTRO | DEV_PATH_INTRO
@@ -258,6 +259,7 @@ struct
      | RULE_EXACT tau => [[] * [] <> tau] ->> TAC
      | RULE_HEAD_EXP => [] ->> TAC
      | RULE_CUT => [[] * [] <> JDG] ->> TAC
+     | RULE_PRIM _ => [] ->> TAC
 
      | DEV_DFUN_INTRO => [[HYP EXP] * [] <> TAC] ->> TAC
      | DEV_DPROD_INTRO => [[] * [] <> TAC, [] * [] <> TAC] ->> TAC
@@ -508,6 +510,7 @@ struct
      | RULE_EXACT _ => "exact"
      | RULE_HEAD_EXP => "head-expand"
      | RULE_CUT => "cut"
+     | RULE_PRIM name => "refine{" ^ name ^ "}"
 
      | DEV_PATH_INTRO => "path-intro"
      | DEV_DFUN_INTRO => "fun-intro"

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -161,6 +161,7 @@ end
  | FRESH
  | LET | WITH
  | THEN | ELSE
+ | REFINE
  | MTAC_REC | MTAC_PROGRESS | MTAC_REPEAT | MTAC_AUTO | MTAC_HOLE
  | RULE_ID | RULE_AUTO_STEP | RULE_SYMMETRY | RULE_ELIM | RULE_HEAD_EXP | RULE_LEMMA | RULE_CUT_LEMMA | RULE_UNFOLD
  | RULE_EXACT
@@ -519,7 +520,8 @@ src_sequent
   | src_seqhyps DOUBLE_RANGLE src_catjdg (src_seqhyps, src_catjdg)
 
 atomicRawTac
-  : RULE_ID (Ast.$$ (O.MONO O.RULE_ID, []))
+  : REFINE VARNAME (Ast.$$ (O.MONO (O.RULE_PRIM VARNAME), []))
+  | RULE_ID (Ast.$$ (O.MONO O.RULE_ID, []))
   | RULE_AUTO_STEP (Ast.$$ (O.MONO O.RULE_AUTO_STEP, []))
   | RULE_SYMMETRY (Ast.$$ (O.MONO O.RULE_SYMMETRY, []))
   | HYP VARNAME COLON sort (Ast.$$ (O.POLY (O.RULE_HYP (VARNAME, sort)), []))

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -115,6 +115,7 @@ whitespace = [\ \t];
 "with"             => (Tokens.WITH (posTuple (size yytext)));
 "case"             => (Tokens.CASE (posTuple (size yytext)));
 "of"               => (Tokens.OF (posTuple (size yytext)));
+"refine"           => (Tokens.REFINE (posTuple (size yytext)));
 
 "dim"              => (Tokens.DIM (posTuple (size yytext)));
 

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -537,7 +537,55 @@ struct
 
 
   val lookupRule = 
-    fn "bool/eq-type" => Bool.EqType
+    fn "bool/eq/type" => Bool.EqType
+     | "bool/eq/tt" => Bool.EqTT
+     | "bool/eq/ff" => Bool.EqFF
+     | "bool/eq/if" => Bool.ElimEq
+     | "wbool/eq/type" => WBool.EqType
+     | "wbool/eq/tt" => WBool.EqTT
+     | "wbool/eq/ff" => WBool.EqFF
+     | "wbool/eq/fcom" => WBool.EqFCom
+     | "wbool/eq/wif" => WBool.ElimEq
+     | "nat/eq/type" => Nat.EqType
+     | "nat/eq/zero" => Nat.EqZero
+     | "nat/eq/succ" => Nat.EqSucc
+     | "nat/eq/nat-rec" => Nat.ElimEq
+     | "int/eq/type" => Int.EqType
+     | "int/eq/zero" => Int.EqZero
+     | "int/eq/succ" => Int.EqSucc
+     | "int/eq/negsucc" => Int.EqNegSucc
+     | "void/eq/type" => Void.EqType
+     | "S1/eq/type" => S1.EqType
+     | "S1/eq/base" => S1.EqBase
+     | "S1/eq/loop" => S1.EqLoop
+     | "S1/eq/fcom" => S1.EqFCom
+     | "S1/eq/S1-rec" => S1.ElimEq
+     | "dfun/eq/type" => DFun.EqType
+     | "dfun/eq/lam" => DFun.Eq
+     | "dfun/intro" => DFun.True
+     | "dfun/eq/eta" => DFun.Eta
+     | "dfun/eq/app" => DFun.AppEq
+     | "dpair/eq/type" => DProd.EqType
+     | "dpair/eq/pair" => DProd.Eq
+     | "dpair/eq/eta" => DProd.Eta
+     | "dpair/eq/fst" => DProd.FstEq
+     | "dpair/eq/snd" => DProd.SndEq
+     | "dpair/intro" => DProd.True
+     | "record/eq/type" => Record.EqType
+     | "record/eq/tuple" => Record.Eq
+     | "record/eq/eta" => Record.Eta
+     | "record/eq/proj" => Record.ProjEq
+     | "record/intro" => Record.True
+     | "path/eq/type" => Path.EqType
+     | "path/intro" => Path.True
+     | "path/eq/abs" => Path.Eq
+     | "path/eq/app" => Path.AppEq
+     | "path/eq/app/const" => Path.AppConstCompute
+     | "path/eq/eta" => Path.Eta
+     | "hcom/eq" => HCom.Eq
+     | "hcom/eq/cap" => HCom.CapEqL
+     | "hcom/eq/tube" => HCom.TubeEqL
+
      | r => raise E.error [Fpp.text "No rule registered with name", Fpp.text r]
 
 

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -18,6 +18,7 @@ struct
   type rule = (int -> Sym.t) -> Lcf.jdg Lcf.tactic
   type catjdg = (Sym.t, abt) CJ.jdg
   type opid = Sig.opid
+  type rule_name = string
 
   infixr @@
   infix 1 || #>
@@ -532,6 +533,13 @@ struct
   fun Exact tm =
     Truth.Witness tm
       orelse_ Term.Exact tm
+
+
+
+  val lookupRule = 
+    fn "bool/eq-type" => Bool.EqType
+     | r => raise E.error [Fpp.text "No rule registered with name", Fpp.text r]
+
 
   local
     val CatJdgSymmetry : Sym.t Tactical.tactic =

--- a/src/redprl/refiner.sig
+++ b/src/redprl/refiner.sig
@@ -38,4 +38,8 @@ sig
   end
 
   val Exact : abt -> rule
+
+
+  type rule_name = string
+  val lookupRule : rule_name -> rule
 end

--- a/test/success/bool-fhcom-without-open-eval.prl
+++ b/test/success/bool-fhcom-without-open-eval.prl
@@ -5,7 +5,7 @@ Thm FHcom/trans3 : [
    (path {_} wbool b d)
    (path {_} wbool c d))
 ] by [
-  <a> lam b. lam c. lam d.
+  lam a. lam b. lam c. lam d.
     lam pab. lam pac. lam pbd.
     <i> `(fcom{0~>1} (@ ,pab i) [i=0 {j} (@ ,pac j)] [i=1 {j} (@ ,pbd j)])
 ].

--- a/test/success/num.prl
+++ b/test/success/num.prl
@@ -86,8 +86,8 @@ Thm NatSymm : [
   fresh i:dim <- refine path/intro;
   #0 {
     `(hcom{0 ~> 1} nat ,a 
-     [i=0 {j} (@ ,pab j)]
-     [i=1 {_} ,a])
+      [i=0 {j} (@ ,pab j)]
+      [i=1 {_} ,a])
   };
 
   refine hcom/eq/tube;

--- a/test/success/num.prl
+++ b/test/success/num.prl
@@ -74,3 +74,24 @@ Thm Plus2UnitL : [
 ] by [
   auto
 ].
+
+
+Thm NatSymm : [
+  (->
+   [a b : nat]
+   (path {_} nat a b)
+   (path {_} nat b a))
+] by [
+  lam a. lam b. lam pab.
+  fresh i:dim <- refine path/intro;
+  #0 {
+    `(hcom{0 ~> 1} nat ,a 
+     [i=0 {j} (@ ,pab j)]
+     [i=1 {_} ,a])
+  };
+
+  refine hcom/eq/tube;
+  auto
+].
+
+Print NatSymm.


### PR DESCRIPTION
This allows proofs to call primitive rules by name, rather than trying to steer `auto` and `auto-step` in the right direction. It's kind of a hack, but I think it is more economical (engineering-wise) than trying to do something nicer.