### PR TITLE
"use" tactical

### DIFF
--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -100,7 +100,6 @@ struct
      PAT_VAR of 'a
    | PAT_TUPLE of (string * 'a dev_pattern) list
 
-
   (* We split our operator signature into a couple datatypes, because the implementation of
    * some of the 2nd-order signature obligations can be made trivial for "constant" operators,
    * which we call "monomorphic".
@@ -167,7 +166,6 @@ struct
    | CUST of 'a * ('a P.term * psort option) list * RedPrlArity.t option
    | HYP_REF of 'a
    | PARAM_REF of psort * 'a P.term
-   | RULE_HYP of 'a * sort
    | RULE_ELIM of 'a * sort
    | RULE_UNFOLD of 'a
    | DEV_BOOL_ELIM of 'a
@@ -175,6 +173,7 @@ struct
 
    | DEV_APPLY_LEMMA of 'a * ('a P.term * psort option) list * RedPrlArity.t option * unit dev_pattern * int
    | DEV_APPLY_HYP of 'a * unit dev_pattern * int
+   | DEV_USE_HYP of 'a * int
 
   (* We split our operator signature into a couple datatypes, because the implementation of
    * some of the 2nd-order signature obligations can be made trivial for "constant" operators,
@@ -319,12 +318,12 @@ struct
        | CUST (_, _, ar) => Option.valOf ar
        | HYP_REF _ => [] ->> EXP
        | PARAM_REF (sigma, _) => [] ->> PARAM_EXP sigma
-       | RULE_HYP _ => [] ->> TAC
        | RULE_ELIM _ => [] ->> TAC
        | RULE_UNFOLD _ => [] ->> TAC
        | DEV_BOOL_ELIM _ => [[] * [] <> TAC, [] * [] <> TAC] ->> TAC
        | DEV_S1_ELIM _ => [[] * [] <> TAC, [DIM] * [] <> TAC] ->> TAC
        | DEV_APPLY_HYP (_, pat, n) => List.tabulate (n, fn _ => [] * [] <> TAC) @ [devPatternSymValence pat * [] <> TAC] ->> TAC
+       | DEV_USE_HYP (_, n) => List.tabulate (n, fn _ => [] * [] <> TAC) ->> TAC
        | DEV_APPLY_LEMMA (_, _, ar, pat, n) => 
          let
            val (vls, tau) = Option.valOf ar
@@ -369,12 +368,12 @@ struct
        | CUST (opid, ps, _) => (opid, OPID) :: paramsSupport ps
        | HYP_REF a => [(a, HYP EXP)]
        | PARAM_REF (sigma, r) => paramsSupport [(r, SOME sigma)]
-       | RULE_HYP (a, tau) => [(a, HYP tau)]
        | RULE_ELIM (a, tau) => [(a, HYP tau)]
        | RULE_UNFOLD a => [(a, OPID)]
        | DEV_BOOL_ELIM a => [(a, HYP EXP)]
        | DEV_S1_ELIM a => [(a, HYP EXP)]
        | DEV_APPLY_HYP (a, _, _) => [(a, HYP EXP)]
+       | DEV_USE_HYP (a, _) => [(a, HYP EXP)]
        | DEV_APPLY_LEMMA (opid, ps, _, _, _) => (opid, OPID) :: paramsSupport ps
   end
 
@@ -418,12 +417,12 @@ struct
 
        | (HYP_REF a, t) => (case t of HYP_REF b => f (a, b) | _ => false)
        | (PARAM_REF (sigma1, r1), t) => (case t of PARAM_REF (sigma2, r2) => sigma1 = sigma2 andalso P.eq f (r1, r2) | _ => false)
-       | (RULE_HYP (a, _), t) => (case t of RULE_HYP (b, _) => f (a, b) | _ => false)
        | (RULE_ELIM (a, _), t) => (case t of RULE_ELIM (b, _) => f (a, b) | _ => false)
        | (RULE_UNFOLD a, t) => (case t of RULE_UNFOLD b => f (a, b) | _ => false)
        | (DEV_BOOL_ELIM a, t) => (case t of DEV_BOOL_ELIM b => f (a, b) | _ => false)
        | (DEV_S1_ELIM a, t) => (case t of DEV_S1_ELIM b => f (a, b) | _ => false)
        | (DEV_APPLY_HYP (a, pat, n), t) => (case t of DEV_APPLY_HYP (b, pat', n') => f (a, b) andalso pat = pat' andalso n = n' | _ => false)
+       | (DEV_USE_HYP (a, n), t) => (case t of DEV_USE_HYP (b, n') => f (a, b) andalso n = n' | _ => false)
        | (DEV_APPLY_LEMMA (opid1, ps1, _, pat1, n1), t) =>
          (case t of
              DEV_APPLY_LEMMA (opid2, ps2, _, pat2, n2) => f (opid1, opid2) andalso paramsEq f (ps1, ps2) andalso pat1 = pat2 andalso n1 = n2
@@ -554,12 +553,12 @@ struct
            f opid ^ "{" ^ paramsToString f ps ^ "}"
        | HYP_REF a => "hyp-ref{" ^ f a ^ "}"
        | PARAM_REF (_, r) => "param-ref{" ^ P.toString f r ^ "}"
-       | RULE_HYP (a, _) => "hyp{" ^ f a ^ "}"
        | RULE_ELIM (a, _) => "elim{" ^ f a ^ "}"
        | RULE_UNFOLD a => "unfold{" ^ f a ^ "}"
        | DEV_BOOL_ELIM a => "bool-elim{" ^ f a ^ "}"
        | DEV_S1_ELIM a => "s1-elim{" ^ f a ^ "}"
        | DEV_APPLY_HYP (a, _, _) => "apply-hyp{" ^ f a ^ "}"
+       | DEV_USE_HYP (a, _) => "use-hyp{" ^ f a ^ "}"
        | DEV_APPLY_LEMMA (opid, ps, _, _, _) => "apply-lemma{" ^ f opid ^ "}{" ^ paramsToString f ps ^ "}"
   end
 
@@ -599,13 +598,13 @@ struct
        | CUST (opid, ps, ar) => CUST (mapSym (passSort OPID f) opid, mapParams f ps, ar)
        | HYP_REF a => HYP_REF (mapSym (passSort (HYP EXP) f) a)
        | PARAM_REF (sigma, r) => PARAM_REF (sigma, P.bind (passSort sigma f) r)
-       | RULE_HYP (a, tau) => RULE_HYP (mapSym (passSort (HYP tau) f) a, tau)
        | RULE_ELIM (a, tau) => RULE_ELIM (mapSym (passSort (HYP tau) f) a, tau)
        | RULE_UNFOLD a => RULE_UNFOLD (mapSym (passSort OPID f) a)
        | DEV_BOOL_ELIM a => DEV_BOOL_ELIM (mapSym (passSort (HYP EXP) f) a)
        | DEV_S1_ELIM a => DEV_S1_ELIM (mapSym (passSort (HYP EXP) f) a)
        | DEV_APPLY_LEMMA (opid, ps, ar, pat, n) => DEV_APPLY_LEMMA (mapSym (passSort OPID f) opid, mapParams f ps, ar, pat, n)
        | DEV_APPLY_HYP (a, pat, spine) => DEV_APPLY_HYP (mapSym (passSort (HYP EXP) f) a, pat, spine)
+       | DEV_USE_HYP (a, n) => DEV_USE_HYP (mapSym (passSort (HYP EXP) f) a, n)
   end
 
   fun mapWithSort f =

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -215,13 +215,20 @@ struct
       O.POLY (O.DEV_USE_HYP (z, List.length tacs)) $$ args
     end
 
-  fun makeCutLemma pat (opid, params, subtermArgs) tacs tac = 
+  fun makeApplyLemma pat (opid, params, subtermArgs) tacs tac = 
     let
       val (pat, names) = unstitchPattern pat
       val appArgs = List.map (fn tac => ([],[]) \ tac) tacs
       val args = subtermArgs @ appArgs @ [(names, []) \ tac]
     in
       O.POLY (O.DEV_APPLY_LEMMA (opid, params, NONE, pat, List.length tacs)) $$ args
+    end
+
+  fun makeUseLemma (opid, params, subtermArgs) tacs = 
+    let
+      val args = List.map (fn tac => ([],[]) \ tac) tacs
+    in
+      O.POLY (O.DEV_USE_LEMMA (opid, params, NONE, List.length tacs)) $$ args
     end
 
 end
@@ -711,9 +718,10 @@ atomicRawTac
   | LET devDecompPattern EQUALS VARNAME devAppSpine DOT tactic
       (Pattern.makeApplyHyp devDecompPattern VARNAME devAppSpine tactic)
 
-  | LET devDecompPattern EQUALS customOpTerm devAppSpine DOT tactic (Pattern.makeCutLemma devDecompPattern customOpTerm devAppSpine tactic)
+  | LET devDecompPattern EQUALS customOpTerm devAppSpine DOT tactic (Pattern.makeApplyLemma devDecompPattern customOpTerm devAppSpine tactic)
 
   | USE VARNAME devAppSpine (Pattern.makeUseHyp VARNAME devAppSpine)
+  | USE customOpTerm devAppSpine (Pattern.makeUseLemma customOpTerm devAppSpine)
 
   | CASE VARNAME OF BASE DOUBLE_RIGHT_ARROW tactic PIPE LOOP VARNAME DOUBLE_RIGHT_ARROW tactic
       (Ast.$$ (O.POLY (O.DEV_S1_ELIM VARNAME1), [\ (([],[]), tactic1), \(([VARNAME2], []), tactic2)]))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -208,6 +208,12 @@ struct
       O.POLY (O.DEV_APPLY_HYP (z, pat, List.length tacs)) $$ args
     end
 
+  fun makeUseHyp z tacs = 
+    let
+      val args = List.map (fn tac => ([],[]) \ tac) tacs
+    in
+      O.POLY (O.DEV_USE_HYP (z, List.length tacs)) $$ args
+    end
 
   fun makeCutLemma pat (opid, params, subtermArgs) tacs tac = 
     let
@@ -279,7 +285,7 @@ end
  (* keywords in tactics *)
  | CASE | OF
  | FRESH
- | LET | WITH
+ | LET | USE | WITH
  | THEN | ELSE
  | REFINE
  | MTAC_REC | MTAC_PROGRESS | MTAC_REPEAT | MTAC_AUTO | MTAC_HOLE
@@ -682,8 +688,6 @@ atomicRawTac
   | RULE_ID (Ast.$$ (O.MONO O.RULE_ID, []))
   | RULE_AUTO_STEP (Ast.$$ (O.MONO O.RULE_AUTO_STEP, []))
   | RULE_SYMMETRY (Ast.$$ (O.MONO O.RULE_SYMMETRY, []))
-  | HYP VARNAME COLON sort (Ast.$$ (O.POLY (O.RULE_HYP (VARNAME, sort)), []))
-  | HYP VARNAME (Ast.$$ (O.POLY (O.RULE_HYP (VARNAME, O.EXP)), []))
   | RULE_ELIM VARNAME COLON sort (Ast.$$ (O.POLY (O.RULE_ELIM (VARNAME, sort)), []))
   | RULE_ELIM VARNAME (Ast.$$ (O.POLY (O.RULE_ELIM (VARNAME, O.EXP)), []))
   | RULE_UNFOLD OPNAME (Ast.$$ (O.POLY (O.RULE_UNFOLD OPNAME), []))
@@ -708,6 +712,8 @@ atomicRawTac
       (Pattern.makeApplyHyp devDecompPattern VARNAME devAppSpine tactic)
 
   | LET devDecompPattern EQUALS customOpTerm devAppSpine DOT tactic (Pattern.makeCutLemma devDecompPattern customOpTerm devAppSpine tactic)
+
+  | USE VARNAME devAppSpine (Pattern.makeUseHyp VARNAME devAppSpine)
 
   | CASE VARNAME OF BASE DOUBLE_RIGHT_ARROW tactic PIPE LOOP VARNAME DOUBLE_RIGHT_ARROW tactic
       (Ast.$$ (O.POLY (O.DEV_S1_ELIM VARNAME1), [\ (([],[]), tactic1), \(([VARNAME2], []), tactic2)]))

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -108,6 +108,7 @@ whitespace = [\ \t];
 "then"             => (Tokens.THEN (posTuple (size yytext)));
 "else"             => (Tokens.ELSE (posTuple (size yytext)));
 "let"              => (Tokens.LET (posTuple (size yytext)));
+"use"              => (Tokens.USE (posTuple (size yytext)));
 "with"             => (Tokens.WITH (posTuple (size yytext)));
 "case"             => (Tokens.CASE (posTuple (size yytext)));
 "of"               => (Tokens.OF (posTuple (size yytext)));

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -96,7 +96,6 @@ struct
           NONE => setAnnotation (getAnnotation t1) t2
         | _ => t2
 
-
       fun processOp pos sign =
         fn O.POLY (O.CUST (opid, ps, NONE)) =>
            (case arityOfOpid sign opid of
@@ -114,6 +113,15 @@ struct
                    val ps' = ListPair.mapEq (fn ((p, _), tau) => (O.P.check tau p; (p, SOME tau))) (ps, psorts)
                  in
                    O.POLY (O.DEV_APPLY_LEMMA (opid, ps', SOME ar, pat, n))
+                 end
+             | NONE => error pos [Fpp.text "Encountered undefined custom operator:", Fpp.text opid])
+         | O.POLY (O.DEV_USE_LEMMA (opid, ps, NONE, n)) =>
+           (case arityOfOpid sign opid of
+               SOME (psorts, ar) =>
+                 let
+                   val ps' = ListPair.mapEq (fn ((p, _), tau) => (O.P.check tau p; (p, SOME tau))) (ps, psorts)
+                 in
+                   O.POLY (O.DEV_USE_LEMMA (opid, ps', SOME ar, n))
                  end
              | NONE => error pos [Fpp.text "Encountered undefined custom operator:", Fpp.text opid])
          | th => th

--- a/src/redprl/tactic_elaborator.fun
+++ b/src/redprl/tactic_elaborator.fun
@@ -278,7 +278,6 @@ struct
      | O.MONO O.RULE_ID $ _ => idn
      | O.MONO O.RULE_AUTO_STEP $ _ => R.AutoStep sign
      | O.POLY (O.RULE_ELIM (z, _)) $ _ => R.Elim sign z
-     | O.POLY (O.RULE_HYP (z, _)) $ _ => hyp z
      | O.MONO (O.RULE_EXACT _) $ [_ \ tm] => R.Exact (expandHypVars tm)
      | O.MONO O.RULE_HEAD_EXP $ _ => R.Computation.EqHeadExpansion sign
      | O.MONO O.RULE_SYMMETRY $ _ => R.Equality.Symmetry
@@ -298,6 +297,13 @@ struct
          val tac = tactic sign env tm
        in
          applications sign z (pattern, names) tacs tac
+       end
+     | O.POLY (O.DEV_USE_HYP (z, n)) $ args => 
+       let
+         val z' = RedPrlSym.named (Sym.toString z ^ "'")
+         val tacs = List.map (fn _ \ tm => tactic sign env tm) args
+       in
+         applications sign z (O.PAT_VAR (), [z']) tacs (hyp z')
        end
      | O.POLY (O.DEV_APPLY_LEMMA (opid, ps, ar, pat, n)) $ args =>
        let

--- a/src/redprl/tactic_elaborator.fun
+++ b/src/redprl/tactic_elaborator.fun
@@ -314,6 +314,14 @@ struct
        in
          cutLemma sign opid (Option.valOf ar) ps (List.rev subtermArgs) (pat, names) (List.rev appTacs) tac
        end
+     | O.POLY (O.DEV_USE_LEMMA (opid, ps, ar, n)) $ args =>
+       let
+         val z = RedPrlSym.named (Sym.toString opid ^ "'")
+         val (appArgs, subtermArgs) = ListUtil.splitAt (List.rev args, n)
+         val appTacs = List.map (fn _ \ tm => tactic sign env tm) appArgs
+       in
+         cutLemma sign opid (Option.valOf ar) ps (List.rev subtermArgs) (O.PAT_VAR (), [z]) (List.rev appTacs) (hyp z)
+       end
      | O.POLY (O.CUST (opid, ps, _)) $ args => tactic sign env (unfoldCustomOperator sign (opid, ps, args))
      | _ => raise RedPrlError.error [Fpp.text "Unrecognized tactic", TermPrinter.ppTerm tm]
 

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -20,7 +20,7 @@ Thm LowLevel : [
 ] by [
   fresh f <- refine dfun/intro;
   [fresh x, x/eq <- elim f;
-  [`tt, hyp x],
+  [`tt, use x],
   refine dfun/eq/type;
   refine wbool/eq/type]
 ].
@@ -34,7 +34,7 @@ Thm LowLevel2 : [
 ] by [
   fresh f <- auto;
   fresh x, x/eq <- elim f;
-  [`tt, hyp x]
+  [`tt, use x]
 ].
 
 Extract LowLevel2.
@@ -44,7 +44,7 @@ Thm FunElimTest : [
    (-> wbool wbool)
    wbool)
 ] by [
-  lam f. let x = f {`tt}. hyp x
+  lam f. let x = f {`tt}. use x
 ].
 
 Thm S1ElimTest : [ (-> S1 S1) ] by [
@@ -133,8 +133,7 @@ Thm PathTest2 : [
       // interactive tactic environment, dimension expressions are
       // supplied to the refiner using the & "dimension quotation"
       // operator.
-      let px = p @x.
-      hyp px
+      use p @x
 ].
 
 // It turns out that it is just as good to figure out what the witness
@@ -203,7 +202,7 @@ Thm FunExt(#A; #B) : [
    (path {_} (-> #A #B) f g))
 ] by [
   lam f, g, p.
-    <i> lam a. let q = p {hyp a}, @i. hyp q
+    <i> lam a. use p {use a}, @i
 ].
 
 Print FunExt.
@@ -211,7 +210,7 @@ Print FunExt.
 
 Tac FunExtTac(#A; #B; #F; #G) = [
   let p : [(-> [x : #A] (path {_} wbool ($ #F x) ($ #G x)))] = id.
-  <i> lam a. let q = p {hyp a}, @i. hyp q
+  <i> lam a. use p {use a}, @i
 ].
 
 Thm NotNotPath : [(path {_} (-> wbool wbool) (Cmp Not Not) (lam [x] x))] by [
@@ -228,7 +227,7 @@ Thm Singleton : [(* [x : wbool] (path {_} wbool x tt))] by [
 ].
 
 Thm PathElimTest : [(-> (path {_} bool tt tt) bool)] by [
-  lam x. let x/0 = x @0. hyp x/0
+  lam x. use x @0
 ].
 
 Thm PathEta(#A) : [
@@ -238,7 +237,7 @@ Thm PathEta(#A) : [
    (path {_} #A m n)
    (path {_} #A m n))
 ] by [
-  lam m, n, p. <j> let p/j = p @j. hyp p/j
+  lam m, n, p. <j> use p @j
 ].
 
 Print PathEta.

--- a/test/success/decomposition.prl
+++ b/test/success/decomposition.prl
@@ -4,7 +4,7 @@ Thm Decomposition : [
    bool)
 ] by [
   lam <foo = <a, b = <proj1>>>.
-  hyp proj1
+  use proj1
 ].
 
 Extract Decomposition.
@@ -22,10 +22,19 @@ Thm Apply : [
 ] by [
   lam f.
     let <a> = f `tt, `ff, @0.
-    hyp a
+    use a
 ].
 
 Extract Apply.
+
+Thm UseHypTest : [
+  bool
+] by [
+  let p : [(-> bool S1 bool)] = lam b, c. use b.
+  use p `tt, `(loop 0)
+].
+
+Print UseHypTest.
 
 
 Thm MyLemma(#m: {dim,dim}[exp,exp].exp) : [
@@ -38,7 +47,7 @@ Thm UsingLemma : [
   (path {_} bool tt tt)
 ] by [
   let <proj2 = lem> = (MyLemma {i j} [x y] (@ (abs {_} y) i)) `tt, <_> `tt.
-  hyp lem
+  use lem
 ].
 
 Print UsingLemma.

--- a/test/success/decomposition.prl
+++ b/test/success/decomposition.prl
@@ -28,13 +28,21 @@ Thm Apply : [
 Extract Apply.
 
 Thm UseHypTest : [
-  bool
+  (-> bool bool)
 ] by [
+  lam x.
   let p : [(-> bool S1 bool)] = lam b, c. use b.
-  use p `tt, `(loop 0)
+  use p {use x}, `(loop 0)
 ].
 
 Print UseHypTest.
+
+Thm UseLemmaTest : [
+  (-> bool bool)
+] by [
+  lam x.
+  use UseHypTest {use x}
+].
 
 
 Thm MyLemma(#m: {dim,dim}[exp,exp].exp) : [

--- a/test/success/logical-investigations.prl
+++ b/test/success/logical-investigations.prl
@@ -14,21 +14,8 @@ Thm Thm1(#A; #B) : [
   type/B : #B type
   >> (-> #A #B #A)
 ] by [
-  lam a, b. hyp a
+  lam a, b. use a
 ].
-
-
-
-// We'll make a handy little tactic to apply a functional hypothesis.
-Tac Apply{z:hyp}(#t:tac) = [
-  // RedPRL's logic is a sequent calculus, which means that you apply 
-  // functions in your context using let bindings in the following way:
-  let x = z #t.
-  hyp x
-].
-
-
-// #{t} tells the parser that 't' should be parsed using tactic notation.
 
 Thm Thm2(#A; #B; #C) : [
   type/A : #A type,
@@ -37,10 +24,7 @@ Thm Thm2(#A; #B; #C) : [
   >> (-> (-> #A #B) (-> #A #B #C) #A #C)
 ] by [
   lam f, g, a.
-  let h = g {hyp a}.
-  ({Apply h}
-   ({Apply f}
-    #{hyp a}))
+  use g {use a}, {use f {use a}}
 ].
 
 // It is worthwhile to print out the extract program / evidence for Thm2.
@@ -58,7 +42,7 @@ Thm Thm3/low-level(#A; #B; #C) : [
 ] by [
   fresh ab, bc, a <- auto;
   fresh c <- elim bc;
-  [fresh b <- elim ab; [hyp a, hyp b], hyp c]
+  [fresh b <- elim ab; [use a, use b], use c]
 ].
 
 Extract Thm3/low-level.
@@ -76,9 +60,7 @@ Thm Thm3/high-level(#A; #B; #C) : [
       (-> #A #C))
 ] by [
   lam ab, bc, a.
-  ({Apply bc}
-   ({Apply ab}
-    #{hyp a}))
+  use bc {use ab {use a}}
 ].
 
 Extract Thm3/high-level.
@@ -99,7 +81,7 @@ Thm Thm4(#A; #B) : [
 ] by [
   lam r, a.
   unfold Not;
-  let boom = r {hyp a}.
+  let boom = r {use a}.
   elim boom
 ].
 
@@ -108,8 +90,7 @@ Thm Thm5(#A) : [
   >> (-> #A (Not (Not #A)))
 ] by [
   lam a. unfold Not; lam r.
-  ({Apply r}
-   #{hyp a})
+  use r {use a}
 ].
 
 Print Thm4.
@@ -122,7 +103,5 @@ Thm Thm6(#A;#B) : [
   >> (-> (-> #A #B) (Not #B) (Not #A))
 ] by [
   lam ab, nb. unfold Not; lam a.
-  ({Apply nb} 
-   ({Apply ab}
-    #{hyp a}))
+  use nb {use ab {use a}}
 ].

--- a/test/success/num.prl
+++ b/test/success/num.prl
@@ -22,7 +22,7 @@ Thm Pred : [
   lam a.
   fresh a', ind <- elim a;
   [ `zero ];
-  [ hyp a' ]
+  [ use a' ]
 ].
 
 Extract Pred.

--- a/test/success/path-ap-const.prl
+++ b/test/success/path-ap-const.prl
@@ -1,7 +1,7 @@
 Thm PathApConst : [
   (-> (path {_} bool tt tt) bool)
 ] by [
-  lam p. let p0 = p @0. hyp p0
+  lam p. use p @0
 ].
 
 Print PathApConst.

--- a/test/success/primitive-sequencing.prl
+++ b/test/success/primitive-sequencing.prl
@@ -1,6 +1,6 @@
 Thm PrimitiveSequencingTest : [(-> bool bool bool bool)] by [
   fresh x,y,z <- auto;
-  hyp y
+  use y
 ].
 
 Extract PrimitiveSequencingTest.

--- a/test/success/record.prl
+++ b/test/success/record.prl
@@ -49,7 +49,7 @@ Thm RecordTest6 : [
     [p : (record [a : bool] [b c : record])]
     bool)
 ] by [
-  lam <a>. hyp a
+  lam <a>. use a
 ].
 
 Thm RecordTest7 : [
@@ -69,8 +69,8 @@ Thm RecordElimTest : [
    (* [b : bool] (path {_} bool b b)))
 ] by [
   lam <b = welp, p = hello>.
-    <proj2 = hyp hello,
-     proj1 = hyp welp>
+    <proj2 = use hello,
+     proj1 = use welp>
 ].
 
 Print RecordElimTest.

--- a/test/success/strict-bool.prl
+++ b/test/success/strict-bool.prl
@@ -18,7 +18,7 @@ Thm SBool/Not-Not-Id-Path : [
     (Cmp Bool/Not Bool/Not)
     (lam [x] x))
 ] by [
-  <i> lam x. hyp x
+  <i> lam x. use x
 ].
 
 Extract SBool/Not-Not-Id-Path.

--- a/test/success/unfold.prl
+++ b/test/success/unfold.prl
@@ -4,12 +4,12 @@ Def Times(#A; #B) = [
 
 Tac Proj1{z:hyp} = [
   let <proj1> = z.
-  hyp proj1
+  use proj1
 ].
 
 Tac Proj2{z:hyp} = [
   let <proj2> = z.
-  hyp proj2
+  use proj2
 ].
 
 Thm Times/Proj(#A) : [


### PR DESCRIPTION
This is like "let" except it uses the result as a hypothesis at the end. It doesn't support pattern decomposition yet, but it does support applications.

This is like backward chaining (#303) without unification: the user has to fill in the arguments. Later, as we start to build up some unification machinery, we can let uses put underscores for those cases where we can unify (patterns).

I've removed `hyp`. Just always use `use`.