### PR TITLE
higher order unification...

### DIFF
--- a/src/redprl.cm
+++ b/src/redprl.cm
@@ -17,6 +17,7 @@ is
   $libs/sml-cats/cats.cm
   $libs/sml-telescopes/telescopes.cm
   $libs/sml-typed-abts/abt.cm
+  $libs/sml-typed-abts/abt-unify.cm
   $libs/sml-typed-abts/basis/basis.cm
   $libs/sml-dependent-lcf/dependent_lcf.cm
   $libs/sml-dependent-lcf/lcf_abt.cm

--- a/src/redprl.mlb
+++ b/src/redprl.mlb
@@ -11,6 +11,7 @@ in
     $(LIBS)/sml-cats/cats.mlb
     $(LIBS)/sml-telescopes/telescopes.mlb
     $(LIBS)/sml-typed-abts/abt.mlb
+    $(LIBS)/sml-typed-abts/abt-unify.mlb
     $(LIBS)/sml-typed-abts/basis/basis.mlb
     $(LIBS)/sml-dependent-lcf/dependent_lcf.mlb
     $(LIBS)/sml-dependent-lcf/lcf_abt.mlb

--- a/src/redprl/abt.sml
+++ b/src/redprl/abt.sml
@@ -1,6 +1,6 @@
-structure Metavar = AbtSymbol ()
 structure RedPrlSym = AbtSymbol ()
 structure RedPrlVar = RedPrlSym
+structure Metavar = RedPrlSym
 
 structure Sym = RedPrlSym and Var = RedPrlVar
 

--- a/src/redprl/machine.fun
+++ b/src/redprl/machine.fun
@@ -22,9 +22,6 @@ struct
     val autoStep = O.MONO O.RULE_AUTO_STEP $$ []
     val auto = O.MONO O.MTAC_AUTO $$ []
 
-    fun elim (u, tau) =
-      O.POLY (O.RULE_ELIM (u, tau)) $$ []
-
     fun all t =
       O.MONO O.MTAC_ALL $$ [([],[]) \ t]
 

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -173,7 +173,7 @@ struct
    | COM of 'a dir * 'a equation list
    | CUST of 'a * ('a P.term * psort option) list * RedPrlArity.t option
    | PAT_META of 'a * sort * ('a P.term * psort) list * sort list
-   | HYP_REF of 'a
+   | HYP_REF of 'a * sort
    | PARAM_REF of psort * 'a P.term
    | RULE_ELIM of 'a
    | RULE_UNFOLD of 'a
@@ -332,7 +332,7 @@ struct
        | COM params => arityCom params
        | CUST (_, _, ar) => Option.valOf ar
        | PAT_META (_, tau, _, taus) => List.map (fn tau => [] * [] <> tau) taus ->> tau
-       | HYP_REF _ => [] ->> EXP
+       | HYP_REF (_, tau) => [] ->> tau
        | PARAM_REF (sigma, _) => [] ->> PARAM_EXP sigma
        | RULE_ELIM _ => [] ->> TAC
        | RULE_UNFOLD _ => [] ->> TAC
@@ -396,7 +396,7 @@ struct
        | COM params => comSupport params
        | CUST (opid, ps, _) => (opid, OPID) :: paramsSupport ps
        | PAT_META (x, _, ps, _) => (x, META_NAME) :: paramsSupport' ps
-       | HYP_REF a => [(a, HYP)]
+       | HYP_REF (a, _) => [(a, HYP)]
        | PARAM_REF (sigma, r) => paramsSupport [(r, SOME sigma)]
        | RULE_ELIM a => [(a, HYP)]
        | RULE_UNFOLD a => [(a, OPID)]
@@ -450,7 +450,7 @@ struct
              PAT_META (x2, tau2, ps2, taus2) => f (x1, x2) andalso tau1 = tau2 andalso paramsEq f (ps1, ps2) andalso taus1 = taus2
            | _ => false)
 
-       | (HYP_REF a, t) => (case t of HYP_REF b => f (a, b) | _ => false)
+       | (HYP_REF (a, _), t) => (case t of HYP_REF (b, _) => f (a, b) | _ => false)
        | (PARAM_REF (sigma1, r1), t) => (case t of PARAM_REF (sigma2, r2) => sigma1 = sigma2 andalso P.eq f (r1, r2) | _ => false)
        | (RULE_ELIM a, t) => (case t of RULE_ELIM b => f (a, b) | _ => false)
        | (RULE_UNFOLD a, t) => (case t of RULE_UNFOLD b => f (a, b) | _ => false)
@@ -594,7 +594,7 @@ struct
            f opid ^ "{" ^ paramsToString f ps ^ "}"
        | PAT_META (x, _, ps, _) =>
            "?" ^ f x ^ "{" ^ paramsToString f ps ^ "}"
-       | HYP_REF a => "hyp-ref{" ^ f a ^ "}"
+       | HYP_REF (a, _) => "hyp-ref{" ^ f a ^ "}"
        | PARAM_REF (_, r) => "param-ref{" ^ P.toString f r ^ "}"
        | RULE_ELIM a => "elim{" ^ f a ^ "}"
        | RULE_UNFOLD a => "unfold{" ^ f a ^ "}"
