### PR TITLE
make 'auto' only affect auxiliary / wf subgoals

### DIFF
--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -574,13 +574,6 @@ struct
       f jdg alpha jdg
   in
     local
-      fun StepTrue _ ty =
-        case Syn.out ty of
-           Syn.PATH_TY _ => Path.True
-         | Syn.DFUN _ => DFun.True
-         | Syn.RECORD _ => Record.True
-         | _ => raise E.error [Fpp.text "Could not find introduction rule for", TermPrinter.ppTerm ty]
-
       fun StepEqTypeVal (ty1, ty2) =
         case (Syn.out ty1, Syn.out ty2) of
            (Syn.BOOL, Syn.BOOL) => Bool.EqType
@@ -708,13 +701,13 @@ struct
          | _ => raise E.error [Fpp.text "Could not find suitable type synthesis rule for", TermPrinter.ppTerm m]
 
       fun StepJdg sign = matchGoal
-        (fn _ >> CJ.TRUE ty => StepTrue sign ty
-          | _ >> CJ.EQ_TYPE tys => StepEqType sign tys
+        (fn _ >> CJ.EQ_TYPE tys => StepEqType sign tys
           | _ >> CJ.EQ ((m, n), ty) => StepEq sign ((m, n), ty)
           | _ >> CJ.SYNTH m => StepSynth sign m
           | _ >> CJ.PARAM_SUBST _ => Misc.ParamSubst
           | MATCH _ => Misc.MatchOperator
-          | MATCH_RECORD _ => Record.MatchRecord orelse_ Computation.MatchRecordHeadExpansion sign then_ Record.MatchRecord)
+          | MATCH_RECORD _ => Record.MatchRecord orelse_ Computation.MatchRecordHeadExpansion sign then_ Record.MatchRecord
+          | _ >> jdg => raise E.error [Fpp.text "AutoStep does not apply to the judgment", CJ.pretty' TermPrinter.ppTerm jdg])
 
 
       fun isWfJdg (CJ.TRUE _) = false

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -32,7 +32,7 @@ Thm LowLevel2 : [
     (-> wbool wbool)
     wbool)
 ] by [
-  fresh f -> auto;
+  fresh f -> repeat {refine dfun/intro; [id, auto]};
   fresh x, x/eq -> elim f;
   [`tt, use x]
 ].

--- a/test/success/logical-investigations.prl
+++ b/test/success/logical-investigations.prl
@@ -40,7 +40,8 @@ Thm Thm3/low-level(#A; #B; #C) : [
       (-> #B #C)
       (-> #A #C))
 ] by [
-  fresh ab, bc, a -> auto;
+  fresh ab, bc, a -> repeat {refine dfun/intro || id};
+  auto;
   fresh c -> elim bc;
   [fresh b -> elim ab; [use a, use b], use c]
 ].

--- a/test/success/primitive-sequencing.prl
+++ b/test/success/primitive-sequencing.prl
@@ -1,5 +1,5 @@
 Thm PrimitiveSequencingTest : [(-> bool bool bool bool)] by [
-  fresh x,y,z -> repeat {refine dfun/intro; [id, auto]};
+  fresh x,y,z -> repeat {refine dfun/intro || id}; auto;
   use y
 ].
 

--- a/test/success/primitive-sequencing.prl
+++ b/test/success/primitive-sequencing.prl
@@ -1,5 +1,5 @@
 Thm PrimitiveSequencingTest : [(-> bool bool bool bool)] by [
-  fresh x,y,z -> auto;
+  fresh x,y,z -> repeat {refine dfun/intro; [id, auto]};
   use y
 ].
 


### PR DESCRIPTION
It's basically never desirable for `auto` to perform introduction rules, etc. I want to reserve `auto` for undertaking "typechecking" tasks automatically.