### PR TITLE
Decomposition tacticals

### DIFF
--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -146,7 +146,8 @@ struct
    | RULE_PRIM of string
 
    (* development calculus terms *)
-   | DEV_DFUN_INTRO of int | DEV_PATH_INTRO of int | DEV_RECORD_INTRO of string list
+   | DEV_DFUN_INTRO of unit dev_pattern list
+   | DEV_PATH_INTRO of int | DEV_RECORD_INTRO of string list
    | DEV_LET of RedPrlSort.t
 
    | JDG_EQ | JDG_TRUE | JDG_EQ_TYPE | JDG_SYNTH | JDG_TERM of RedPrlSort.t | JDG_DIM_SUBST
@@ -268,7 +269,7 @@ struct
      | RULE_CUT => [[] * [] <> JDG] ->> TAC
      | RULE_PRIM _ => [] ->> TAC
 
-     | DEV_DFUN_INTRO n => [List.tabulate (n, fn _ => HYP EXP) * [] <> TAC] ->> TAC
+     | DEV_DFUN_INTRO pats => [List.concat (List.map devPatternValence pats) * [] <> TAC] ->> TAC
      | DEV_RECORD_INTRO lbls => List.map (fn _ => [] * [] <> TAC) lbls ->> TAC
      | DEV_PATH_INTRO n => [List.tabulate (n, fn _ => DIM) * [] <> TAC] ->> TAC
      | DEV_LET tau => [[] * [] <> JDG, [] * [] <> TAC, [HYP tau] * [] <> TAC] ->> TAC
@@ -497,7 +498,7 @@ struct
      | RULE_PRIM name => "refine{" ^ name ^ "}"
 
      | DEV_PATH_INTRO n => "path-intro{" ^ Int.toString n ^ "}"
-     | DEV_DFUN_INTRO n => "fun-intro{" ^ Int.toString n ^ "}"
+     | DEV_DFUN_INTRO pats => "fun-intro"
      | DEV_RECORD_INTRO lbls => "record-intro{" ^ ListSpine.pretty (fn x => x) "," lbls ^ "}"
      | DEV_LET _ => "let"
 
@@ -566,6 +567,7 @@ struct
        | DEV_BOOL_ELIM a => "bool-elim{" ^ f a ^ "}"
        | DEV_S1_ELIM a => "s1-elim{" ^ f a ^ "}"
        | DEV_DFUN_ELIM a => "dfun-elim{" ^ f a ^ "}"
+       | DEV_DECOMPOSE (a, _) => "decompose{" ^ f a ^ "}"
        | DEV_PATH_ELIM a => "path-elim{" ^ f a ^ "}"
   end
 

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -383,64 +383,45 @@ struct
   in
     fun eqPoly f =
       fn (FCOM (dir1, eqs1), t) =>
-           (case t of
-                 FCOM (dir2, eqs2) =>
-                   spanEq f (dir1, dir2)
-                   andalso spansEq f (eqs1, eqs2)
-               | _ => false)
+         (case t of
+             FCOM (dir2, eqs2) => spanEq f (dir1, dir2) andalso spansEq f (eqs1, eqs2)
+           | _ => false)
        | (LOOP r, t) => (case t of LOOP r' => P.eq f (r, r') | _ => false)
        | (PATH_APP r, t) => (case t of PATH_APP r' => P.eq f (r, r') | _ => false)
        | (HCOM (dir1, eqs1), t) =>
-           (case t of
-                 HCOM (dir2, eqs2) =>
-                   spanEq f (dir1, dir2)
-                   andalso spansEq f (eqs1, eqs2)
-               | _ => false)
+         (case t of
+             HCOM (dir2, eqs2) => spanEq f (dir1, dir2) andalso spansEq f (eqs1, eqs2)
+           | _ => false)
        | (COE dir1, t) =>
-           (case t of
-                 COE dir2 => spanEq f (dir1, dir2)
-               | _ => false)
+         (case t of
+             COE dir2 => spanEq f (dir1, dir2)
+            | _ => false)
        | (COM (dir1, eqs1), t) =>
-           (case t of
-                 COM (dir2, eqs2) =>
-                   spanEq f (dir1, dir2)
-                   andalso spansEq f (eqs1, eqs2)
-               | _ => false)
+         (case t of
+             COM (dir2, eqs2) => spanEq f (dir1, dir2) andalso spansEq f (eqs1, eqs2)
+            | _ => false)
        | (CUST (opid1, ps1, _), t) =>
-           (case t of
-                 CUST (opid2, ps2, _) =>
-                   f (opid1, opid2) andalso paramsEq f (ps1, ps2)
-               | _ => false)
+         (case t of
+             CUST (opid2, ps2, _) => f (opid1, opid2) andalso paramsEq f (ps1, ps2)
+           | _ => false)
        | (RULE_LEMMA (opid1, ps1), t) =>
-           (case t of
-                 RULE_LEMMA (opid2, ps2) =>
-                   f (opid1, opid2) andalso paramsEq f (ps1, ps2)
-               | _ => false)
+         (case t of
+             RULE_LEMMA (opid2, ps2) => f (opid1, opid2) andalso paramsEq f (ps1, ps2)
+           | _ => false)
        | (RULE_CUT_LEMMA (opid1, ps1), t) =>
