### PR TITLE
Polytypes, stage 2.

### DIFF
--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -142,9 +142,9 @@ struct
       val leq : t * t -> bool
       val meet : t * t -> t
 
-      (* greatestMeetRight (a, b) is the greatest element c
+      (* greatestMeetComplement (a, b) is the greatest element c
        * such that meet (b, c) <= a *)
-      val greatestMeetRight : t * t -> t
+      val greatestMeetComplement : t * t -> t
     end
     =
     struct
@@ -169,7 +169,7 @@ struct
 
          | (CUBICAL, CUBICAL) => CUBICAL
 
-      val greatestMeetRight =
+      val greatestMeetComplement =
         fn (_, DISCRETE) => top
          | (DISCRETE, _) => DISCRETE
          | (_, KAN) => top
@@ -182,14 +182,14 @@ struct
          | (COE, _) => COE
          | (CUBICAL, CUBICAL) => top
 
-      fun leq (a, b) = greatestMeetRight (b, a) = top
+      fun leq (a, b) = greatestMeetComplement (b, a) = top
     end
   in
     open Internal
   end
 
-  fun greatestMeetRight' (a, b) =
-    let val gmr = greatestMeetRight (a, b)
+  fun greatestMeetComplement' (a, b) =
+    let val gmr = greatestMeetComplement (a, b)
     in if gmr = top then NONE else SOME gmr
     end
 end

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -154,19 +154,14 @@ struct
       val meet =
         fn (DISCRETE, _) => DISCRETE
          | (_, DISCRETE) => DISCRETE
-
          | (KAN, _) => KAN
          | (_, KAN) => KAN
-
          | (HCOM, COE) => KAN
          | (COE, HCOM) => KAN
-
          | (HCOM, _) => HCOM
          | (_, HCOM) => HCOM
-
          | (COE, _) => COE
          | (_, COE) => COE
-
          | (CUBICAL, CUBICAL) => CUBICAL
 
       val greatestMeetComplement =
@@ -176,9 +171,11 @@ struct
          | (KAN, HCOM) => COE
          | (KAN, COE) => HCOM
          | (KAN, _) => KAN
-         | (HCOM, HCOM) => top
+         | (COE, HCOM) => COE
+         | (HCOM, COE) => HCOM
+         | (_, HCOM) => top
          | (HCOM, _) => HCOM
-         | (COE, COE) => top
+         | (_, COE) => top
          | (COE, _) => COE
          | (CUBICAL, CUBICAL) => top
 

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -109,7 +109,7 @@ struct
         val _ = Assert.alphaEq (a0, a1)
         val _ = Assert.alphaEq (b0, b1)
         val goal =
-          case K.greatestMeetRight' (k0, k1) of
+          case K.greatestMeetComplement' (k0, k1) of
             NONE => NONE
           | SOME k'' => SOME @@ makeEqType (I, H) ((a0, b0), k'')
       in
@@ -124,7 +124,7 @@ struct
         val _ = Assert.alphaEq (a0, b0)
         val _ = Assert.alphaEq (a0, a1)
         val goal =
-          case K.greatestMeetRight' (k0, k1) of
+          case K.greatestMeetComplement' (k0, k1) of
             NONE => NONE
           | SOME k'' => SOME @@ makeEqType (I, H) ((a0, b0), k'')
       in
@@ -139,7 +139,7 @@ struct
         val _ = Assert.alphaEq (a0, b0)
         val _ = Assert.alphaEq (a0, a1)
         val goal =
-          case K.greatestMeetRight' (k0, k1) of
+          case K.greatestMeetComplement' (k0, k1) of
             NONE => NONE
           | SOME k'' => SOME @@ makeEqType (I, H) ((a0, b0), k'')
       in
@@ -345,7 +345,7 @@ struct
         val _ = Assert.alphaEq (n0, n1)
         val _ = Assert.alphaEq (a0, a1)
         val goal =
-          case K.greatestMeetRight' (k0, k1) of
+          case K.greatestMeetComplement' (k0, k1) of
             NONE => NONE
           | SOME k'' => SOME @@ makeEq (I, H) ((m0, n0), (a0, k''))
       in
@@ -757,13 +757,13 @@ struct
           val isUseful =
             fn CJ.EQ_TYPE ((a1, b1), k1) =>
                  Abt.eq (a0, a1) andalso Abt.eq (b0, b1)
-                 andalso K.greatestMeetRight' (k0, k1) <> SOME k0
+                 andalso K.greatestMeetComplement' (k0, k1) <> SOME k0
              | CJ.EQ (_, (a1, k1)) =>
                  isUnary andalso Abt.eq (a0, a1)
-                 andalso K.greatestMeetRight' (k0, k1) <> SOME k0
+                 andalso K.greatestMeetComplement' (k0, k1) <> SOME k0
              | CJ.TRUE (a1, k1) =>
                  isUnary andalso Abt.eq (a0, a1)
-                 andalso K.greatestMeetRight' (k0, k1) <> SOME k0
+                 andalso K.greatestMeetComplement' (k0, k1) <> SOME k0
              | _ => false
         in
           case Hyps.search H isUseful of
@@ -781,7 +781,7 @@ struct
           val isUseful =
             fn CJ.EQ ((m1, n1), (a1, k1)) =>
                 Abt.eq (m0, m1) andalso Abt.eq (n0, n1) andalso Abt.eq (a0, a1)
-                andalso K.greatestMeetRight' (k0, k1) <> SOME k0
+                andalso K.greatestMeetComplement' (k0, k1) <> SOME k0
              | _ => false
         in
           case Hyps.search H isUseful of

--- a/src/redprl/refiner_kit.fun
+++ b/src/redprl/refiner_kit.fun
@@ -178,7 +178,7 @@ struct
     else makeEqTypeIfDifferent (I, H) ((m, n), k)
 
   fun makeTypeIfLess (I, H) (m, k) k' =
-    case K.greatestMeetRight' (k, k') of
+    case K.greatestMeetComplement' (k, k') of
       NONE => NONE
     | SOME k'' => SOME @@ makeType (I, H) (m, k'')
 