@@ -652,7 +652,7 @@ struct
        | COM (dir, eqs) => COM (mapSpan f dir, mapSpans f eqs)
        | CUST (opid, ps, ar) => CUST (mapSym (passSort OPID f) opid, mapParams f ps, ar)
        | PAT_META (x, tau, ps, taus) => PAT_META (mapSym (passSort META_NAME f) x, tau, mapParams' f ps, taus)
-       | HYP_REF a => HYP_REF (mapSym (passSort HYP f) a)
+       | HYP_REF (a, tau) => HYP_REF (mapSym (passSort HYP f) a, tau)
        | PARAM_REF (sigma, r) => PARAM_REF (sigma, P.bind (passSort sigma f) r)
        | RULE_ELIM a => RULE_ELIM (mapSym (passSort HYP f) a)
        | RULE_UNFOLD a => RULE_UNFOLD (mapSym (passSort OPID f) a)

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -12,6 +12,7 @@ struct
    | MTAC
    | JDG
    | TRIV
+   | MATCH_CLAUSE of sort
    | PARAM_EXP of param_sort
 
   val rec sortToString = 
@@ -20,6 +21,7 @@ struct
      | MTAC => "mtac"
      | JDG => "jdg"
      | TRIV => "triv"
+     | MATCH_CLAUSE tau => "match-clause"
      | PARAM_EXP sigma => "param-exp{" ^ paramSortToString sigma ^ "}"
 
   and paramSortToString = 
@@ -151,6 +153,8 @@ struct
    | DEV_DFUN_INTRO of unit dev_pattern list
    | DEV_PATH_INTRO of int | DEV_RECORD_INTRO of string list
    | DEV_LET of RedPrlSort.t
+   | DEV_MATCH of RedPrlSort.t * int list
+   | DEV_MATCH_CLAUSE of RedPrlSort.t 
 
    | JDG_EQ | JDG_TRUE | JDG_EQ_TYPE | JDG_SYNTH | JDG_TERM of RedPrlSort.t | JDG_PARAM_SUBST of RedPrlParamSort.t list * RedPrlSort.t
 
@@ -279,6 +283,9 @@ struct
      | DEV_RECORD_INTRO lbls => List.map (fn _ => [] * [] <> TAC) lbls ->> TAC
      | DEV_PATH_INTRO n => [List.tabulate (n, fn _ => DIM) * [] <> TAC] ->> TAC
      | DEV_LET tau => [[] * [] <> JDG, [] * [] <> TAC, [HYP tau] * [] <> TAC] ->> TAC
+
+     | DEV_MATCH (tau, ns) => ([] * [] <> tau) :: List.map (fn n => List.tabulate (n, fn _ => META_NAME) * [] <> MATCH_CLAUSE tau) ns ->> TAC
+     | DEV_MATCH_CLAUSE tau => [[] * [] <> tau, [] * [] <> TAC] ->> MATCH_CLAUSE tau
 
      | JDG_EQ => [[] * [] <> EXP, [] * [] <> EXP, [] * [] <> EXP] ->> JDG
      | JDG_TRUE => [[] * [] <> EXP] ->> JDG
@@ -525,6 +532,8 @@ struct
      | DEV_DFUN_INTRO pats => "fun-intro"
      | DEV_RECORD_INTRO lbls => "record-intro{" ^ ListSpine.pretty (fn x => x) "," lbls ^ "}"
      | DEV_LET _ => "let"
+     | DEV_MATCH _ => "dev-match"
+     | DEV_MATCH_CLAUSE _ => "dev-match-clause"
 
      | JDG_EQ => "eq"
      | JDG_TRUE => "true"

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -155,6 +155,8 @@ struct
    | DEV_LET of RedPrlSort.t
    | DEV_MATCH of RedPrlSort.t * int list
    | DEV_MATCH_CLAUSE of RedPrlSort.t 
+   | DEV_QUERY_GOAL
+   | DEV_PRINT of RedPrlSort.t
 
    | JDG_EQ | JDG_TRUE | JDG_EQ_TYPE | JDG_SYNTH | JDG_TERM of RedPrlSort.t | JDG_PARAM_SUBST of RedPrlParamSort.t list * RedPrlSort.t
 
@@ -286,6 +288,8 @@ struct
 
      | DEV_MATCH (tau, ns) => ([] * [] <> tau) :: List.map (fn n => List.tabulate (n, fn _ => META_NAME) * [] <> MATCH_CLAUSE tau) ns ->> TAC
      | DEV_MATCH_CLAUSE tau => [[] * [] <> tau, [] * [] <> TAC] ->> MATCH_CLAUSE tau
+     | DEV_QUERY_GOAL => [[] * [JDG] <> TAC] ->> TAC
+     | DEV_PRINT tau => [[] * [] <> tau] ->> TAC
 
      | JDG_EQ => [[] * [] <> EXP, [] * [] <> EXP, [] * [] <> EXP] ->> JDG
      | JDG_TRUE => [[] * [] <> EXP] ->> JDG

--- a/src/redprl/pretty.sml
+++ b/src/redprl/pretty.sml
@@ -165,7 +165,7 @@ struct
 
   and ppTerm m =
     case Abt.out m of
-       O.POLY (O.HYP_REF x) $ [] => seq [char #",", ppVar x]
+       O.POLY (O.HYP_REF (x, _)) $ [] => seq [char #",", ppVar x]
      | `x => ppVar x
      | O.POLY (O.LOOP x) $ [] =>
          Atomic.parens @@ expr @@ hvsep @@ [text "loop", ppParam x]

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -309,6 +309,8 @@ end
  | RULE_ID | RULE_AUTO_STEP | RULE_SYMMETRY | RULE_ELIM | RULE_HEAD_EXP | RULE_UNFOLD
  | RULE_EXACT
  | MATCH
+ | QUERY | GOAL
+ | PRINT
 
  (* keywords in judgments *)
  | JDG_TRUE | JDG_TYPE | JDG_SYNTH
@@ -465,6 +467,7 @@ sort
   : EXP (O.EXP)
   | TAC (O.TAC)
   | TRIV (O.TRIV)
+  | JDG (O.JDG)
 
 sorts
   : sort ([sort])
@@ -795,6 +798,8 @@ atomicRawTac
       (Ast.$$ (O.POLY (O.DEV_S1_ELIM VARNAME1), [\ (([],[]), tactic1), \(([VARNAME2], []), tactic2)]))
 
   | MATCH typedTerm LBRACKET devMatchClauses RBRACKET (Tac.makeMatch typedTerm devMatchClauses)
+  | QUERY VARNAME LEFT_ARROW GOAL DOT tactic (Ast.$$ (O.MONO O.DEV_QUERY_GOAL, [\ (([],[VARNAME]), tactic)]))
+  | PRINT typedTerm (Ast.$$ (O.MONO (O.DEV_PRINT (#2 typedTerm)), [\ (([], []), #1 typedTerm)]))
 
   (* overlapping with term *)
   | rawTermAndTac (rawTermAndTac)

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -606,8 +606,8 @@ patvar
   | PERCENT VARNAME ((VARNAME, O.EXP))
 
 patvarBindings
-  : PERCENT VARNAME COMMA patvarBindings (VARNAME :: patvarBindings)
-  | PERCENT VARNAME ([VARNAME])
+  : VARNAME COMMA patvarBindings (VARNAME :: patvarBindings)
+  | VARNAME ([VARNAME])
 
 rawTermAndTac
   : VARNAME (`` VARNAME)

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -224,7 +224,7 @@ struct
       O.POLY (O.DEV_USE_HYP (z, List.length tacs)) $$ args
     end
 
-  fun makeApplyLemma pat (opid, params, subtermArgs) tacs tac = 
+  fun makeApplyLemma pat (opid, params, subtermArgs) tacs tac =
     let
       val (pat, names) = unstitchPattern pat
       val appArgs = List.map (fn tac => ([],[]) \ tac) tacs
@@ -455,7 +455,7 @@ boundVars
 
 psort
   : DIM (P.DIM)
-  | HYP (P.HYP O.EXP)
+  | HYP (P.HYP)
   | META_NAME (P.META_NAME)
 
 psorts
@@ -765,8 +765,7 @@ atomicRawTac
   | RULE_ID (Ast.$$ (O.MONO O.RULE_ID, []))
   | RULE_AUTO_STEP (Ast.$$ (O.MONO O.RULE_AUTO_STEP, []))
   | RULE_SYMMETRY (Ast.$$ (O.MONO O.RULE_SYMMETRY, []))
-  | RULE_ELIM VARNAME COLON sort (Ast.$$ (O.POLY (O.RULE_ELIM (VARNAME, sort)), []))
-  | RULE_ELIM VARNAME (Ast.$$ (O.POLY (O.RULE_ELIM (VARNAME, O.EXP)), []))
+  | RULE_ELIM VARNAME (Ast.$$ (O.POLY (O.RULE_ELIM VARNAME), []))
   | RULE_UNFOLD OPNAME (Ast.$$ (O.POLY (O.RULE_UNFOLD OPNAME), []))
   | BACK_TICK term (Tac.exactAuto O.EXP term)
   | RULE_EXACT term (Tac.exact O.EXP term)
@@ -783,7 +782,7 @@ atomicRawTac
       (Ast.$$ (O.POLY (O.DEV_BOOL_ELIM VARNAME), [\ (([],[]), tactic1), \ (([],[]), tactic2)]))
 
    | LET VARNAME COLON LSQUARE judgment RSQUARE EQUALS tactic DOT tactic
-      (Ast.$$ (O.MONO (O.DEV_LET (sortOfJudgment judgment)), [\ (([],[]), judgment), \ (([],[]), tactic1), \(([VARNAME],[]), tactic2)]))
+      (Ast.$$ (O.MONO O.DEV_LET, [\ (([],[]), judgment), \ (([],[]), tactic1), \(([VARNAME],[]), tactic2)]))
 
   | LET devDecompPattern EQUALS VARNAME bracketedDevAppSpine DOT tactic
       (Pattern.makeApplyHyp devDecompPattern VARNAME bracketedDevAppSpine tactic)
@@ -829,7 +828,7 @@ multitac : rawMultitac (annotate (Pos.pos (rawMultitac1left fileName) (rawMultit
 
 hypBinding
   : VARNAME COLON psort (VARNAME, psort)
-  | VARNAME (VARNAME, P.HYP O.EXP)
+  | VARNAME (VARNAME, P.HYP)
 
 hypBindings
   : hypBinding ([hypBinding])

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -813,7 +813,7 @@ atomicRawMultitac
   | MTAC_PROGRESS LBRACKET multitac RBRACKET (Ast.$$ (O.MONO O.MTAC_PROGRESS, [\ (([], []), multitac)]))
   | MTAC_REC VARNAME IN LBRACKET multitac RBRACKET (Ast.$$ (O.MONO O.MTAC_REC, [\ (([],[VARNAME]), multitac)]))
   | LBRACKET multitac RBRACKET (multitac)
-  | FRESH hypBindings LEFT_ARROW atomicRawMultitac SEMI multitac %prec LEFT_ARROW (Tac.makeSeq atomicRawMultitac hypBindings multitac)
+  | FRESH hypBindings RIGHT_ARROW atomicRawMultitac SEMI multitac %prec LEFT_ARROW (Tac.makeSeq atomicRawMultitac hypBindings multitac)
   | atomicTac %prec SEMI (Ast.$$ (O.MONO O.MTAC_ALL, [\ (([],[]), atomicTac)]))
   | QUESTION ident (Ast.$$ (O.MONO (O.MTAC_HOLE (SOME ident)), []))
   | QUESTION (Ast.$$ (O.MONO (O.MTAC_HOLE NONE), []))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -670,7 +670,8 @@ rawTerm
   | HASH TAC LBRACKET tactic RBRACKET (tactic)
   | HASH JDG LBRACKET judgment RBRACKET (judgment)
   (* hypotheses *)
-  | COMMA VARNAME (Ast.$$ (O.POLY (O.HYP_REF VARNAME), []))
+  | COMMA LSQUARE VARNAME COLON sort RSQUARE (Ast.$$ (O.POLY (O.HYP_REF (VARNAME, sort)), []))
+  | COMMA VARNAME (Ast.$$ (O.POLY (O.HYP_REF (VARNAME, O.EXP)), []))
 
 term : rawTerm (annotate (Pos.pos (rawTerm1left fileName) (rawTerm1right fileName)) rawTerm)
 

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -750,7 +750,7 @@ tupleDecompPattern
    | ([])
 
  devMatchClause
-  : patvarBindings TRIANGLE_RIGHT term DOUBLE_RIGHT_ARROW tactic (patvarBindings, (term, tactic))
+  : patvarBindings PIPE term DOUBLE_RIGHT_ARROW tactic (patvarBindings, (term, tactic))
   | term DOUBLE_RIGHT_ARROW tactic ([], (term, tactic))
 
 devMatchClauses

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -59,9 +59,8 @@ struct
   fun exactDim r =
     exactAuto (O.PARAM_EXP O.DIM) (O.POLY (O.PARAM_REF (O.DIM, r)) $$ [])
 
-  fun makeMatch term clauses = 
+  fun makeMatch (term, tau) clauses = 
     let
-      val tau = O.EXP (* TODO *)
       fun makeClause t1 t2 = O.MONO (O.DEV_MATCH_CLAUSE tau) $$ [([],[]) \ t1, ([],[]) \ t2]
       val clauseArgs = List.map (fn (xs, (t1, t2)) => (xs,[]) \ makeClause t1 t2) clauses
       val ns = List.map (List.length o #1) clauses
@@ -281,7 +280,7 @@ end
  (* parameter sorts *)
  | DIM | HYP | META_NAME
  (* sorts *)
- | EXP | TAC | TRIV
+ | EXP | TAC | TRIV | JDG
 
  (* keywords and symbols in expressions *)
  | FCOM
@@ -665,7 +664,8 @@ rawTermAndTac
 
 rawTerm
   : rawTermAndTac (rawTermAndTac)
-  | HASH LBRACKET tactic RBRACKET (tactic)
+  | HASH TAC LBRACKET tactic RBRACKET (tactic)
+  | HASH JDG LBRACKET judgment RBRACKET (judgment)
   (* hypotheses *)
   | COMMA VARNAME (Ast.$$ (O.POLY (O.HYP_REF VARNAME), []))
 
@@ -794,7 +794,7 @@ atomicRawTac
   | CASE VARNAME OF BASE DOUBLE_RIGHT_ARROW tactic PIPE LOOP VARNAME DOUBLE_RIGHT_ARROW tactic
       (Ast.$$ (O.POLY (O.DEV_S1_ELIM VARNAME1), [\ (([],[]), tactic1), \(([VARNAME2], []), tactic2)]))
 
-  | MATCH term LBRACKET devMatchClauses RBRACKET (Tac.makeMatch term devMatchClauses)
+  | MATCH typedTerm LBRACKET devMatchClauses RBRACKET (Tac.makeMatch typedTerm devMatchClauses)
 
   (* overlapping with term *)
   | rawTermAndTac (rawTermAndTac)

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -268,7 +268,7 @@ end
  | RIGHT_ARROW | LEFT_ARROW | DOUBLE_RIGHT_ARROW | LONG_RIGHT_ARROW
 
  (* parameter sorts *)
- | DIM | HYP
+ | DIM | HYP | META_NAME
  (* sorts *)
  | EXP | TAC | TRIV
 
@@ -333,12 +333,15 @@ end
    (* parameters *)
  | param of string param
  | params of string param list
+ | typedParam of string param * P.param_sort
+ | typedParams of (string param * P.param_sort) list
  | dir of string param * string param
  | equation of string param * string param
  | tube of (string param * string param) * ast abs
  | tubes of ((string param * string param) * ast abs) list
 
  | metavar of string
+ | patvar of string * O.sort
  | customOpParams of (string param * P.param_sort option) list
  | customOpTerm of string * (string param * P.param_sort option) list * ast abs list
 
@@ -364,6 +367,8 @@ end
    (* a type-theoretic term, annotated with source position *)
  | term of ast
  | terms of ast list
+ | typedTerm of ast * O.sort
+ | typedTerms of (ast * O.sort) list
 
  | rawJudgment of ast
  | judgment of ast
@@ -434,6 +439,7 @@ boundVars
 psort
   : DIM (P.DIM)
   | HYP (P.HYP O.EXP)
+  | META_NAME (P.META_NAME)
 
 psorts
   : psort ([psort])
@@ -463,9 +469,17 @@ param
   : VARNAME (P.VAR VARNAME)
   | NUMERAL (P.APP (case NUMERAL of 0 => P.DIM0 | 1 => P.DIM1 | _ => raise RedPrlError.annotate (SOME (Pos.pos (NUMERAL1left fileName) (NUMERAL1right fileName))) (RedPrlError.error [Fpp.text "Invalid dimension constant"])))
 
+typedParam
+  : LSQUARE param COLON psort RSQUARE ((param, psort))
+
 params
   : param ([param])
   | param params (param :: params)
+
+typedParams
+  : typedParam ([typedParam])
+  | typedParam typedParams (typedParam :: typedParams)
+
 
 dir
   : param SQUIGGLE_ARROW param ((param1, param2))
@@ -568,6 +582,10 @@ customOpTerm
   | LBRACKET OPNAME customOpParams RBRACKET (OPNAME, customOpParams, [])
   | LPAREN LBRACKET OPNAME customOpParams RBRACKET bindings RPAREN (OPNAME, customOpParams, bindings)
 
+patvar
+  : PERCENT LSQUARE VARNAME COLON sort RSQUARE ((VARNAME, sort))
+  | PERCENT VARNAME ((VARNAME, O.EXP))
+
 rawTermAndTac
   : VARNAME (`` VARNAME)
 
@@ -576,6 +594,12 @@ rawTermAndTac
   | LPAREN metavar terms RPAREN (Ast.$$# (metavar, ([], terms)))
   | LBRACKET metavar params RBRACKET (Ast.$$# (metavar, (params, [])))
   | LPAREN LBRACKET metavar params RBRACKET terms RPAREN (Ast.$$# (metavar, (params, terms)))
+
+  (* pattern variables *)
+  | patvar (Ast.$$ (O.POLY (O.PAT_META (#1 patvar, #2 patvar, [], [])), []))
+  | LPAREN patvar typedTerms RPAREN (Ast.$$ (O.POLY (O.PAT_META (#1 patvar, #2 patvar, [], List.map #2 typedTerms)), List.map (fn (tm, _) => \ (([],[]), tm)) typedTerms))
+  | LBRACKET patvar typedParams RBRACKET  (Ast.$$ (O.POLY (O.PAT_META (#1 patvar, #2 patvar, typedParams, [])), []))
+  | LPAREN LBRACKET patvar typedParams RBRACKET typedTerms RPAREN (Ast.$$ (O.POLY (O.PAT_META (#1 patvar, #2 patvar, typedParams, List.map #2 typedTerms)), List.map (fn (tm, _) => \ (([],[]), tm)) typedTerms))
 
   (* custom operators *)
   | customOpTerm (makeCustom customOpTerm)
@@ -629,6 +653,14 @@ term : rawTerm (annotate (Pos.pos (rawTerm1left fileName) (rawTerm1right fileNam
 terms
   : term ([term])
   | term terms (term :: terms)
+
+typedTerm
+  : LSQUARE term COLON sort RSQUARE ((term, sort))
+
+typedTerms
+  : typedTerm ([typedTerm])
+  | typedTerm typedTerms (typedTerm :: typedTerms)
+
 
 rawJudgment
   : term EQUALS term IN term (Ast.$$ (O.MONO O.JDG_EQ, [\ (([],[]), term1), \ (([],[]), term2), \ (([],[]), term3)]))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -758,7 +758,6 @@ tupleDecompPattern
 
 devMatchClauses
   : devMatchClause devMatchClauses (devMatchClause :: devMatchClauses)
-  | devMatchClause ([devMatchClause])
   | ([])
 
 atomicRawTac

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -750,12 +750,13 @@ tupleDecompPattern
    | ([])
 
  devMatchClause
-  : patvarBindings PIPE term DOUBLE_RIGHT_ARROW tactic (patvarBindings, (term, tactic))
-  | term DOUBLE_RIGHT_ARROW tactic ([], (term, tactic))
+  : LSQUARE patvarBindings PIPE term DOUBLE_RIGHT_ARROW tactic RSQUARE (patvarBindings, (term, tactic))
+  | LSQUARE term DOUBLE_RIGHT_ARROW tactic RSQUARE ([], (term, tactic))
 
 devMatchClauses
-  : devMatchClause COMMA devMatchClauses (devMatchClause :: devMatchClauses)
+  : devMatchClause devMatchClauses (devMatchClause :: devMatchClauses)
   | devMatchClause ([devMatchClause])
+  | ([])
 
 atomicRawTac
   : REFINE VARNAME (Ast.$$ (O.MONO (O.RULE_PRIM VARNAME), []))
@@ -793,7 +794,7 @@ atomicRawTac
   | CASE VARNAME OF BASE DOUBLE_RIGHT_ARROW tactic PIPE LOOP VARNAME DOUBLE_RIGHT_ARROW tactic
       (Ast.$$ (O.POLY (O.DEV_S1_ELIM VARNAME1), [\ (([],[]), tactic1), \(([VARNAME2], []), tactic2)]))
 
-  | MATCH term LSQUARE devMatchClauses RSQUARE (Tac.makeMatch term devMatchClauses)
+  | MATCH term LBRACKET devMatchClauses RBRACKET (Tac.makeMatch term devMatchClauses)
 
   (* overlapping with term *)
   | rawTermAndTac (rawTermAndTac)

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -487,6 +487,7 @@ param
 
 typedParam
   : LSQUARE param COLON psort RSQUARE ((param, psort))
+  | param ((param, O.DIM))
 
 params
   : param ([param])
@@ -676,6 +677,7 @@ terms
 
 typedTerm
   : LSQUARE term COLON sort RSQUARE ((term, sort))
+  | term ((term, O.EXP))
 
 typedTerms
   : typedTerm ([typedTerm])

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -58,6 +58,16 @@ struct
 
   fun exactDim r =
     exactAuto (O.PARAM_EXP O.DIM) (O.POLY (O.PARAM_REF (O.DIM, r)) $$ [])
+
+  fun makeMatch term clauses = 
+    let
+      val tau = O.EXP (* TODO *)
+      fun makeClause t1 t2 = O.MONO (O.DEV_MATCH_CLAUSE tau) $$ [([],[]) \ t1, ([],[]) \ t2]
+      val clauseArgs = List.map (fn (xs, (t1, t2)) => (xs,[]) \ makeClause t1 t2) clauses
+      val ns = List.map (List.length o #1) clauses
+    in
+      O.MONO (O.DEV_MATCH (tau, ns)) $$ (([],[]) \ term) :: clauseArgs
+    end
 end
 
 structure Multi =
@@ -266,6 +276,7 @@ end
  (* arrows *)
  | SQUIGGLE_ARROW
  | RIGHT_ARROW | LEFT_ARROW | DOUBLE_RIGHT_ARROW | LONG_RIGHT_ARROW
+ | TRIANGLE_RIGHT
 
  (* parameter sorts *)
  | DIM | HYP | META_NAME
@@ -298,6 +309,7 @@ end
  | MTAC_REC | MTAC_PROGRESS | MTAC_REPEAT | MTAC_AUTO | MTAC_HOLE
  | RULE_ID | RULE_AUTO_STEP | RULE_SYMMETRY | RULE_ELIM | RULE_HEAD_EXP | RULE_UNFOLD
  | RULE_EXACT
+ | MATCH
 
  (* keywords in judgments *)
  | JDG_TRUE | JDG_TYPE | JDG_SYNTH
@@ -342,6 +354,7 @@ end
 
  | metavar of string
  | patvar of string * O.sort
+ | patvarBindings of string list
  | customOpParams of (string param * P.param_sort option) list
  | customOpTerm of string * (string param * P.param_sort option) list * ast abs list
 
@@ -396,6 +409,9 @@ end
  | labeledDecompPattern of string * string O.dev_pattern
  | devAppSpine of ast list
  | bracketedDevAppSpine of ast list
+
+ | devMatchClause of string list * (ast * ast)
+ | devMatchClauses of (string list * (ast * ast)) list
 
  | recordFieldTactics of (string * ast) list
 
@@ -586,6 +602,10 @@ patvar
   : PERCENT LSQUARE VARNAME COLON sort RSQUARE ((VARNAME, sort))
   | PERCENT VARNAME ((VARNAME, O.EXP))
 
+patvarBindings
+  : PERCENT VARNAME COMMA patvarBindings (VARNAME :: patvarBindings)
+  | PERCENT VARNAME ([VARNAME])
+
 rawTermAndTac
   : VARNAME (`` VARNAME)
 
@@ -727,6 +747,14 @@ tupleDecompPattern
    | labeledDecompPattern ([labeledDecompPattern])
    | ([])
 
+ devMatchClause
+  : patvarBindings TRIANGLE_RIGHT term DOUBLE_RIGHT_ARROW tactic (patvarBindings, (term, tactic))
+  | term DOUBLE_RIGHT_ARROW tactic ([], (term, tactic))
+
+devMatchClauses
+  : devMatchClause COMMA devMatchClauses (devMatchClause :: devMatchClauses)
+  | devMatchClause ([devMatchClause])
+
 atomicRawTac
   : REFINE VARNAME (Ast.$$ (O.MONO (O.RULE_PRIM VARNAME), []))
   | RULE_ID (Ast.$$ (O.MONO O.RULE_ID, []))
@@ -762,6 +790,8 @@ atomicRawTac
 
   | CASE VARNAME OF BASE DOUBLE_RIGHT_ARROW tactic PIPE LOOP VARNAME DOUBLE_RIGHT_ARROW tactic
       (Ast.$$ (O.POLY (O.DEV_S1_ELIM VARNAME1), [\ (([],[]), tactic1), \(([VARNAME2], []), tactic2)]))
+
+  | MATCH term LSQUARE devMatchClauses RSQUARE (Tac.makeMatch term devMatchClauses)
 
   (* overlapping with term *)
   | rawTermAndTac (rawTermAndTac)

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -119,6 +119,7 @@ whitespace = [\ \t];
 
 "exp"              => (Tokens.EXP (posTuple (size yytext)));
 "tac"              => (Tokens.TAC (posTuple (size yytext)));
+"jdg"              => (Tokens.JDG (posTuple (size yytext)));
 "triv"             => (Tokens.TRIV (posTuple (size yytext)));
 
 "tactic"           => (Tokens.TACTIC (posTuple (size yytext)));

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -41,7 +41,7 @@ whitespace = [\ \t];
 "-"?{digit}+       => (Tokens.NUMERAL (posTupleWith (size yytext) (valOf (IntInf.fromString yytext))));
 "//"[^\n]*         => (continue ());
 
-
+":>"               => (Tokens.TRIANGLE_RIGHT (posTuple (size yytext)));
 "<|"               => (Tokens.LANGLE_PIPE (posTuple (size yytext)));
 "|>"               => (Tokens.RANGLE_PIPE (posTuple (size yytext)));
 "("                => (Tokens.LPAREN (posTuple (size yytext)));
@@ -146,6 +146,8 @@ whitespace = [\ \t];
 "head-expand"      => (Tokens.RULE_HEAD_EXP (posTuple (size yytext)));
 "unfold"           => (Tokens.RULE_UNFOLD (posTuple (size yytext)));
 "exact"            => (Tokens.RULE_EXACT (posTuple (size yytext)));
+
+"match"            => (Tokens.MATCH (posTuple (size yytext)));
 
 "true"             => (Tokens.JDG_TRUE (posTuple (size yytext)));
 "type"             => (Tokens.JDG_TYPE (posTuple (size yytext)));

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -149,6 +149,9 @@ whitespace = [\ \t];
 "exact"            => (Tokens.RULE_EXACT (posTuple (size yytext)));
 
 "match"            => (Tokens.MATCH (posTuple (size yytext)));
+"query"            => (Tokens.QUERY (posTuple (size yytext)));
+"goal"             => (Tokens.GOAL (posTuple (size yytext)));
+"print"            => (Tokens.PRINT (posTuple (size yytext)));
 
 "true"             => (Tokens.JDG_TRUE (posTuple (size yytext)));
 "type"             => (Tokens.JDG_TYPE (posTuple (size yytext)));

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -115,6 +115,7 @@ whitespace = [\ \t];
 "refine"           => (Tokens.REFINE (posTuple (size yytext)));
 
 "dim"              => (Tokens.DIM (posTuple (size yytext)));
+"meta-name"        => (Tokens.META_NAME (posTuple (size yytext)));
 
 "exp"              => (Tokens.EXP (posTuple (size yytext)));
 "tac"              => (Tokens.TAC (posTuple (size yytext)));

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -263,7 +263,7 @@ struct
       let
         val x = NameEnv.lookup env srcname handle _ => Sym.named srcname
         val env' = NameEnv.insert env srcname x
-        val symctx' = Sym.Ctx.insert symctx x (RedPrlSortData.HYP tau)
+        val symctx' = Sym.Ctx.insert symctx x RedPrlSortData.HYP
         val varctx' = Sym.Ctx.insert varctx x tau
       in
         (env', symctx', varctx', x)
@@ -423,7 +423,7 @@ struct
                       val taux = CJ.synthesis jdgx
                     in
                       (ps,
-                       Tm.Sym.Ctx.insert ctx x (RedPrlSortData.HYP taux),
+                       Tm.Sym.Ctx.insert ctx x RedPrlSortData.HYP,
                        NameEnv.insert env (Sym.toString x) x)
                     end)
                   (params', symctx, env)

--- a/src/redprl/tactic_elaborator.fun
+++ b/src/redprl/tactic_elaborator.fun
@@ -347,9 +347,9 @@ struct
              val pat' = defrostMetas metas pat
              val handler' = defrostMetas metas handler
              val rho = Unify.unify metas (term, pat')
-               handle exn as Unify.Unify (tm1, tm2) => 
+               (* handle exn as Unify.Unify (tm1, tm2) => 
                  (RedPrlLog.print RedPrlLog.WARN (getAnnotation pat, Fpp.hsep [Fpp.text "Failed to unify", TermPrinter.ppTerm tm1, Fpp.text "and", TermPrinter.ppTerm tm2]);
-                  raise exn)
+                  raise exn) *)
              val handler'' = substMetaenv rho handler'
            in
              tactic sign env handler'' alpha jdg

--- a/src/redprl/tactic_elaborator.fun
+++ b/src/redprl/tactic_elaborator.fun
@@ -343,7 +343,7 @@ struct
          fun reviveClause ((pvars,_) \ clause) alpha jdg =
            let
              val O.MONO (O.DEV_MATCH_CLAUSE _) $ [_ \ pat, _ \ handler] = out clause
-             val metas = List.foldl (fn (pvar, metas) => Unify.Metas.insert metas pvar) Unify.Metas.empty pvars
+             val metas = Unify.Metas.fromList pvars
              val pat' = defrostMetas metas pat
              val handler' = defrostMetas metas handler
              val rho = Unify.unify metas (term, pat')

--- a/src/redprl/tactic_elaborator.fun
+++ b/src/redprl/tactic_elaborator.fun
@@ -44,11 +44,11 @@ struct
 
     fun go syms m =
       case Tm.out m of
-         O.POLY (O.HYP_REF a) $ _ =>
+         O.POLY (O.HYP_REF (a, tau)) $ _ =>
            if Sym.Ctx.member syms a then
              m
            else
-             inheritAnnotation m (check (`a, O.EXP)) 
+             inheritAnnotation m (check (`a, tau)) 
        | _ => goStruct syms m
 
     and goStruct syms m =
@@ -247,7 +247,7 @@ struct
         let
           val syms = ListPair.zipEq (us, sigmas)
           val vars = ListPair.mapEq (fn (x, tau) => (x, O.HYP)) (xs, taus)
-          val rho = ListPair.foldl (fn (x, tau, rho) => Var.Ctx.insert rho x (O.POLY (O.HYP_REF x) $$ [])) Var.Ctx.empty (xs, taus)
+          val rho = ListPair.foldl (fn (x, tau, rho) => Var.Ctx.insert rho x (O.POLY (O.HYP_REF (x, tau)) $$ [])) Var.Ctx.empty (xs, taus)
           val m' = substVarenv rho m
         in
           {subtermNames = us @ xs @ subtermNames,

--- a/src/redprl/tactic_elaborator.fun
+++ b/src/redprl/tactic_elaborator.fun
@@ -49,7 +49,6 @@ struct
              m
            else
              inheritAnnotation m (check (`a, O.EXP)) 
-              (* TODO: This can't be right *)
        | _ => goStruct syms m
 
     and goStruct syms m =
@@ -247,7 +246,7 @@ struct
       fun processArg ((us, xs) \ m, ((sigmas, taus), _), {subtermNames, subtermTacs}) =
         let
           val syms = ListPair.zipEq (us, sigmas)
-          val vars = ListPair.mapEq (fn (x, tau) => (x, O.HYP tau)) (xs, taus)
+          val vars = ListPair.mapEq (fn (x, tau) => (x, O.HYP)) (xs, taus)
           val rho = ListPair.foldl (fn (x, tau, rho) => Var.Ctx.insert rho x (O.POLY (O.HYP_REF x) $$ [])) Var.Ctx.empty (xs, taus)
           val m' = substVarenv rho m
         in
@@ -278,14 +277,14 @@ struct
        O.MONO O.TAC_MTAC $ [_ \ tm] => multitacToTac (multitactic sign env tm)
      | O.MONO O.RULE_ID $ _ => idn
      | O.MONO O.RULE_AUTO_STEP $ _ => R.AutoStep sign
-     | O.POLY (O.RULE_ELIM (z, _)) $ _ => R.Elim sign z
+     | O.POLY (O.RULE_ELIM z) $ _ => R.Elim sign z
      | O.MONO (O.RULE_EXACT _) $ [_ \ tm] => R.Exact (expandHypVars tm)
      | O.MONO O.RULE_HEAD_EXP $ _ => R.Computation.EqHeadExpansion sign
      | O.MONO O.RULE_SYMMETRY $ _ => R.Equality.Symmetry
      | O.MONO O.RULE_CUT $ [_ \ catjdg] => R.Cut (CJ.fromAbt (expandHypVars catjdg))
      | O.POLY (O.RULE_UNFOLD opid) $ _ => R.Computation.Unfold sign opid
      | O.MONO (O.RULE_PRIM ruleName) $ _ => R.lookupRule ruleName
-     | O.MONO (O.DEV_LET tau) $ [_ \ jdg, _ \ tm1, ([u],_) \ tm2] => R.Cut (CJ.fromAbt (expandHypVars jdg)) thenl' ([u], [tactic sign env tm1, tactic sign env tm2])
+     | O.MONO O.DEV_LET $ [_ \ jdg, _ \ tm1, ([u],_) \ tm2] => R.Cut (CJ.fromAbt (expandHypVars jdg)) thenl' ([u], [tactic sign env tm1, tactic sign env tm2])
      | O.MONO (O.DEV_DFUN_INTRO pats) $ [(us, _) \ tm] => dfunIntros sign (pats, us) (tactic sign env tm)
      | O.MONO (O.DEV_RECORD_INTRO lbls) $ args => recordIntro sign lbls (List.map (fn _ \ tm => tactic sign env tm) args)
      | O.MONO (O.DEV_PATH_INTRO _) $ [(us, _) \ tm] => pathIntros sign us (tactic sign env tm)

--- a/src/redprl/tactic_elaborator.fun
+++ b/src/redprl/tactic_elaborator.fun
@@ -359,6 +359,16 @@ struct
        in
          List.foldr (fn (clause, tac) => T.orelse_ (reviveClause clause, tac)) fail clauses
        end
+     | O.MONO O.DEV_QUERY_GOAL $ [(_,[x]) \ tm] =>
+       (fn alpha => fn jdg as _ >> cj =>
+         let
+           val tm' = substVar (CJ.toAbt cj, x) tm
+         in
+           tactic sign env tm' alpha jdg
+         end)
+     | O.MONO (O.DEV_PRINT _) $ [_ \ tm'] =>
+       (RedPrlLog.print RedPrlLog.INFO (getAnnotation tm, TermPrinter.ppTerm tm');
+        T.idn)
      | _ => raise RedPrlError.error [Fpp.text "Unrecognized tactic", TermPrinter.ppTerm tm]
 
   and multitactic_ sign env tm =

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -64,7 +64,7 @@ Tac TryStep = [
   // We can call our Try tactical. But tactics are parsed with a different grammar than terms,
   // so to avoid ambiguity, when we need to provide a tactic expression as an argument to 
   // an operator, we wrap it in (tactic ....).
-  (Try #{auto-step})
+  (Try #tac{auto-step})
 ].
 
 Thm ApEqTest : [

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -18,8 +18,8 @@ Thm LowLevel : [
     (-> wbool wbool)
     wbool)
 ] by [
-  fresh f <- refine dfun/intro;
-  [fresh x, x/eq <- elim f;
+  fresh f -> refine dfun/intro;
+  [fresh x, x/eq -> elim f;
   [`tt, use x],
   refine dfun/eq/type;
   refine wbool/eq/type]
@@ -32,8 +32,8 @@ Thm LowLevel2 : [
     (-> wbool wbool)
     wbool)
 ] by [
-  fresh f <- auto;
-  fresh x, x/eq <- elim f;
+  fresh f -> auto;
+  fresh x, x/eq -> elim f;
   [`tt, use x]
 ].
 

--- a/test/success/equality-elim.prl
+++ b/test/success/equality-elim.prl
@@ -6,7 +6,7 @@ Tac Rewrite(#m; #n; #a; #t : tac; #c : {hyp}.exp) = [
   // Use the elimination rule for equality; we have to provide an annotation to
   // the hypothesis 'p' (sad!). We bind a new hypothesis which will represent the location
   // in the goal #c which is being rewritten.
-  fresh x <- elim p;
+  fresh x -> elim p;
   [`{#c x}, id, auto, auto]
 ].
 

--- a/test/success/equality-elim.prl
+++ b/test/success/equality-elim.prl
@@ -6,7 +6,7 @@ Tac Rewrite(#m; #n; #a; #t : tac; #c : {hyp}.exp) = [
   // Use the elimination rule for equality; we have to provide an annotation to
   // the hypothesis 'p' (sad!). We bind a new hypothesis which will represent the location
   // in the goal #c which is being rewritten.
-  fresh x <- elim p:triv;
+  fresh x <- elim p;
   [`{#c x}, id, auto, auto]
 ].
 

--- a/test/success/equality-elim.prl
+++ b/test/success/equality-elim.prl
@@ -17,7 +17,7 @@ Thm EqualityElimTest : [
   // We'll rewrite the goal by asserting [(if tt tt ff) = tt in bool].
   (Rewrite
    (if tt tt ff) tt bool
-   #{auto}
+   #tac{auto}
    // we specify the motive (to be unified with the goal) by binding a *hypothesis* x,
    // which can then be unquoted in the term that we provide.
    {x} (-> bool (path {_} bool tt ,x)));

--- a/test/success/logical-investigations.prl
+++ b/test/success/logical-investigations.prl
@@ -40,9 +40,9 @@ Thm Thm3/low-level(#A; #B; #C) : [
       (-> #B #C)
       (-> #A #C))
 ] by [
-  fresh ab, bc, a <- auto;
-  fresh c <- elim bc;
-  [fresh b <- elim ab; [use a, use b], use c]
+  fresh ab, bc, a -> auto;
+  fresh c -> elim bc;
+  [fresh b -> elim ab; [use a, use b], use c]
 ].
 
 Extract Thm3/low-level.

--- a/test/success/match.prl
+++ b/test/success/match.prl
@@ -1,10 +1,10 @@
-Thm MatchGoal : [ (-> bool bool bool) ] by [
+Thm MatchGoal : [ (-> bool bool bool bool bool bool) ] by [
   fresh x, y <- repeat {
     query gl <- goal.
     print [gl:jdg];
     match [gl:jdg] {
-      [%a, %b | #jdg{(-> [x : %a] (%b x))} => refine dfun/intro; [id, auto]]
-      [%a | %[a:jdg] => id]
+      [a, b | #jdg{(-> [x : %a] (%b x))} => refine dfun/intro; [id, auto]]
+      [a | %[a:jdg] => id]
     }
   };
   

--- a/test/success/match.prl
+++ b/test/success/match.prl
@@ -2,9 +2,15 @@ Thm Test : [ bool ] by [
   // We can do second-order pattern matching on a term by providing a
   // sequence of match clauses. Pattern variables are bound behind the pipe,
   // and are written with a %-sigil. Think of these as if they were metavariables.
-  match (lam [x] ($ x tt))
-    [%a | (lam [x] (%a x)) => `(%a (lam [x] x)), // in this clause, we extract the body of the lambda expression "capturing" the variable
-     %a, %b | ($ %a %b) => `%a] // in this clause we extract the first element of an application expression
+  match (lam [x] ($ x tt)) {
+    // in the first clause clause, we extract the body of the lambda expression "capturing" the variable.
+    // in the second clause, we extract the first element of an application expression.
+    [%a | (lam [x] (%a x)) => exact (%a (lam [x] x))]
+    [%a, %b | ($ %a %b) => exact %a]
+  };
+  auto
+  // later on, I'll add special magic terms like 'goal', so that you can type "match goal" and it will
+  // do the appropriate thing in a proof script.
 ].
 
 Print Test.

--- a/test/success/match.prl
+++ b/test/success/match.prl
@@ -1,16 +1,14 @@
-Thm Test : [ bool ] by [
-  // We can do second-order pattern matching on a term by providing a
-  // sequence of match clauses. Pattern variables are bound behind the pipe,
-  // and are written with a %-sigil. Think of these as if they were metavariables.
-  match [(lam [x] ($ x tt)) : exp] {
-    // in the first clause clause, we extract the body of the lambda expression "capturing" the variable.
-    // in the second clause, we extract the first element of an application expression.
-    [%a | (lam [x] (%a x)) => exact (%a (lam [x] x))]
-    [%a, %b | ($ %a %b) => exact %a]
+Thm MatchGoal : [ (-> bool bool bool) ] by [
+  fresh x, y <- repeat {
+    query gl <- goal.
+    print [gl:jdg];
+    match [gl:jdg] {
+      [%a, %b | #jdg{(-> [x : %a] (%b x))} => refine dfun/intro; [id, auto]]
+      [%a | %[a:jdg] => id]
+    }
   };
-  auto
-  // later on, I'll add special magic terms like 'goal', so that you can type "match goal" and it will
-  // do the appropriate thing in a proof script.
+  
+  use y
 ].
 
-Print Test.
+Print MatchGoal.

--- a/test/success/match.prl
+++ b/test/success/match.prl
@@ -2,7 +2,7 @@ Thm Test : [ bool ] by [
   // We can do second-order pattern matching on a term by providing a
   // sequence of match clauses. Pattern variables are bound behind the pipe,
   // and are written with a %-sigil. Think of these as if they were metavariables.
-  match (lam [x] ($ x tt)) {
+  match [(lam [x] ($ x tt)) : exp] {
     // in the first clause clause, we extract the body of the lambda expression "capturing" the variable.
     // in the second clause, we extract the first element of an application expression.
     [%a | (lam [x] (%a x)) => exact (%a (lam [x] x))]

--- a/test/success/match.prl
+++ b/test/success/match.prl
@@ -1,6 +1,10 @@
 Thm Test : [ bool ] by [
+  // We can do second-order pattern matching on a term by providing a
+  // sequence of match clauses. Pattern variables are bound behind the pipe,
+  // and are written with a %-sigil. Think of these as if they were metavariables.
   match (lam [x] ($ x tt))
-    [%a :> (lam [x] (%a x)) => `(%a (lam [x] x))]
+    [%a | (lam [x] (%a x)) => `(%a (lam [x] x)), // in this clause, we extract the body of the lambda expression "capturing" the variable
+     %a, %b | ($ %a %b) => `%a] // in this clause we extract the first element of an application expression
 ].
 
 Print Test.

--- a/test/success/match.prl
+++ b/test/success/match.prl
@@ -1,11 +1,17 @@
+Tac QueryGoalType(#t : [exp].tac) = [
+  query gl <- goal.
+  match [gl:jdg] {
+    [a | #jdg{%a true} => (#t %a)]
+  }
+].
+
 Thm MatchGoal : [ (-> bool bool bool bool bool bool) ] by [
   fresh x, y <- repeat {
-    query gl <- goal.
-    print [gl:jdg];
-    match [gl:jdg] {
-      [a, b | #jdg{(-> [x : %a] (%b x))} => refine dfun/intro; [id, auto]]
-      [a | %[a:jdg] => id]
-    }
+    (QueryGoalType [ty] #tac{
+      match ty {
+        [a, b | (-> [x:%a] (%b x)) => refine dfun/intro; [id, auto]]
+      }
+    })
   };
   
   use y

--- a/test/success/match.prl
+++ b/test/success/match.prl
@@ -5,8 +5,10 @@ Tac QueryGoalType(#t : [exp].tac) = [
   }
 ].
 
+// find hyp [a | x : %a => tac]
+
 Thm MatchGoal : [ (-> bool bool bool bool bool bool) ] by [
-  fresh x, y <- repeat {
+  fresh x, y -> repeat {
     (QueryGoalType [ty] #tac{
       match ty {
         [a, b | (-> [x:%a] (%b x)) => refine dfun/intro; [id, auto]]

--- a/test/success/match.prl
+++ b/test/success/match.prl
@@ -1,0 +1,6 @@
+Thm Test : [ bool ] by [
+  match (lam [x] ($ x tt))
+    [%a :> (lam [x] (%a x)) => `(%a (lam [x] x))]
+].
+
+Print Test.

--- a/test/success/match.prl
+++ b/test/success/match.prl
@@ -5,8 +5,6 @@ Tac QueryGoalType(#t : [exp].tac) = [
   }
 ].
 
-// find hyp [a | x : %a => tac]
-
 Thm MatchGoal : [ (-> bool bool bool bool bool bool) ] by [
   fresh x, y -> repeat {
     (QueryGoalType [ty] #tac{

--- a/test/success/num.prl
+++ b/test/success/num.prl
@@ -20,7 +20,7 @@ Thm Pred : [
   (-> nat nat)
 ] by [
   lam a.
-  fresh a', ind <- elim a;
+  fresh a', ind -> elim a;
   [ `zero ];
   [ use a' ]
 ].
@@ -50,7 +50,7 @@ Thm Plus : [
   (-> nat nat nat)
 ] by [
   lam a.
-  fresh a', ind <- elim a;
+  fresh a', ind -> elim a;
   [ `(lam [x] x)
   , `(lam [x] (succ ($ ,ind x)))
   ]

--- a/test/success/num.prl
+++ b/test/success/num.prl
@@ -33,17 +33,21 @@ Def Pred2 = [
 
 Extract Pred2.
 
-Tac NatRecEq(#a) = [
-  refine nat/eq/nat-rec;
-  [`#a];
-  auto
+// A tactic to infer and supply a simple (non-dependent) motive to the nat/eq/nat-rec rule.
+Tac SimpleNatRecEq = [
+  query gl <- goal.
+  match [gl:jdg] {
+    [n,z,s,ty | #jdg{(nat-rec %n %z [x y] (%s x y)) in %ty} => {
+      refine nat/eq/nat-rec; [`%ty]; auto
+    }]
+  }
 ].
 
 Thm Prod2Wf : [
   Pred2 in (-> nat nat)
 ] by [
   auto;
-  (NatRecEq nat)
+  SimpleNatRecEq
 ].
 
 Thm Plus : [
@@ -51,8 +55,8 @@ Thm Plus : [
 ] by [
   lam a.
   fresh a', ind -> elim a;
-  [ `(lam [x] x)
-  , `(lam [x] (succ ($ ,ind x)))
+  [ lam x. use x
+  , lam x. let ih/x = ind [use x]. `(succ ,ih/x)
   ]
 ].
 
@@ -69,8 +73,7 @@ Def Plus2 = [
 Thm Plus2Wf : [
   Plus2 in (-> nat nat nat)
 ] by [
-  auto;
-  (NatRecEq (-> nat nat))
+  auto; SimpleNatRecEq
 ].
 
 Thm Plus2UnitL : [

--- a/test/success/primitive-sequencing.prl
+++ b/test/success/primitive-sequencing.prl
@@ -1,5 +1,5 @@
 Thm PrimitiveSequencingTest : [(-> bool bool bool bool)] by [
-  fresh x,y,z <- auto;
+  fresh x,y,z -> auto;
   use y
 ].
 


### PR DESCRIPTION
I'm adding higher order pattern unification to the abt library, and i'm testing it out in RedPRL. Currently I have a tactical to do second-order pattern matching on a term.

I've also added a tactical `query gl <- goal. tac` which projects the conclusion of the current sequent, which in combination with the matching tactic enables something like `match goal`. Of course, this is not as powerful as Coq's goal matcher, because we have no way to inspect the hypotheses just yet. I would like to add that modularly through queries that target the left side of the current sequent.