-           (case t of
-                 RULE_CUT_LEMMA (opid2, ps2) =>
-                   f (opid1, opid2) andalso paramsEq f (ps1, ps2)
-               | _ => false)
-       | (HYP_REF a, t) =>
-           (case t of HYP_REF b => f (a, b) | _ => false)
-       | (DIM_REF r1, t) =>
-           (case t of DIM_REF r2 => P.eq f (r1, r2) | _ => false)
-       | (RULE_HYP (a, _), t) =>
-           (case t of RULE_HYP (b, _) => f (a, b) | _ => false)
-       | (RULE_ELIM (a, _), t) =>
-           (case t of RULE_ELIM (b, _) => f (a, b) | _ => false)
-       | (RULE_UNFOLD a, t) =>
-           (case t of RULE_UNFOLD b => f (a, b) | _ => false)
-       | (DEV_BOOL_ELIM a, t) =>
-           (case t of DEV_BOOL_ELIM b => f (a, b) | _ => false)
-       | (DEV_S1_ELIM a, t) =>
-           (case t of DEV_S1_ELIM b => f (a, b) | _ => false)
-       | (DEV_DFUN_ELIM a, t) =>
-           (case t of DEV_DFUN_ELIM b => f (a, b) | _ => false)
-       | (DEV_RECORD_ELIM (a, lbls), t) =>
-           (case t of DEV_RECORD_ELIM (b, lbls') => f (a, b) andalso lbls = lbls' | _ => false)
-       | (DEV_PATH_ELIM a, t) =>
-           (case t of DEV_PATH_ELIM b => f (a, b) | _ => false)
+         (case t of
+             RULE_CUT_LEMMA (opid2, ps2) => f (opid1, opid2) andalso paramsEq f (ps1, ps2)
+           | _ => false)
+       | (HYP_REF a, t) => (case t of HYP_REF b => f (a, b) | _ => false)
+       | (DIM_REF r1, t) => (case t of DIM_REF r2 => P.eq f (r1, r2) | _ => false)
+       | (RULE_HYP (a, _), t) => (case t of RULE_HYP (b, _) => f (a, b) | _ => false)
+       | (RULE_ELIM (a, _), t) => (case t of RULE_ELIM (b, _) => f (a, b) | _ => false)
+       | (RULE_UNFOLD a, t) => (case t of RULE_UNFOLD b => f (a, b) | _ => false)
+       | (DEV_BOOL_ELIM a, t) => (case t of DEV_BOOL_ELIM b => f (a, b) | _ => false)
+       | (DEV_S1_ELIM a, t) => (case t of DEV_S1_ELIM b => f (a, b) | _ => false)
+       | (DEV_DFUN_ELIM a, t) => (case t of DEV_DFUN_ELIM b => f (a, b) | _ => false)
+       | (DEV_RECORD_ELIM (a, lbls), t) => (case t of DEV_RECORD_ELIM (b, lbls') => f (a, b) andalso lbls = lbls' | _ => false)
+       | (DEV_PATH_ELIM a, t) => (case t of DEV_PATH_ELIM b => f (a, b) | _ => false)
   end
 
   fun eq f =

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -357,7 +357,8 @@ end
 
  | devDecompPattern of string O.dev_pattern
  | devDecompPatterns of string O.dev_pattern list
- | tupleDecompPatterns of (string * string O.dev_pattern) list
+ | tupleDecompPattern of (string * string O.dev_pattern) list
+ | labeledDecompPattern of string * string O.dev_pattern
  | recordFieldTactics of (string * ast) list
 
  | declArgument of metavariable * Ar.valence
@@ -633,16 +634,20 @@ recordFieldTactics
 
 devDecompPattern
   : VARNAME (O.PAT_VAR VARNAME)
-  | LANGLE tupleDecompPatterns RANGLE (O.PAT_TUPLE tupleDecompPatterns)
+  | LANGLE tupleDecompPattern RANGLE (O.PAT_TUPLE tupleDecompPattern)
 
 devDecompPatterns
   : devDecompPattern COMMA devDecompPatterns (devDecompPattern :: devDecompPatterns)
   | devDecompPattern ([devDecompPattern])
   | ([])
 
-tupleDecompPatterns
-   : VARNAME EQUALS devDecompPattern COMMA tupleDecompPatterns ((VARNAME, devDecompPattern) :: tupleDecompPatterns)
-   | VARNAME EQUALS devDecompPattern ([(VARNAME, devDecompPattern)])
+labeledDecompPattern 
+  : VARNAME EQUALS devDecompPattern (VARNAME, devDecompPattern)
+  | VARNAME (VARNAME, O.PAT_VAR VARNAME)
+
+tupleDecompPattern
+   : labeledDecompPattern COMMA tupleDecompPattern (labeledDecompPattern :: tupleDecompPattern)
+   | labeledDecompPattern ([labeledDecompPattern])
    | ([])
 
 atomicRawTac

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -173,6 +173,30 @@ struct
 
 end
 
+structure Pattern =
+struct
+  infix $$ $ \
+
+  (* this code is kind of crappy, feel free to improve it *)
+  fun unstitchPattern (pat : 'a O.dev_pattern) : unit O.dev_pattern * 'a list = 
+    case pat of 
+       O.PAT_VAR a => (O.PAT_VAR (), [a])
+     | O.PAT_TUPLE lpats =>
+       let
+         val (lbls, pats) = ListPair.unzip (List.map (fn (lbl, pat) => (lbl, unstitchPattern pat)) lpats)
+         val (pats, names) = ListPair.unzip pats
+       in
+         (O.PAT_TUPLE (ListPair.zip (lbls, pats)), List.concat names)
+       end
+
+  fun makeDecompose z pat tac = 
+    let
+      val (pat, names) = unstitchPattern pat
+    in
+      O.POLY (O.DEV_DECOMPOSE (z, pat)) $$ [(names, []) \ tac]
+    end
+end
+
 
 %%
 %header (functor RedPrlLrValsFun (structure Token : TOKEN))
@@ -187,7 +211,7 @@ end
 
  | COLON
  (* delimiters *)
- | LANGLE | RANGLE | DOUBLE_RANGLE
+ | LANGLE | RANGLE
  | LANGLE_PIPE | RANGLE_PIPE
  | LPAREN | RPAREN
  | RBRACKET | LBRACKET
@@ -232,7 +256,7 @@ end
  (* keywords in tactics *)
  | CASE | OF
  | FRESH
- | LET | WITH
+ | LET | DECOMPOSE | WITH
  | THEN | ELSE
  | REFINE
  | MTAC_REC | MTAC_PROGRESS | MTAC_REPEAT | MTAC_AUTO | MTAC_HOLE
@@ -323,7 +347,8 @@ end
  | tactic of ast
  | tactics of ast list
 
- | recordFieldPatterns of (string * string) list
+ | devDecompPattern of string O.dev_pattern
+ | tupleDecompPatterns of (string * string O.dev_pattern) list
  | recordFieldTactics of (string * ast) list
 
  | declArgument of metavariable * Ar.valence
@@ -590,16 +615,20 @@ src_seqhyps
 
 src_sequent
   : src_catjdg ([], src_catjdg)
-  | src_seqhyps DOUBLE_RANGLE src_catjdg (src_seqhyps, src_catjdg)
-
-recordFieldPatterns
-   : VARNAME EQUALS VARNAME COMMA recordFieldPatterns ((VARNAME1, VARNAME2) :: recordFieldPatterns)
-   | VARNAME EQUALS VARNAME ([(VARNAME1, VARNAME2)])
-   | ([])
+  | src_seqhyps RANGLE RANGLE src_catjdg (src_seqhyps, src_catjdg)
 
 recordFieldTactics
    : VARNAME EQUALS tactic COMMA recordFieldTactics ((VARNAME, tactic) :: recordFieldTactics)
    | VARNAME EQUALS tactic ([(VARNAME, tactic)])
+   | ([])
+
+devDecompPattern
+  : VARNAME (O.PAT_VAR VARNAME)
+  | LANGLE tupleDecompPatterns RANGLE (O.PAT_TUPLE tupleDecompPatterns)
+
+tupleDecompPatterns
+   : VARNAME EQUALS devDecompPattern COMMA tupleDecompPatterns ((VARNAME, devDecompPattern) :: tupleDecompPatterns)
+   | VARNAME EQUALS devDecompPattern ([(VARNAME, devDecompPattern)])
    | ([])
 
 atomicRawTac
@@ -625,18 +654,25 @@ atomicRawTac
   | LANGLE recordFieldTactics RANGLE (Multi.recordIntro (SOME (Pos.pos (LANGLE1left fileName) (RANGLE1right fileName))) recordFieldTactics)
   | IF VARNAME THEN tactic ELSE tactic
       (Ast.$$ (O.POLY (O.DEV_BOOL_ELIM VARNAME), [\ (([],[]), tactic1), \ (([],[]), tactic2)]))
+      
   | LET VARNAME COLON LSQUARE judgment RSQUARE EQUALS tactic DOT tactic
       (Ast.$$ (O.MONO (O.DEV_LET (sortOfJudgment judgment)), [\ (([],[]), judgment), \ (([],[]), tactic1), \(([VARNAME],[]), tactic2)]))
+
   | LET VARNAME WITH VARNAME EQUALS VARNAME tactic DOT tactic
       (Ast.$$ (O.POLY (O.DEV_DFUN_ELIM VARNAME3), [\ (([],[]), tactic1), \ (([VARNAME1, VARNAME2],[]), tactic2)]))
+
   | LET VARNAME EQUALS VARNAME tactic DOT tactic
       (Ast.$$ (O.POLY (O.DEV_DFUN_ELIM VARNAME2), [\ (([],[]), tactic1), \ (([VARNAME1, "_"],[]), tactic2)]))
+
   | LET VARNAME WITH VARNAME EQUALS VARNAME AT_SIGN tactic DOT tactic
       (Ast.$$ (O.POLY (O.DEV_PATH_ELIM VARNAME3), [\ (([],[]), tactic1), \ (([VARNAME1, VARNAME2],[]), tactic2)]))
+
   | LET VARNAME EQUALS VARNAME AT_SIGN tactic DOT tactic
       (Ast.$$ (O.POLY (O.DEV_PATH_ELIM VARNAME2), [\ (([],[]), tactic1), \ (([VARNAME1, "_"],[]), tactic2)]))
-  | LET LANGLE recordFieldPatterns RANGLE EQUALS VARNAME DOT tactic
-      (Ast.$$ (O.POLY (O.DEV_RECORD_ELIM (VARNAME, List.map #1 recordFieldPatterns)), [\ ((List.map #2 recordFieldPatterns, []), tactic)]))
+
+  | DECOMPOSE devDecompPattern EQUALS VARNAME DOT tactic
+      (Pattern.makeDecompose VARNAME devDecompPattern tactic)
+
   | CASE VARNAME OF BASE DOUBLE_RIGHT_ARROW tactic PIPE LOOP VARNAME DOUBLE_RIGHT_ARROW tactic
       (Ast.$$ (O.POLY (O.DEV_S1_ELIM VARNAME1), [\ (([],[]), tactic1), \(([VARNAME2], []), tactic2)]))
 

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -189,19 +189,20 @@ struct
          (O.PAT_TUPLE (ListPair.zip (lbls, pats)), List.concat names)
        end
 
-  fun makeDecompose z pat tac = 
-    let
-      val (pat, names) = unstitchPattern pat
-    in
-      O.POLY (O.DEV_DECOMPOSE (z, pat)) $$ [(names, []) \ tac]
-    end
-
   fun makeLambda pats tac = 
     let
       val (pats', namess) = ListPair.unzip (List.map unstitchPattern pats)
       val names = List.concat namess
     in
       O.MONO (O.DEV_DFUN_INTRO pats') $$ [(names, []) \ tac]
+    end
+
+  fun makeApply pat z tacs tac = 
+    let
+      val (pat, names) = unstitchPattern pat
+      val args = (List.map (fn tac => ([],[]) \ tac) tacs) @ [(names, []) \ tac]
+    in
+      O.POLY (O.DEV_APPLY (z, pat, List.length tacs)) $$ args
     end
 end
 
@@ -264,7 +265,7 @@ end
  (* keywords in tactics *)
  | CASE | OF
  | FRESH
- | LET | DECOMPOSE | WITH
+ | LET | WITH
  | THEN | ELSE
  | REFINE
  | MTAC_REC | MTAC_PROGRESS | MTAC_REPEAT | MTAC_AUTO | MTAC_HOLE
@@ -359,6 +360,8 @@ end
  | devDecompPatterns of string O.dev_pattern list
  | tupleDecompPattern of (string * string O.dev_pattern) list
  | labeledDecompPattern of string * string O.dev_pattern
+ | devAppSpine of ast list
+
  | recordFieldTactics of (string * ast) list
 
  | declArgument of metavariable * Ar.valence
@@ -632,6 +635,11 @@ recordFieldTactics
    | VARNAME EQUALS tactic ([(VARNAME, tactic)])
    | ([])
 
+devAppSpine
+  : tactic devAppSpine (tactic :: devAppSpine)
+  | tactic ([tactic])
+  | ([])
+
 devDecompPattern
   : VARNAME (O.PAT_VAR VARNAME)
   | LANGLE tupleDecompPattern RANGLE (O.PAT_TUPLE tupleDecompPattern)
@@ -662,7 +670,7 @@ atomicRawTac
   | RULE_UNFOLD OPNAME (Ast.$$ (O.POLY (O.RULE_UNFOLD OPNAME), []))
   | BACK_TICK term (Tac.exactAuto O.EXP term)
   | RULE_EXACT term (Tac.exact O.EXP term)
-  | AMPERSAND param (Tac.exactDim param)
+  | AT_SIGN param (Tac.exactDim param)
   | RULE_HEAD_EXP (Ast.$$ (O.MONO O.RULE_HEAD_EXP, []))
 
   | atomicTac DOUBLE_PIPE tactic %prec DOUBLE_PIPE (Tac.orElse (atomicTac, tactic))
@@ -677,20 +685,8 @@ atomicRawTac
   | LET VARNAME COLON LSQUARE judgment RSQUARE EQUALS tactic DOT tactic
       (Ast.$$ (O.MONO (O.DEV_LET (sortOfJudgment judgment)), [\ (([],[]), judgment), \ (([],[]), tactic1), \(([VARNAME],[]), tactic2)]))
 
-  | LET VARNAME WITH VARNAME EQUALS VARNAME tactic DOT tactic
-      (Ast.$$ (O.POLY (O.DEV_DFUN_ELIM VARNAME3), [\ (([],[]), tactic1), \ (([VARNAME1, VARNAME2],[]), tactic2)]))
-
-  | LET VARNAME EQUALS VARNAME tactic DOT tactic
-      (Ast.$$ (O.POLY (O.DEV_DFUN_ELIM VARNAME2), [\ (([],[]), tactic1), \ (([VARNAME1, "_"],[]), tactic2)]))
-
-  | LET VARNAME WITH VARNAME EQUALS VARNAME AT_SIGN tactic DOT tactic
-      (Ast.$$ (O.POLY (O.DEV_PATH_ELIM VARNAME3), [\ (([],[]), tactic1), \ (([VARNAME1, VARNAME2],[]), tactic2)]))
-
-  | LET VARNAME EQUALS VARNAME AT_SIGN tactic DOT tactic
-      (Ast.$$ (O.POLY (O.DEV_PATH_ELIM VARNAME2), [\ (([],[]), tactic1), \ (([VARNAME1, "_"],[]), tactic2)]))
-
-  | DECOMPOSE devDecompPattern EQUALS VARNAME DOT tactic
-      (Pattern.makeDecompose VARNAME devDecompPattern tactic)
+  | LET devDecompPattern EQUALS VARNAME devAppSpine DOT tactic
+      (Pattern.makeApply devDecompPattern VARNAME devAppSpine tactic)
 
   | CASE VARNAME OF BASE DOUBLE_RIGHT_ARROW tactic PIPE LOOP VARNAME DOUBLE_RIGHT_ARROW tactic
       (Ast.$$ (O.POLY (O.DEV_S1_ELIM VARNAME1), [\ (([],[]), tactic1), \(([VARNAME2], []), tactic2)]))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -195,6 +195,14 @@ struct
     in
       O.POLY (O.DEV_DECOMPOSE (z, pat)) $$ [(names, []) \ tac]
     end
+
+  fun makeLambda pats tac = 
+    let
+      val (pats', namess) = ListPair.unzip (List.map unstitchPattern pats)
+      val names = List.concat namess
+    in
+      O.MONO (O.DEV_DFUN_INTRO pats') $$ [(names, []) \ tac]
+    end
 end
 
 
@@ -348,6 +356,7 @@ end
  | tactics of ast list
 
  | devDecompPattern of string O.dev_pattern
+ | devDecompPatterns of string O.dev_pattern list
  | tupleDecompPatterns of (string * string O.dev_pattern) list
  | recordFieldTactics of (string * ast) list
 
@@ -626,6 +635,11 @@ devDecompPattern
   : VARNAME (O.PAT_VAR VARNAME)
   | LANGLE tupleDecompPatterns RANGLE (O.PAT_TUPLE tupleDecompPatterns)
 
+devDecompPatterns
+  : devDecompPattern COMMA devDecompPatterns (devDecompPattern :: devDecompPatterns)
+  | devDecompPattern ([devDecompPattern])
+  | ([])
+
 tupleDecompPatterns
    : VARNAME EQUALS devDecompPattern COMMA tupleDecompPatterns ((VARNAME, devDecompPattern) :: tupleDecompPatterns)
    | VARNAME EQUALS devDecompPattern ([(VARNAME, devDecompPattern)])
@@ -649,7 +663,7 @@ atomicRawTac
   | atomicTac DOUBLE_PIPE tactic %prec DOUBLE_PIPE (Tac.orElse (atomicTac, tactic))
   | LANGLE_PIPE multitac RANGLE_PIPE (Tac.multitacToTac multitac)
 
-  | LAMBDA boundVars DOT tactic (Ast.$$ (O.MONO (O.DEV_DFUN_INTRO (List.length boundVars)), [\ ((Multi.addUnderscores boundVars, []), tactic)]))
+  | LAMBDA devDecompPatterns DOT tactic (Pattern.makeLambda devDecompPatterns tactic)
   | LANGLE boundVars RANGLE tactic (Ast.$$ (O.MONO (O.DEV_PATH_INTRO (List.length boundVars)), [\ ((Multi.addUnderscores boundVars, []), tactic)]))
   | LANGLE recordFieldTactics RANGLE (Multi.recordIntro (SOME (Pos.pos (LANGLE1left fileName) (RANGLE1right fileName))) recordFieldTactics)
   | IF VARNAME THEN tactic ELSE tactic

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -73,7 +73,6 @@ whitespace = [\ \t];
 "|"                => (Tokens.PIPE (posTuple (size yytext)));
 "%"                => (Tokens.PERCENT (posTuple (size yytext)));
 "_"                => (Tokens.UNDER (posTuple (size yytext)));
-">>"               => (Tokens.DOUBLE_RANGLE (posTuple (size yytext)));
 "?"                => (Tokens.QUESTION (posTuple (size yytext)));
 
 "fcom"             => (Tokens.FCOM (posTuple (size yytext)));
@@ -109,6 +108,7 @@ whitespace = [\ \t];
 "then"             => (Tokens.THEN (posTuple (size yytext)));
 "else"             => (Tokens.ELSE (posTuple (size yytext)));
 "let"              => (Tokens.LET (posTuple (size yytext)));
+"decompose"        => (Tokens.DECOMPOSE (posTuple (size yytext)));
 "with"             => (Tokens.WITH (posTuple (size yytext)));
 "case"             => (Tokens.CASE (posTuple (size yytext)));
 "of"               => (Tokens.OF (posTuple (size yytext)));

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -108,7 +108,6 @@ whitespace = [\ \t];
 "then"             => (Tokens.THEN (posTuple (size yytext)));
 "else"             => (Tokens.ELSE (posTuple (size yytext)));
 "let"              => (Tokens.LET (posTuple (size yytext)));
-"decompose"        => (Tokens.DECOMPOSE (posTuple (size yytext)));
 "with"             => (Tokens.WITH (posTuple (size yytext)));
 "case"             => (Tokens.CASE (posTuple (size yytext)));
 "of"               => (Tokens.OF (posTuple (size yytext)));

--- a/src/redprl/refiner.sig
+++ b/src/redprl/refiner.sig
@@ -30,6 +30,8 @@ sig
   structure Hyp :
   sig
     val Project : hyp -> rule
+    val Rename : hyp -> rule
+    val Delete : hyp -> rule
   end
 
   structure Synth :

--- a/src/redprl/tactic_elaborator.fun
+++ b/src/redprl/tactic_elaborator.fun
@@ -186,7 +186,7 @@ struct
   fun nameForPattern pat = 
     case pat of 
        O.PAT_VAR x => x
-     | O.PAT_TUPLE lpats => Sym.named (ListSpine.pretty (Sym.toString o nameForPattern o #2) "_" lpats)
+     | O.PAT_TUPLE lpats => Sym.named (ListSpine.pretty (Sym.toString o nameForPattern o #2) "-" lpats)
 
   fun dfunIntros sign (pats, names) tac =
     case pats of 

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -133,7 +133,7 @@ Thm PathTest2 : [
       // interactive tactic environment, dimension expressions are
       // supplied to the refiner using the & "dimension quotation"
       // operator.
-      let px = p @ &x.
+      let px = p @ x.
       hyp px
 ].
 
@@ -203,7 +203,7 @@ Thm FunExt(#A; #B) : [
    (path {_} (-> #A #B) f g))
 ] by [
   lam f, g, p.
-    <i> lam a. let q = p hyp a. let q/i = q @ &i. hyp q/i
+    <i> lam a. let q = p hyp a. let q/i = q @ i. hyp q/i
 ].
 
 Print FunExt.
@@ -211,7 +211,7 @@ Print FunExt.
 
 Tac FunExtTac(#A; #B; #F; #G) = [
   let p : [(-> [x : #A] (path {_} wbool ($ #F x) ($ #G x)))] = {}.
-  <i> lam a. let q = p hyp a. let q/i = q @ &i. hyp q/i
+  <i> lam a. let q = p hyp a. let q/i = q @ i. hyp q/i
 ].
 
 Thm NotNotPath : [(path {_} (-> wbool wbool) (Cmp Not Not) (lam [x] x))] by [
@@ -228,7 +228,7 @@ Thm Singleton : [(* [x : wbool] (path {_} wbool x tt))] by [
 ].
 
 Thm PathElimTest : [(-> (path {_} bool tt tt) bool)] by [
-  lam x. let x/0 = x @ &0. hyp x/0
+  lam x. let x/0 = x @ 0. hyp x/0
 ].
 
 Thm PathEta(#A) : [
@@ -238,7 +238,7 @@ Thm PathEta(#A) : [
    (path {_} #A m n)
    (path {_} #A m n))
 ] by [
-  lam m, n, p. <j> let p/j = p @ &j. hyp p/j
+  lam m, n, p. <j> let p/j = p @ j. hyp p/j
 ].
 
 Print PathEta.

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -202,7 +202,7 @@ Thm FunExt(#A; #B) : [
    [p : (-> [y : #A] (path {_} #B ($ f y) ($ g y)))]
    (path {_} (-> #A #B) f g))
 ] by [
-  lam f. lam g. lam p.
+  lam f, g, p.
     <i> lam a. let q = p hyp a. let q/i = q @ &i. hyp q/i
 ].
 
@@ -238,7 +238,7 @@ Thm PathEta(#A) : [
    (path {_} #A m n)
    (path {_} #A m n))
 ] by [
-  lam m. lam n. lam p. <j> let p/j = p @ &j. hyp p/j
+  lam m, n, p. <j> let p/j = p @ &j. hyp p/j
 ].
 
 Print PathEta.

--- a/test/success/bool-fhcom-without-open-eval.prl
+++ b/test/success/bool-fhcom-without-open-eval.prl
@@ -5,7 +5,7 @@ Thm FHcom/trans3 : [
    (path {_} wbool b d)
    (path {_} wbool c d))
 ] by [
-  lam a b c d pab pac pbd.
+  lam a, b, c, d, pab, pac, pbd.
     <i> `(fcom{0~>1} (@ ,pab i) [i=0 {j} (@ ,pac j)] [i=1 {j} (@ ,pbd j)])
 ].
 
@@ -17,7 +17,7 @@ Thm FHcom/trans2 : [
    (path {_} wbool b c)
    (path {_} wbool a c))
 ] by [
-  lam a b c pab pbc.
+  lam a, b, c, pab, pbc.
     <i> `(fcom{0~>1} (@ ,pab i) [i=0 {_} ,a] [i=1 {j} (@ ,pbc j)])
 ].
 
@@ -26,7 +26,7 @@ Thm FHcom/symm : [
    (path {_} wbool a b)
    (path {_} wbool b a))
 ] by [
-  lam a b pab.
+  lam a, b, pab.
     <i> `(fcom{0~>1} ,a [i=0 {j} (@,pab j)] [i=1 {_} ,a])
 ].
 

--- a/test/success/connection.prl
+++ b/test/success/connection.prl
@@ -5,7 +5,7 @@ Thm Connection(#A) : [
    [p : (path {_} #A a b)]
    (path {i} (path {_} #A a (@ p i)) (abs {_} a) p))
 ] by [
-  lam a b p.
+  lam a, b, p.
     <i j>
       `(hcom{0~>1} #A ,a
         [i=0 {k}

--- a/test/success/decomposition.prl
+++ b/test/success/decomposition.prl
@@ -3,7 +3,6 @@ Thm Decomposition : [
    (record [foo : (record [a : bool] [b : (* bool bool)])] [bar : S1])
    bool)
 ] by [
-  lam rcd.
-    decompose <foo = <a = a, b = <proj1 = p1>>> = rcd.
-    hyp p1
+  lam <foo = <a = a, b = <proj1 = p1>>>.
+  hyp p1
 ].

--- a/test/success/decomposition.prl
+++ b/test/success/decomposition.prl
@@ -11,10 +11,18 @@ Extract Decomposition.
 
 Thm Apply : [
   (-> 
-   (-> bool (record [a : S1]))
+   (->
+    bool
+    bool
+    (path {_}
+     (record [a : S1])
+     (tuple [a base])
+     (tuple [a base])))
    S1)
 ] by [
   lam f.
-    let <a> = f `tt.
-      hyp a
+    let <a> = f `tt `ff @0.
+    hyp a
 ].
+
+Extract Apply.

--- a/test/success/decomposition.prl
+++ b/test/success/decomposition.prl
@@ -3,6 +3,8 @@ Thm Decomposition : [
    (record [foo : (record [a : bool] [b : (* bool bool)])] [bar : S1])
    bool)
 ] by [
-  lam <foo = <a = a, b = <proj1 = p1>>>.
-  hyp p1
+  lam <foo = <a, b = <proj1>>>.
+  hyp proj1
 ].
+
+Extract Decomposition.

--- a/test/success/decomposition.prl
+++ b/test/success/decomposition.prl
@@ -1,0 +1,9 @@
+Thm Decomposition : [
+  (->
+   (record [foo : (record [a : bool] [b : (* bool bool)])] [bar : S1])
+   bool)
+] by [
+  lam rcd.
+    decompose <foo = <a = a, b = <proj1 = p1>>> = rcd.
+    hyp p1
+].

--- a/test/success/decomposition.prl
+++ b/test/success/decomposition.prl
@@ -8,3 +8,13 @@ Thm Decomposition : [
 ].
 
 Extract Decomposition.
+
+Thm Apply : [
+  (-> 
+   (-> bool (record [a : S1]))
+   S1)
+] by [
+  lam f.
+    let <a> = f `tt.
+      hyp a
+].

--- a/test/success/hcom.prl
+++ b/test/success/hcom.prl
@@ -16,7 +16,7 @@ Thm Hcom/Poly(#A) : [
    (path {_} #A b d)
    (path {_} #A c d))
 ] by [
-  lam a b c d pab pac pbd.
+  lam a, b, c, d, pab, pac, pbd.
     <i> 
       `(hcom{0 ~> 1} #A (@ ,pab i) 
         [i=0 {j} (@ ,pac j)]
@@ -34,7 +34,7 @@ Thm Hcom/trans(#A) : [
    (path {_} #A b c)
    (path {_} #A a c))
 ] by [
-  lam a b c pab pbc.
+  lam a, b, c, pab, pbc.
     <i>
       `(hcom{0 ~> 1} #A (@ ,pab i) 
         [i=0 {_} ,a] 
@@ -49,7 +49,7 @@ Thm Hcom/symm(#A) : [
    (path {_} #A a b)
    (path {_} #A b a))
 ] by [
-  lam a b pab.
+  lam a, b, pab.
     <i>
       `(hcom{0 ~> 1} #A ,a 
         [i=0 {j} (@ ,pab j)]

--- a/test/success/logical-investigations.prl
+++ b/test/success/logical-investigations.prl
@@ -14,7 +14,7 @@ Thm Thm1(#A; #B) : [
   type/B : #B type
   >> (-> #A #B #A)
 ] by [
-  lam a. lam b. hyp a
+  lam a, b. hyp a
 ].
 
 
@@ -33,7 +33,7 @@ Thm Thm2(#A; #B; #C) : [
   type/C : #C type
   >> (-> (-> #A #B) (-> #A #B #C) #A #C)
 ] by [
-  lam f. lam g. lam a.
+  lam f, g, a.
   let h = g {hyp a}.
   ({Apply h}
    ({Apply f}
@@ -72,7 +72,7 @@ Thm Thm3/high-level(#A; #B; #C) : [
       (-> #B #C)
       (-> #A #C))
 ] by [
-  lam ab. lam bc. lam a.
+  lam ab, bc, a.
   ({Apply bc}
    ({Apply ab}
     (tactic hyp a)))
@@ -94,7 +94,7 @@ Thm Thm4(#A; #B) : [
   type/A : #A type
   >> (-> (Not #A) #A #B)
 ] by [
-  lam r. lam a.
+  lam r, a.
   unfold Not;
   let boom = r {hyp a}.
   elim boom
@@ -119,7 +119,7 @@ Thm Thm6(#A;#B) : [
   type/B : #B type
   >> (-> (-> #A #B) (Not #B) (Not #A))
 ] by [
-  lam ab. lam nb. unfold Not; lam a.
+  lam ab, nb. unfold Not; lam a.
   ({Apply nb} 
    ({Apply ab}
     (tactic hyp a)))

--- a/test/success/num.prl
+++ b/test/success/num.prl
@@ -86,7 +86,7 @@ Thm NatSymm : [
    (path {_} nat a b)
    (path {_} nat b a))
 ] by [
-  lam a b pab.
+  lam a, b, pab.
   <i>
     `(hcom{0 ~> 1} nat ,a 
       [i=0 {j} (@ ,pab j)]

--- a/test/success/path-ap-const.prl
+++ b/test/success/path-ap-const.prl
@@ -1,7 +1,7 @@
 Thm PathApConst : [
   (-> (path {_} bool tt tt) bool)
 ] by [
-  lam p. let p0 = p @ &0. hyp p0
+  lam p. let p0 = p @0. hyp p0
 ].
 
 Print PathApConst.

--- a/test/success/record.prl
+++ b/test/success/record.prl
@@ -49,7 +49,7 @@ Thm RecordTest6 : [
     [p : (record [a : bool] [b c : record])]
     bool)
 ] by [
-  lam p. decompose <a = a> = p. hyp a
+  lam <a = a>. hyp a
 ].
 
 Thm RecordTest7 : [
@@ -68,8 +68,7 @@ Thm RecordElimTest : [
     [p : (path {_} bool b b)])
    (* [b : bool] (path {_} bool b b)))
 ] by [
-  lam r.
-    decompose <b = welp, p = hello> = r.
+  lam <b = welp, p = hello>.
     <proj2 = hyp hello,
      proj1 = hyp welp>
 ].

--- a/test/success/record.prl
+++ b/test/success/record.prl
@@ -49,7 +49,7 @@ Thm RecordTest6 : [
     [p : (record [a : bool] [b c : record])]
     bool)
 ] by [
-  lam <a = a>. hyp a
+  lam <a>. hyp a
 ].
 
 Thm RecordTest7 : [

--- a/test/success/record.prl
+++ b/test/success/record.prl
@@ -49,7 +49,7 @@ Thm RecordTest6 : [
     [p : (record [a : bool] [b c : record])]
     bool)
 ] by [
-  lam p. let <a = a> = p. hyp a
+  lam p. decompose <a = a> = p. hyp a
 ].
 
 Thm RecordTest7 : [
@@ -69,7 +69,7 @@ Thm RecordElimTest : [
    (* [b : bool] (path {_} bool b b)))
 ] by [
   lam r.
-    let <b = welp, p = hello> = r.
+    decompose <b = welp, p = hello> = r.
     <proj2 = hyp hello,
      proj1 = hyp welp>
 ].

--- a/test/success/unfold.prl
+++ b/test/success/unfold.prl
@@ -3,12 +3,12 @@ Def Times(#A; #B) = [
 ].
 
 Tac Proj1{z:hyp} = [
-  let <proj1 = x> = z.
+  decompose <proj1 = x> = z.
   hyp x
 ].
 
 Tac Proj2{z:hyp} = [
-  let <proj2 = y> = z.
+  decompose <proj2 = y> = z.
   hyp y
 ].
 

--- a/test/success/unfold.prl
+++ b/test/success/unfold.prl
@@ -3,12 +3,12 @@ Def Times(#A; #B) = [
 ].
 
 Tac Proj1{z:hyp} = [
-  decompose <proj1> = z.
+  let <proj1> = z.
   hyp proj1
 ].
 
 Tac Proj2{z:hyp} = [
-  decompose <proj2> = z.
+  let <proj2> = z.
   hyp proj2
 ].
 

--- a/test/success/unfold.prl
+++ b/test/success/unfold.prl
@@ -3,13 +3,13 @@ Def Times(#A; #B) = [
 ].
 
 Tac Proj1{z:hyp} = [
-  decompose <proj1 = x> = z.
-  hyp x
+  decompose <proj1> = z.
+  hyp proj1
 ].
 
 Tac Proj2{z:hyp} = [
-  decompose <proj2 = y> = z.
-  hyp y
+  decompose <proj2> = z.
+  hyp proj2
 ].
 
 Thm Times/Proj(#A) : [


### PR DESCRIPTION
~This is work-in-progress.~ I have added support for deep decomposition patterns in tacticals, including with the `lam` tactical. So you, can write something like `lam <u = <a = b>, v = v>. t` to abstract over and decompose a deep record simultaneously.

I have then combined this with stacks of "application tacticals", so that I can unify all the decomposition and application (function & path) tacticals into a single monstrous form.