@@ -195,7 +195,7 @@ struct
     else makeEqIfDifferent (I, H) ((m, n), (ty, k))
 
   fun makeMemIfLess (I, H) (m, (ty, k)) k' =
-    case K.greatestMeetRight' (k, k') of
+    case K.greatestMeetComplement' (k, k') of
       NONE => NONE
     | SOME k'' => SOME @@ makeMem (I, H) (m, (ty, k''))
 

--- a/test/success/kinds.prl
+++ b/test/success/kinds.prl
@@ -1,0 +1,45 @@
+Thm Kind0(#A) : [
+  #A hcom type,
+  >> #A type
+] by [ auto ].
+
+Thm Kind1(#A) : [
+  #A type,
+  >> #A type
+] by [ auto ].
+
+Thm Kind2(#A) : [
+  #A cubical type,
+  >> #A type
+] by [ auto ].
+
+Thm Kind3(#A) : [
+  #A type,
+  >> #A cubical type
+] by [ auto ].
+
+Thm Kind4(#A) : [
+  x : #A hcom type,
+  y : #A coe type
+  >> #A kan type
+] by [ auto ].
+
+Thm Kind5(#A) : [
+  #A discrete type,
+  >> #A kan type
+] by [ auto ].
+
+Thm Kind6(#A) : [
+  #A kan type,
+  >> #A kan type
+] by [ auto ].
+
+Thm Kind7(#A) : [
+  #A discrete type,
+  >> #A hcom type
+] by [ auto ].
+
+Thm Kind8(#A) : [
+  #A discrete type,
+  >> #A coe type
+] by [ auto ].


### PR DESCRIPTION
Continuation of #284 and #315.

- [ ] Enhance the tactic `use` to handle kind mismatch better.
- [ ] Wait for `Lcf.allSeqAfter` or something like that, and then remove those extra `auto`.

The above list is left for stage 3.