### PR TITLE
Refactor categorical judgments and sequents.

### DIFF
--- a/src/redprl.cm
+++ b/src/redprl.cm
@@ -51,7 +51,7 @@ is
   redprl/sequent.sig
   redprl/sequent.sml
 
-  redprl/judgment.fun
+  redprl/judgment.sml
 
   redprl/elab_monad.sig
   redprl/elab_monad.sml

--- a/src/redprl.mlb
+++ b/src/redprl.mlb
@@ -40,7 +40,7 @@ in
     redprl/sequent.sig
     redprl/sequent.sml
 
-    redprl/judgment.fun
+    redprl/judgment.sml
 
     redprl/elab_monad.sig
     redprl/elab_monad.sml

--- a/src/redprl/categorical_judgment.sig
+++ b/src/redprl/categorical_judgment.sig
@@ -66,7 +66,6 @@ sig
   val synthesis : jdg -> RedPrlAbt.sort
   val into : jdg -> RedPrlAbt.abt
   val out : RedPrlAbt.abt -> jdg
-  val metactx : jdg -> RedPrlAbt.metactx
   val eq : jdg * jdg -> bool
   val pretty : jdg -> Fpp.doc
 

--- a/src/redprl/categorical_judgment.sig
+++ b/src/redprl/categorical_judgment.sig
@@ -1,24 +1,76 @@
+structure RedPrlCategoricalJudgmentData =
+struct
+  type kind = RedPrlKind.t
+
+  datatype ('sym, 'a) jdg' =
+
+   (* `EQ ((m, n), (a, k))`:
+    *   `EQ_TYPE ((a, a), k)` and `m` and `n` are related by the PER associated with `a`.
+    *   The realizer is `TV` of sort `TRIV`.
+    *)
+     EQ of ('a * 'a) * ('a * kind)
+
+   (* `TRUE (a, k)`:
+    *   `EQ_TYPE ((a, a), k)` and there exists a term `m` such that
+    *   `EQ ((m, m), (a, k))` is provable.
+    *   The realizer is such an `m` of sort `EXP`.
+    *)
+   | TRUE of 'a * kind
+
+   (* `EQ_TYPE ((a, b), k)`:
+    *   `a` and `b` are equal types, taking into account the additional
+    *   structures specified by `k`. For example, `EQ_TYPE ((a, b), KAN)`
+    *   means they are equally Kan, in addition to being equal pretypes.
+    *   The realizer is `TV` of sort `TRIV`.
+    *)
+   | EQ_TYPE of ('a * 'a) * kind
+
+   (* `TERM tau`:
+    *   There exists some `m` of sort `tau`.
+    *   The realizer is such an `m` of sort `tau`.
+    *)
+   | SYNTH of 'a * kind
+
+   (* `TERM tau`:
+    *   There exists some `m` of sort `tau`.
+    *   The realizer is such an `m` of sort `tau`.
+    *)
+   | TERM of RedPrlSort.t
+
+   (* `PARAM_SUBST (l, m, s)`:
+    *   `l` is a list of elements of shape `(pe, ps, r)`, representing a
+    *   parameter substitution, where `pe` will (eventually) be `PARAM_EXP p`
+    *   for some parameter term `p`, `r` is a parameter variable and `ps` is
+    *   the sort of `p` and `r`. `m` is an expression of sort `s`.
+    *   The realizer is the result of applying the substitution `l` to `m`.
+    *)
+   | PARAM_SUBST of ('a * RedPrlParamSort.t * 'sym) list * 'a * RedPrlSort.t
+end
+
 signature CATEGORICAL_JUDGMENT =
 sig
-  type ('sym, 'a) jdg
+  datatype jdg' = datatype RedPrlCategoricalJudgmentData.jdg'
+  val MEM : 'a * ('a * RedPrlKind.t) -> ('sym, 'a) jdg'
+  val TYPE : 'a * RedPrlKind.t -> ('sym, 'a) jdg'
 
-  val map : ('sym1 -> 'sym2) -> ('a -> 'b) -> ('sym1, 'a) jdg -> ('sym2, 'b) jdg
-  val map_ : ('a -> 'b) -> ('sym, 'a) jdg -> ('sym, 'b) jdg
+  val map' : ('sym1 -> 'sym2) -> ('term1 -> 'term2)
+    -> ('sym1, 'term1) jdg' -> ('sym2, 'term2) jdg'
+  val map : ('term1 -> 'term2) -> ('sym, 'term1) jdg' -> ('sym, 'term2) jdg'
 
-  structure Tm : ABT
-  type abt = Tm.abt
-  type sort = Tm.sort
+  (* Pretty printer *)
+  val pretty' : ('sym -> Fpp.doc) -> ('term -> Fpp.doc) -> ('term * 'term -> bool)
+    -> ('sym, 'term) jdg' -> Fpp.doc
 
-  (* What sort of term does the jdg synthesize? *)
-  val synthesis : ('sym, 'a) jdg -> sort
+  (* Functions for abt *)
+  type jdg = (Sym.t, RedPrlAbt.abt) jdg'
+  val synthesis : jdg -> RedPrlAbt.sort
+  val into : jdg -> RedPrlAbt.abt
+  val out : RedPrlAbt.abt -> jdg
+  val metactx : jdg -> RedPrlAbt.metactx
+  val eq : jdg * jdg -> bool
+  val pretty : jdg -> Fpp.doc
 
-  val toAbt : (Sym.t, abt) jdg -> abt
-  val fromAbt : abt -> (Sym.t, abt) jdg
-
-  val metactx : (Sym.t, abt) jdg -> Tm.metactx
-
-  val eq : (Sym.t, abt) jdg * (Sym.t, abt) jdg -> bool
-
-  val pretty : ('a * 'a -> bool) -> ('a -> Fpp.doc) -> (Sym.t, 'a) jdg -> Fpp.doc
-  val pretty' : ('a -> Fpp.doc) -> (Sym.t, 'a) jdg -> Fpp.doc
+  (* Functions for ast *)
+  type astjdg = (string, RedPrlAst.ast) jdg'
+  val astOut : RedPrlAst.ast -> astjdg
 end

--- a/src/redprl/categorical_judgment.sml
+++ b/src/redprl/categorical_judgment.sml
@@ -95,7 +95,6 @@ struct
          end
        | _ => raise RedPrlError.error [Fpp.text "Invalid judgment:", TermPrinter.ppTerm jdg]
 
-    val metactx = metactx o into
     val pretty : jdg -> Fpp.doc = pretty' TermPrinter.ppSym TermPrinter.ppTerm eq
     val eq = fn (j1, j2) => eq (into j1, into j2)
   end

--- a/src/redprl/categorical_judgment.sml
+++ b/src/redprl/categorical_judgment.sml
@@ -1,68 +1,6 @@
-structure RedPrlCategoricalJudgment :
-sig
-  type kind = RedPrlKind.t
-
-  datatype ('sym, 'a) redprl_jdg =
-
-   (* `EQ ((m, n), (a, k))`:
-    *   `EQ_TYPE ((a, a), k)` and `m` and `n` are related by the PER associated with `a`.
-    *   The realizer is `TV` of sort `TRIV`.
-    *)
-     EQ of ('a * 'a) * ('a * kind)
-
-   (* `TRUE (a, k)`:
-    *   `EQ_TYPE ((a, a), k)` and there exists a term `m` such that
-    *   `EQ ((m, m), (a, k))` is provable.
-    *   The realizer is such an `m` of sort `EXP`.
-    *)
-   | TRUE of 'a * kind
-
-   (* `EQ_TYPE ((a, b), k)`:
-    *   `a` and `b` are equal types, taking into account the additional
-    *   structures specified by `k`. For example, `EQ_TYPE ((a, b), KAN)`
-    *   means they are equally Kan, in addition to being equal pretypes.
-    *   The realizer is `TV` of sort `TRIV`.
-    *)
-   | EQ_TYPE of ('a * 'a) * kind
-
-   (* `TERM tau`:
-    *   There exists some `m` of sort `tau`.
-    *   The realizer is such an `m` of sort `tau`.
-    *)
-   | SYNTH of 'a * kind
-
-   (* `TERM tau`:
-    *   There exists some `m` of sort `tau`.
-    *   The realizer is such an `m` of sort `tau`.
-    *)
-   | TERM of RedPrlSort.t
-
-   (* `PARAM_SUBST (l, m, s)`:
-    *   `l` is a list of elements of shape `(pe, ps, r)`, representing a
-    *   parameter substitution, where `pe` will (eventually) be `PARAM_EXP p`
-    *   for some parameter term `p`, `r` is a parameter variable and `ps` is
-    *   the sort of `p` and `r`. `m` is an expression of sort `s`.
-    *   The realizer is the result of applying the substitution `l` to `m`.
-    *)
-   | PARAM_SUBST of ('a * RedPrlParamSort.t * 'sym) list * 'a * RedPrlSort.t
-
-  val MEM : 'a * ('a * kind) -> ('sym, 'a) redprl_jdg
-  val TYPE : 'a * kind -> ('sym, 'a) redprl_jdg
-
-  val fromAst : RedPrlAst.ast -> (string, RedPrlAst.ast) redprl_jdg
-
-  include CATEGORICAL_JUDGMENT where type ('sym, 'a) jdg = ('sym, 'a) redprl_jdg
-end =
+structure RedPrlCategoricalJudgment : CATEGORICAL_JUDGMENT =
 struct
-  type kind = RedPrlKind.t
-
-  datatype ('sym, 'a) redprl_jdg =
-     EQ of ('a * 'a) * ('a * kind)
-   | TRUE of 'a * kind
-   | EQ_TYPE of ('a * 'a) * kind
-   | SYNTH of 'a * kind
-   | TERM of RedPrlSort.t
-   | PARAM_SUBST of ('a * RedPrlParamSort.t * 'sym) list * 'a * RedPrlSort.t
+  open RedPrlCategoricalJudgmentData
 
   fun MEM (m, (a, k)) =
     EQ ((m, m), (a, k))
@@ -70,21 +8,46 @@ struct
   fun TYPE (a, k) =
     EQ_TYPE ((a, a), k)
 
-  type ('sym, 'a) jdg = ('sym, 'a) redprl_jdg
-
-  fun map sym f =
-    fn EQ ((m, n), (a, k)) => EQ ((f m, f n), (f a, k))
-     | TRUE (a, k) => TRUE (f a, k)
-     | EQ_TYPE ((a, b), k) => EQ_TYPE ((f a, f b), k)
-     | SYNTH (a, k) => SYNTH (f a, k)
+  fun map' f g =
+    fn EQ ((m, n), (a, k)) => EQ ((g m, g n), (g a, k))
+     | TRUE (a, k) => TRUE (g a, k)
+     | EQ_TYPE ((a, b), k) => EQ_TYPE ((g a, g b), k)
+     | SYNTH (a, k) => SYNTH (g a, k)
      | TERM tau => TERM tau
-     | PARAM_SUBST (psi, m, tau) => PARAM_SUBST (List.map (fn (r, sigma, u) => (f r, sigma, sym u)) psi, f m, tau) 
+     | PARAM_SUBST (psi, m, tau) => PARAM_SUBST
+         (List.map (fn (r, sigma, u) => (g r, sigma, f u)) psi, g m, tau)
   
-  fun map_ f = map (fn x => x) f
+  fun map f = map' (fn x => x) f
+
+  fun @@ (f, x) = f x
+  infixr @@
+
+  fun pretty' _ g eq =
+    fn EQ ((m, n), (a, k)) => Fpp.expr @@ Fpp.hvsep @@ List.concat
+         [ if eq (m, n) then [g m] else [g m, Fpp.Atomic.equals, g n]
+         , [Fpp.hsep [Fpp.text "in", g a]]
+         , if k = RedPrlKind.top then [] else [Fpp.hsep [Fpp.text "with", TermPrinter.ppKind k]]
+         ]
+     | TRUE (a, k) => Fpp.expr @@ Fpp.hvsep @@ List.concat
+         [ [g a]
+         , if k = RedPrlKind.top then []
+           else [Fpp.hsep [Fpp.hsep [Fpp.text "with", TermPrinter.ppKind k]]]
+         ]
+     | EQ_TYPE ((a, b), k) => Fpp.expr @@ Fpp.hvsep @@ List.concat
+         [ if eq (a, b) then [g a] else [g a, Fpp.Atomic.equals, g b]
+         , if k = RedPrlKind.top
+           then [Fpp.hsep [Fpp.text "type"]]
+           else [Fpp.hsep [TermPrinter.ppKind k, Fpp.text "type"]]
+         ]
+     | SYNTH (m, k) => Fpp.expr @@ Fpp.hvsep @@ List.concat
+         [ [g m, Fpp.text "synth"]
+         , if k = RedPrlKind.top then []
+           else [Fpp.hsep [Fpp.hsep [Fpp.text "with", TermPrinter.ppKind k]]]
+         ]
+     | TERM tau => TermPrinter.ppSort tau
+     | PARAM_SUBST _ => Fpp.text "param-subst" (* TODO *)
 
   structure O = RedPrlOpData
-  structure Tm = RedPrlAbt
-  structure Ast = RedPrlAst
 
   val synthesis =
     fn EQ _ => O.TRIV
@@ -95,14 +58,13 @@ struct
      | PARAM_SUBST (_, _, tau) => tau
 
   local
-    open Tm
+    open RedPrlAbt
     structure O = RedPrlOpData
     infix $ $$ \
   in
-    type abt = abt
-    type sort = sort
+    type jdg = (Sym.t, abt) jdg'
 
-    val toAbt : (Sym.t, abt) jdg -> abt =
+    val into : jdg -> abt =
       fn EQ ((m, n), (a, k)) => O.MONO (O.JDG_EQ k) $$ [([],[]) \ m, ([],[]) \ n, ([],[]) \ a]
        | TRUE (a, k) => O.MONO (O.JDG_TRUE k) $$ [([],[]) \ a]
        | EQ_TYPE ((a, b), k) => O.MONO (O.JDG_EQ_TYPE k) $$ [([],[]) \ a, ([],[]) \ b]
@@ -116,7 +78,7 @@ struct
            O.MONO (O.JDG_PARAM_SUBST (sigmas, tau)) $$ List.map (fn r => ([],[]) \ r) rs @ [(us,[]) \ m]
          end
 
-    fun fromAbt jdg =
+    fun out jdg =
       case RedPrlAbt.out jdg of
          O.MONO (O.JDG_EQ k) $ [_ \ m, _ \ n, _ \ a] => EQ ((m, n), (a, k))
        | O.MONO (O.JDG_TRUE k) $ [_ \ a] => TRUE (a, k)
@@ -125,22 +87,28 @@ struct
        | O.MONO (O.JDG_TERM tau) $ [] => TERM tau
        | O.MONO (O.JDG_PARAM_SUBST (sigmas, tau)) $ args =>
          let
-           val ((us, _) \ m) :: args' = List.rev args
-           val rs = List.rev (List.map (fn _ \ r => r) args')
-           val psi = List.map (fn ((r, sigma), u) => (r, sigma, u)) (ListPair.zipEq (ListPair.zipEq (rs, sigmas), us))
+           val (us , _) \ m = List.last args
+           val rs = List.map (fn _ \ r => r) (ListUtil.init args)
+           val psi = ListPair.mapEq (fn ((r, sigma), u) => (r, sigma, u)) (ListPair.zipEq (rs, sigmas), us)
          in
            PARAM_SUBST (psi, m, tau)
          end
        | _ => raise RedPrlError.error [Fpp.text "Invalid judgment:", TermPrinter.ppTerm jdg]
+
+    val metactx = metactx o into
+    val pretty : jdg -> Fpp.doc = pretty' TermPrinter.ppSym TermPrinter.ppTerm eq
+    val eq = fn (j1, j2) => eq (into j1, into j2)
   end
 
   local
-    open Ast
+    open RedPrlAst
     structure O = RedPrlOpData
     infix $ \
   in
-    fun fromAst jdg =
-      case Ast.out jdg of
+    type astjdg = (string, ast) jdg'
+
+    fun astOut jdg =
+      case RedPrlAst.out jdg of
          O.MONO (O.JDG_EQ k) $ [_ \ m, _ \ n, _ \ a] => EQ ((m, n), (a, k))
        | O.MONO (O.JDG_TRUE k) $ [_ \ a] => TRUE (a, k)
        | O.MONO (O.JDG_EQ_TYPE k) $ [_ \ m, _ \ n] => EQ_TYPE ((m, n), k)
@@ -148,46 +116,12 @@ struct
        | O.MONO (O.JDG_TERM tau) $ [] => TERM tau
        | O.MONO (O.JDG_PARAM_SUBST (sigmas, tau)) $ args =>
          let
-           val ((us, _) \ m) :: args' = List.rev args
-           val rs = List.rev (List.map (fn _ \ r => r) args')
-           val psi = List.map (fn ((r, sigma), u) => (r, sigma, u)) (ListPair.zipEq (ListPair.zipEq (rs, sigmas), us))
+           val (us , _) \ m = List.last args
+           val rs = List.map (fn _ \ r => r) (ListUtil.init args)
+           val psi = ListPair.mapEq (fn ((r, sigma), u) => (r, sigma, u)) (ListPair.zipEq (rs, sigmas), us)
          in
            PARAM_SUBST (psi, m, tau)
          end
        | _ => raise RedPrlError.error [Fpp.text "Invalid judgment"]
   end
-
-  val metactx = RedPrlAbt.metactx o toAbt
-
-  fun @@ (f, x) = f x
-  infixr @@
-
-  fun pretty eq f =
-    fn EQ ((m, n), (a, k)) => Fpp.expr @@ Fpp.hvsep @@ List.concat
-         [ if eq (m, n) then [f m] else [f m, Fpp.Atomic.equals, f n]
-         , [Fpp.hsep [Fpp.text "in", f a]]
-         , if k = RedPrlKind.top then [] else [Fpp.hsep [Fpp.text "with", TermPrinter.ppKind k]]
-         ]
-     | TRUE (a, k) => Fpp.expr @@ Fpp.hvsep @@ List.concat
-         [ [f a]
-         , if k = RedPrlKind.top then []
-           else [Fpp.hsep [Fpp.hsep [Fpp.text "with", TermPrinter.ppKind k]]]
-         ]
-     | EQ_TYPE ((a, b), k) => Fpp.expr @@ Fpp.hvsep @@ List.concat
-         [ if eq (a, b) then [f a] else [f a, Fpp.Atomic.equals, f b]
-         , if k = RedPrlKind.top
-           then [Fpp.hsep [Fpp.text "type"]]
-           else [Fpp.hsep [TermPrinter.ppKind k, Fpp.text "type"]]
-         ]
-     | SYNTH (m, k) => Fpp.expr @@ Fpp.hvsep @@ List.concat
-         [ [f m, Fpp.text "synth"]
-         , if k = RedPrlKind.top then []
-           else [Fpp.hsep [Fpp.hsep [Fpp.text "with", TermPrinter.ppKind k]]]
-         ]
-     | TERM tau => TermPrinter.ppSort tau
-     | PARAM_SUBST _ => Fpp.text "param-subst" (* TODO *)
-  fun pretty' f = pretty (fn _ => false) f
-
-  fun eq (j1, j2) =
-    RedPrlAbt.eq (toAbt j1, toAbt j2)
 end

--- a/src/redprl/error.sml
+++ b/src/redprl/error.sml
@@ -15,7 +15,6 @@ struct
   fun annotateException' (SOME pos) thunk = annotateException pos thunk
     | annotateException' NONE thunk = thunk ()
 
-  structure TP = TermPrinter
   val formatError =
     fn INVALID_CATEGORICAL_JUDGMENT doc => Fpp.hvsep
         [Fpp.text "Not a valid categorical judgment:", Fpp.align doc]

--- a/src/redprl/judgment.sml
+++ b/src/redprl/judgment.sml
@@ -12,7 +12,6 @@ struct
   val ren = S.map o Tm.renameMetavars
 
   val eq = S.eq
-  val toString = FppRenderPlainText.toString o FinalPrinter.execPP o S.pretty
 
   local
     open S
@@ -29,6 +28,6 @@ struct
            in
              (([],[]), tau)
            end
-       | MATCH_RECORD (lbl, _) => (([],[]), RedPrlSortData.EXP)
+       | MATCH_RECORD _ => (([],[]), RedPrlSortData.EXP)
   end
 end

--- a/src/redprl/judgment.sml
+++ b/src/redprl/judgment.sml
@@ -1,19 +1,18 @@
-functor SequentJudgment
-  (structure S : SEQUENT where type CJ.Tm.Sym.t = Sym.t and type CJ.Tm.Var.t = Sym.t and type CJ.Tm.O.Ar.Vl.S.t = RedPrlSort.t
-   structure TermPrinter : sig type t = S.CJ.Tm.abt val ppTerm : t -> Fpp.doc end) : LCF_JUDGMENT  =
+structure RedPrlJudgment : LCF_JUDGMENT  =
 struct
-  structure CJ = S.CJ
-  structure Tm = CJ.Tm
+  structure CJ = RedPrlCategoricalJudgment
+  structure S = struct open RedPrlSequentData RedPrlSequent end
+  structure Tm = RedPrlAbt
   type sort = Tm.valence
   type env = Tm.metaenv
   type ren = Tm.metavariable Tm.Metavar.Ctx.dict
-  type jdg = Tm.abt S.jdg
+  type jdg = S.jdg
 
   val subst = S.map o Tm.substMetaenv
   val ren = S.map o Tm.renameMetavars
 
   val eq = S.eq
-  val toString = FppRenderPlainText.toString o FinalPrinter.execPP o S.pretty Tm.eq TermPrinter.ppTerm
+  val toString = FppRenderPlainText.toString o FinalPrinter.execPP o S.pretty
 
   local
     open S
@@ -33,6 +32,3 @@ struct
        | MATCH_RECORD (lbl, _) => (([],[]), RedPrlSortData.EXP)
   end
 end
-
-structure RedPrlSequent = Sequent (structure CJ = RedPrlCategoricalJudgment)
-structure RedPrlJudgment = SequentJudgment (structure S = RedPrlSequent and TermPrinter = TermPrinter)

--- a/src/redprl/lcf.sml
+++ b/src/redprl/lcf.sml
@@ -22,7 +22,7 @@ struct
     Fpp.nest 2 @@
       Fpp.vsep
         [Fpp.seq [Fpp.hsep [Fpp.text "Goal", TermPrinter.ppMeta x], Fpp.text "."],
-         RedPrlSequent.pretty RedPrlAbt.eq TermPrinter.ppTerm jdg]
+         RedPrlSequent.pretty jdg]
 
   val prettyGoals : jdg Tl.telescope -> {doc : Fpp.doc, ren : J.ren, idx : int} =
     let

--- a/src/redprl/lcf.sml
+++ b/src/redprl/lcf.sml
@@ -35,7 +35,7 @@ struct
             val jdg' = J.ren ren jdg
             val ren' = Metavar.Ctx.insert ren x x'
           in
-            {doc = Fpp.seq [doc, prettyGoal (x, jdg), Fpp.newline],
+            {doc = Fpp.seq [doc, prettyGoal (x, jdg'), Fpp.newline],
              ren = ren',
              idx = idx + 1}
           end)

--- a/src/redprl/listutil.sml
+++ b/src/redprl/listutil.sml
@@ -22,12 +22,20 @@ struct
 
   (* From MLton: https://github.com/MLton/mlton/blob/master/lib/mlton/basic/list.sml *)
   fun splitAt (xs, i) = 
-   let
+    let
       val rec loop = 
         fn (0, acc, xs) => (rev acc, xs)
          | (_, _, []) => raise Fail "ListUtil.splitAt"
          | (i, acc, x::xs) => loop (i - 1, x :: acc, xs)
-   in
+    in
       loop (i, [], xs)
-   end
+    end
+
+  local
+    fun init' l [] = raise List.Empty
+      | init' l [_] = List.rev l
+      | init' l (x :: xs) = init' (x :: l) xs
+  in
+    fun init l = init' [] l
+  end
 end

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -286,7 +286,6 @@ struct
    | JDG_TERM of sort
    | JDG_PARAM_SUBST of RedPrlParamSort.t list * sort
 
-  type psort = RedPrlArity.Vl.PS.t
   type 'a equation = 'a P.term * 'a P.term
   type 'a dir = 'a P.term * 'a P.term
 

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -18,8 +18,6 @@ structure CJ = RedPrlCategoricalJudgment
 
 structure TP = TermPrinter
 
-fun sortOfJudgment jdg = CJ.synthesis (CJ.fromAst jdg)
-
 fun makeCustom (opid, params, bindings) =
   Ast.$$ (O.POLY (O.CUST (opid, params, NONE)), bindings)
 
@@ -783,7 +781,7 @@ rawJudgment
 
 judgment : rawJudgment (annotate (Pos.pos (rawJudgment1left fileName) (rawJudgment1right fileName)) rawJudgment)
 
-src_catjdg : rawJudgment (CJ.fromAst rawJudgment)
+src_catjdg : rawJudgment (CJ.astOut rawJudgment)
 
 src_seqhyp
   : VARNAME COLON src_catjdg ((VARNAME, src_catjdg))

--- a/src/redprl/refiner_composition_kit.fun
+++ b/src/redprl/refiner_composition_kit.fun
@@ -5,7 +5,7 @@ struct
 
   type sign = Sig.sign
   type rule = (int -> Sym.t) -> Lcf.jdg Lcf.tactic
-  type catjdg = (Sym.t, abt) CJ.jdg
+  type catjdg = CJ.jdg
   type opid = Sig.opid
 
   infixr @@
@@ -32,7 +32,7 @@ struct
     (* Restrict a judgement (as the goal) by a list of equations.
      * Returns NONE if the resulting judgement is vacuously true.
      *)
-    val restrict : abt jdg -> (param * param) list -> abt jdg option
+    val restrict : jdg -> (param * param) list -> jdg option
   end
   =
   struct

--- a/src/redprl/refiner_types.fun
+++ b/src/redprl/refiner_types.fun
@@ -493,12 +493,12 @@ struct
 
         (* (negsucc succ) branch *)
         val cnegsuccu = Abt.substVar (negsucc @@ VarKit.toExp u, z) holeC
-        val r0 = VarKit.renameMany [(u, a0), (v, b0)] r0
-        val r1 = VarKit.renameMany [(u, a1), (v, b1)] r1
+        val r0 = VarKit.renameMany [(u, c0), (v, d0)] r0
+        val r1 = VarKit.renameMany [(u, c1), (v, d1)] r1
         val goalNSS =
           makeEq
             (I, H @> (u, CJ.TRUE (nat, inherentKind)) @> (v, CJ.TRUE (cnegsuccu, k)))
-            ((p0, p1), (substVar (negsucc @@ succ @@ VarKit.toExp u, z) holeC, K.top))
+            ((r0, r1), (substVar (negsucc @@ succ @@ VarKit.toExp u, z) holeC, K.top))
       in
         |>: goalC >: goalM >: goalZ >: goalS >: goalNSZ >: goalNSS >: goalC' >:? goalTy #> (I, H, trivial)
       end

--- a/src/redprl/refiner_types.fun
+++ b/src/redprl/refiner_types.fun
@@ -7,7 +7,7 @@ struct
 
   type sign = Sig.sign
   type rule = (int -> Sym.t) -> Lcf.jdg Lcf.tactic
-  type catjdg = (Sym.t, abt) CJ.jdg
+  type catjdg = CJ.jdg
   type opid = Sig.opid
 
   infixr @@
@@ -81,12 +81,12 @@ struct
         (* tt branch *)
         val tt = Syn.into Syn.TT
         val Htt = Hyps.substAfter (z, tt) H
-        val (goalT, holeT) = makeGoal @@ (I, Htt) >> CJ.map_ (substVar (tt, z)) catjdg
+        val (goalT, holeT) = makeGoal @@ (I, Htt) >> CJ.map (substVar (tt, z)) catjdg
 
         (* ff branch *)
         val ff = Syn.into Syn.FF
         val Hff = Hyps.substAfter (z, ff) H
-        val (goalF, holeF) = makeGoal @@ (I, Hff) >> CJ.map_ (substVar (ff, z)) catjdg
+        val (goalF, holeF) = makeGoal @@ (I, Hff) >> CJ.map (substVar (ff, z)) catjdg
 
         val evidence =
           case catjdg of
@@ -1229,7 +1229,7 @@ struct
         val (goal, hole) =
           makeGoal
             @@ (I, Hyps.interposeThenSubstAfter (z, |@> (u, CJ.EQ ((m, n), (a, K.top))), ax) H)
-            >> CJ.map_ (substVar (ax, z)) catjdg
+            >> CJ.map (substVar (ax, z)) catjdg
       in
         |>: goal #> (I, H, VarKit.subst (trivial, u) hole)
       end

--- a/src/redprl/sequent.sig
+++ b/src/redprl/sequent.sig
@@ -1,32 +1,33 @@
-signature SEQUENT =
-sig
-  structure CJ : CATEGORICAL_JUDGMENT
+structure RedPrlSequentData =
+struct
+  (* polymorphism is useful for preventing bugs *)
+  type 'a catjdg = (Sym.t, 'a) RedPrlCategoricalJudgment.jdg'
 
-  type var = CJ.Tm.variable
-  type sym = CJ.Tm.symbol
-  type psort = CJ.Tm.psort
-  type sort = CJ.Tm.sort
-  type operator = CJ.Tm.operator
-  type param = CJ.Tm.param
-  type hyp = sym
-  type abt = CJ.Tm.abt
-  type label = string
-
-  structure Hyps : TELESCOPE where type Label.t = hyp
-
+  structure Hyps : TELESCOPE = Telescope (Sym)
   type 'a ctx = 'a Hyps.telescope
 
-  datatype 'a jdg =
-     >> of ((sym * psort) list * (Sym.t, 'a) CJ.jdg ctx) * (Sym.t, 'a) CJ.jdg     (* sequents / formal hypothetical judgment *)
-   | MATCH of operator * int * 'a * param list * 'a list        (* unify a term w/ a head operator and extract the kth subterm *)
-   | MATCH_RECORD of label * 'a                                 (* unify a term w/ RECORD and extract the subterm of the label *)
+  type label = string
 
-  val map : ('a -> 'b) -> 'a jdg -> 'b jdg
+  (* polymorphism is useful for preventing bugs *)
+  datatype 'a jdg' =
+     (* sequents / formal hypothetical judgment *)
+     >> of ((Sym.t * RedPrlAbt.psort) list * 'a catjdg ctx) * 'a catjdg
+     (* unify a term w/ a head operator and extract the kth subterm *)
+   | MATCH of RedPrlAbt.operator * int * 'a * RedPrlAbt.param list * 'a list
+     (* unify a term w/ RECORD and extract the subterm of the label *)
+   | MATCH_RECORD of label * 'a
+end
 
-  val pretty : ('a * 'a -> bool) -> ('a -> Fpp.doc) -> 'a jdg -> Fpp.doc
-  val pretty' : ('a -> Fpp.doc) -> 'a jdg -> Fpp.doc
+signature SEQUENT =
+sig
+  datatype jdg' = datatype RedPrlSequentData.jdg'
+  val map : ('a -> 'b) -> 'a jdg' -> 'b jdg'
 
-  val eq : CJ.Tm.abt jdg * CJ.Tm.abt jdg -> bool
+  val pretty' : ('a -> Fpp.doc) -> ('a * 'a -> bool) -> 'a jdg' -> Fpp.doc
 
-  val relabel : hyp CJ.Tm.Sym.Ctx.dict -> abt jdg -> abt jdg
+  (* specialized to abt *)
+  type jdg = RedPrlAbt.abt jdg'
+  val pretty : jdg -> Fpp.doc
+  val eq : jdg * jdg -> bool
+  val relabel : Sym.t Sym.Ctx.dict -> jdg -> jdg
 end

--- a/src/redprl/sequent.sml
+++ b/src/redprl/sequent.sml
@@ -1,41 +1,23 @@
-functor Sequent (structure CJ : CATEGORICAL_JUDGMENT
-                                  where type 'a Tm.O.t = 'a RedPrlOperator.t
-                                  where type Tm.O.Ar.Vl.S.t = RedPrlSort.t
-                                  where type 'a Tm.O.P.term = 'a RedPrlParameterTerm.t
-                                  where type Tm.Sym.t = Sym.t
-                                  where type Tm.Var.t = Sym.t
-                 sharing type CJ.Tm.Sym.Ctx.dict = CJ.Tm.Var.Ctx.dict) : SEQUENT =
+structure RedPrlSequent : SEQUENT =
 struct
-  structure CJ = CJ
-  structure Tm = CJ.Tm
+  structure CJ = RedPrlCategoricalJudgment
+  structure Tm = RedPrlAbt
+  structure O = RedPrlOperator
+  structure TP = TermPrinter
+  structure PS = RedPrlParamSort
+  structure P = RedPrlParameterTerm
 
-  type var = Tm.variable
-  type sym = Tm.symbol
-  type psort = Tm.psort
-  type sort = Tm.sort
-  type operator = Tm.operator
-  type param = Tm.param
-  type hyp = sym
-  type abt = CJ.Tm.abt
-  type label = string
-
-  structure Hyps : TELESCOPE = Telescope (Sym)
-  type 'a ctx = 'a Hyps.telescope
-
-  datatype 'a jdg =
-     >> of ((sym * psort) list * (sym, 'a) CJ.jdg ctx) * (sym, 'a) CJ.jdg
-   | MATCH of operator * int * 'a * param list * 'a list
-   | MATCH_RECORD of label * 'a
-
+  open RedPrlSequentData
   infix >>
+  type jdg = Tm.abt jdg'
 
   fun map f =
-    fn (I, H) >> catjdg => (I, Hyps.map (CJ.map_ f) H) >> CJ.map_ f catjdg
+    fn (I, H) >> catjdg => (I, Hyps.map (CJ.map f) H) >> CJ.map f catjdg
      | MATCH (th, k, a, ps, ms) => MATCH (th, k, f a, ps, List.map f ms)
      | MATCH_RECORD (lbl, tm) => MATCH_RECORD (lbl, f tm)
 
   fun renameHypsInTerm srho =
-    Tm.substSymenv (Tm.Sym.Ctx.map Tm.O.P.VAR srho)
+    Tm.substSymenv (Sym.Ctx.map P.VAR srho)
       o Tm.renameVars srho
 
   local
@@ -45,22 +27,22 @@ struct
       case (out t1, out t2) of
          (EMPTY, EMPTY) => true
        | (CONS (x, catjdg1, t1'), CONS (y, catjdg2, t2')) =>
-           Tm.Sym.eq (x, y)
+           Sym.eq (x, y)
              andalso CJ.eq (catjdg1, catjdg2)
              andalso telescopeEq (t1', t2')
        | _ => false
 
     fun relabelHyps H srho =
       let
-        val srho' = Tm.Sym.Ctx.map Tm.O.P.VAR srho
+        val srho' = Sym.Ctx.map P.VAR srho
       in
         case out H of
            EMPTY => Hyps.empty
          | CONS (x, catjdg, Hx) =>
            let
-             val catjdg' = CJ.map_ (Tm.substSymenv srho') catjdg
+             val catjdg' = CJ.map (Tm.substSymenv srho') catjdg
            in
-             case Tm.Sym.Ctx.find srho x of
+             case Sym.Ctx.find srho x of
                  NONE => Hyps.cons x catjdg' (relabelHyps Hx srho)
                | SOME y => Hyps.cons y catjdg' (relabelHyps Hx srho)
            end
@@ -70,31 +52,29 @@ struct
 
   fun relabel srho =
     fn (I, H) >> catjdg =>
-       (List.map (fn (u, sigma) => (Tm.Sym.Ctx.lookup srho u handle _ => u, sigma)) I, relabelHyps H srho)
-         >> CJ.map_ (renameHypsInTerm srho) catjdg
+       (List.map (fn (u, sigma) => (Sym.Ctx.lookup srho u handle _ => u, sigma)) I, relabelHyps H srho)
+         >> CJ.map (renameHypsInTerm srho) catjdg
      | jdg => map (renameHypsInTerm srho) jdg
-
-  structure P = CJ.Tm.O.P and PS = CJ.Tm.O.Ar.Vl.PS
 
   fun prettySyms syms =
     Fpp.collection
       (Fpp.char #"{")
       (Fpp.char #"}")
       (Fpp.Atomic.comma)
-      (List.map (fn (u, sigma) => Fpp.hsep [TermPrinter.ppSym u, Fpp.Atomic.colon, Fpp.text (Tm.O.Ar.Vl.PS.toString sigma)]) syms)
+      (List.map (fn (u, sigma) => Fpp.hsep [TP.ppSym u, Fpp.Atomic.colon, Fpp.text (PS.toString sigma)]) syms)
 
   fun prettyHyps f : 'a ctx -> Fpp.doc =
-    Fpp.vsep o Hyps.foldr (fn (x, a, r) => Fpp.hsep [TermPrinter.ppSym x, Fpp.Atomic.colon, f a] :: r) []
+    Fpp.vsep o Hyps.foldr (fn (x, a, r) => Fpp.hsep [TP.ppSym x, Fpp.Atomic.colon, f a] :: r) []
 
-  fun pretty eq f : 'a jdg -> Fpp.doc =
+  fun pretty' f eq : 'a jdg' -> Fpp.doc =
     fn (I, H) >> catjdg =>
        Fpp.seq
          [case I of [] => Fpp.empty | _ => Fpp.seq [prettySyms I, Fpp.newline],
-          if Hyps.isEmpty H then Fpp.empty else Fpp.seq [prettyHyps (CJ.pretty eq f) H, Fpp.newline],
-          Fpp.hsep [Fpp.text ">>", CJ.pretty eq f catjdg]]
-     | MATCH (th, k, a, _, _) => Fpp.hsep [f a, Fpp.text "match", TermPrinter.ppOperator th, Fpp.text "@", Fpp.text (Int.toString k)]
+          if Hyps.isEmpty H then Fpp.empty else Fpp.seq [prettyHyps (CJ.pretty' TP.ppSym f eq) H, Fpp.newline],
+          Fpp.hsep [Fpp.text ">>", CJ.pretty' TP.ppSym f eq catjdg]]
+     | MATCH (th, k, a, _, _) => Fpp.hsep [f a, Fpp.text "match", TP.ppOperator th, Fpp.text "@", Fpp.text (Int.toString k)]
      | MATCH_RECORD (lbl, a) => Fpp.hsep [f a, Fpp.text "match_record", Fpp.text lbl]
-  fun pretty' f = pretty (fn _ => false) f
+  val pretty = pretty' TP.ppTerm Tm.eq
 
   val rec eq =
     fn ((I1, H1) >> catjdg1, (I2, H2) >> catjdg2) =>
@@ -104,29 +84,29 @@ struct
              raise Fail "psort mismatch in Sequent.eq"
 
          val I = ListPair.mapEq (fn ((_, sigma1), (_, sigma2)) => (Sym.new (), unifyPsorts (sigma1, sigma2))) (I1, I2)
-         val srho1 = ListPair.foldr (fn ((u1, _), (u, _), rho) => Tm.Sym.Ctx.insert rho u1 (P.ret u)) Tm.Sym.Ctx.empty (I1, I)
-         val srho2 = ListPair.foldr (fn ((u2, _), (u, _), rho) => Tm.Sym.Ctx.insert rho u2 (P.ret u)) Tm.Sym.Ctx.empty (I2, I)
+         val srho1 = ListPair.foldr (fn ((u1, _), (u, _), rho) => Sym.Ctx.insert rho u1 (P.ret u)) Sym.Ctx.empty (I1, I)
+         val srho2 = ListPair.foldr (fn ((u2, _), (u, _), rho) => Sym.Ctx.insert rho u2 (P.ret u)) Sym.Ctx.empty (I2, I)
 
          val xs1 = Hyps.foldr (fn (x, _, xs) => x :: xs) [] H1
          val xs2 = Hyps.foldr (fn (x, _, xs) => x :: xs) [] H2
          val xs = ListPair.mapEq (fn _ => Sym.new ()) (xs1, xs2)
-         val xrho1 = ListPair.foldr (fn (x1, x, rho) => Tm.Sym.Ctx.insert rho x1 x) Tm.Sym.Ctx.empty (xs1, xs)
-         val xrho2 = ListPair.foldr (fn (x2, x, rho) => Tm.Sym.Ctx.insert rho x2 x) Tm.Sym.Ctx.empty (xs2, xs)
+         val xrho1 = ListPair.foldr (fn (x1, x, rho) => Sym.Ctx.insert rho x1 x) Sym.Ctx.empty (xs1, xs)
+         val xrho2 = ListPair.foldr (fn (x2, x, rho) => Sym.Ctx.insert rho x2 x) Sym.Ctx.empty (xs2, xs)
 
-         val H1' = Hyps.map (CJ.map_ (CJ.Tm.substSymenv srho1)) (relabelHyps H1 xrho1)
-         val H2' = Hyps.map (CJ.map_ (CJ.Tm.substSymenv srho2)) (relabelHyps H2 xrho2)
-         val catjdg1' = CJ.map_ (CJ.Tm.substSymenv srho1 o renameHypsInTerm xrho1) catjdg1
-         val catjdg2' = CJ.map_ (CJ.Tm.substSymenv srho2 o renameHypsInTerm xrho2) catjdg2
+         val H1' = Hyps.map (CJ.map (Tm.substSymenv srho1)) (relabelHyps H1 xrho1)
+         val H2' = Hyps.map (CJ.map (Tm.substSymenv srho2)) (relabelHyps H2 xrho2)
+         val catjdg1' = CJ.map (Tm.substSymenv srho1 o renameHypsInTerm xrho1) catjdg1
+         val catjdg2' = CJ.map (Tm.substSymenv srho2 o renameHypsInTerm xrho2) catjdg2
        in
          telescopeEq (H1', H2')
            andalso CJ.eq (catjdg1', catjdg2')
        end
        handle _ => false)
      | (MATCH (th1, k1, a1, ps1, ms1), MATCH (th2, k2, a2, ps2, ms2)) =>
-          CJ.Tm.O.eq CJ.Tm.Sym.eq (th1, th2)
+          O.eq Sym.eq (th1, th2)
             andalso k1 = k2
             andalso Tm.eq (a1, a2)
-            andalso ListPair.allEq (Tm.O.P.eq Tm.Sym.eq) (ps1, ps2)
+            andalso ListPair.allEq (O.P.eq Sym.eq) (ps1, ps2)
             andalso ListPair.allEq Tm.eq (ms1, ms2)
      | (MATCH_RECORD (lbl1, a1), MATCH_RECORD (lbl2, a2)) =>
           lbl1 = lbl2 andalso Tm.eq (a1, a2)

--- a/src/redprl/signature.sig
+++ b/src/redprl/signature.sig
@@ -34,7 +34,7 @@ sig
 
   include MINI_SIGNATURE
 
-  type src_catjdg = (string, ast) RedPrlCategoricalJudgment.jdg
+  type src_catjdg = RedPrlCategoricalJudgment.astjdg
   type src_seqhyp = string * src_catjdg
   type src_sequent = src_seqhyp list * src_catjdg
 

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -406,7 +406,7 @@ struct
                       val taux = CJ.synthesis jdgx
                     in
                       (ps,
-                       Tm.Sym.Ctx.insert ctx x taux,
+                       Tm.Sym.Ctx.insert ctx x RedPrlSortData.HYP,
                        NameEnv.insert env (Sym.toString x) x)
                     end)
                   (params', symctx, env)

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -38,7 +38,7 @@ struct
           Fpp.seq [Fpp.text @@ Sym.toString opid, prettyArgs arguments],
           Fpp.Atomic.colon,
           Fpp.grouped @@ Fpp.Atomic.squares @@ Fpp.seq
-            [Fpp.nest 2 @@ Fpp.seq [Fpp.newline, RedPrlSequent.pretty Tm.eq TermPrinter.ppTerm spec],
+            [Fpp.nest 2 @@ Fpp.seq [Fpp.newline, RedPrlSequent.pretty spec],
             Fpp.newline],
           Fpp.Atomic.equals,
           Fpp.grouped @@ Fpp.Atomic.squares @@ Fpp.seq
@@ -136,7 +136,7 @@ struct
         inheritAnnotation m (processTerm' sign m)
 
       fun processSrcCatjdg sign =
-        RedPrlCategoricalJudgment.map_ (processTerm sign)
+        RedPrlCategoricalJudgment.map (processTerm sign)
 
       fun processSrcSeq sign (hyps, concl) =
         (List.map (fn (x, hyp) => (x, processSrcCatjdg sign hyp)) hyps, processSrcCatjdg sign concl)
@@ -246,7 +246,7 @@ struct
         AstToAbt.NameEnv.empty
         metactx
 
-    structure CJ = RedPrlCategoricalJudgment and Sort = RedPrlOpData and Hyps = RedPrlSequent.Hyps
+    structure CJ = RedPrlCategoricalJudgment and Sort = RedPrlOpData and Hyps = RedPrlSequentData.Hyps
 
     fun elabAst (metactx, env) ast : abt =
       let
@@ -255,8 +255,8 @@ struct
         abt
       end
 
-    fun elabSrcCatjdg (metactx, symctx, varctx, env) : src_catjdg -> (Sym.t, abt) CJ.jdg =
-      CJ.map (fn name => NameEnv.lookup env name handle _ => Sym.named name) (elabAst (metactx, env))
+    fun elabSrcCatjdg (metactx, symctx, varctx, env) : src_catjdg -> CJ.jdg =
+      CJ.map' (fn name => NameEnv.lookup env name handle _ => Sym.named name) (elabAst (metactx, env))
       (* TODO check scoping *)
 
     fun addHypName (env, symctx, varctx) (srcname, tau) =
@@ -278,7 +278,7 @@ struct
         (env', symctx')
       end
 
-    fun elabSrcSeqHyp (metactx, symctx, varctx, env) (srcname, srcjdg) : Tm.symctx * Tm.varctx * symbol NameEnv.dict * symbol * (Sym.t, abt) CJ.jdg =
+    fun elabSrcSeqHyp (metactx, symctx, varctx, env) (srcname, srcjdg) : Tm.symctx * Tm.varctx * symbol NameEnv.dict * symbol * CJ.jdg =
       let
         val catjdg = elabSrcCatjdg (metactx, symctx, varctx, env) srcjdg
         val tau = CJ.synthesis catjdg
@@ -287,7 +287,7 @@ struct
         (symctx', varctx', env', x, catjdg)
       end
 
-    fun elabSrcSeqHyps (metactx, symctx, varctx, env) : src_seqhyp list -> symbol NameEnv.dict * (Sym.t, abt) CJ.jdg Hyps.telescope =
+    fun elabSrcSeqHyps (metactx, symctx, varctx, env) : src_seqhyp list -> symbol NameEnv.dict * CJ.jdg Hyps.telescope =
       let
         fun go env _ _ H [] = (env, H)
           | go env syms vars H (hyp :: hyps) =
@@ -389,7 +389,7 @@ struct
           fun goalEqualTo goal1 goal2 =
             if RedPrlSequent.eq (goal1, goal2) then true
             else
-              (RedPrlLog.print RedPrlLog.WARN (pos, Fpp.hvsep [RedPrlSequent.pretty Tm.eq TermPrinter.ppTerm goal1, Fpp.text "not equal to", RedPrlSequent.pretty Tm.eq TermPrinter.ppTerm goal2]);
+              (RedPrlLog.print RedPrlLog.WARN (pos, Fpp.hvsep [RedPrlSequent.pretty goal1, Fpp.text "not equal to", RedPrlSequent.pretty goal2]);
                false)
 
           fun go ([], Tl.ConsView.EMPTY) = true

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -1,6 +1,6 @@
 structure Signature :> SIGNATURE =
 struct
-  structure Tm = RedPrlAbt and Ar = RedPrlArity
+  structure Ar = RedPrlArity
   structure P = struct open RedPrlSortData RedPrlParamData end
   structure E = ElabMonadUtil (ElabMonad)
   structure ElabNotation = MonadNotation (E)
@@ -17,11 +17,6 @@ struct
        [] => []
      | [x] => [x]
      | x::xs => Fpp.seq [x, s] :: intersperse s xs
-
-  fun prettyParams ps =
-    Fpp.Atomic.braces @@ Fpp.grouped @@ Fpp.hvsep @@
-      intersperse Fpp.Atomic.comma @@
-        List.map (fn (u, sigma) => Fpp.hsep [Fpp.text (Sym.toString u), Fpp.Atomic.colon, Fpp.text (Ar.Vl.PS.toString sigma)]) ps
 
   fun prettyArgs args =
     Fpp.Atomic.parens @@ Fpp.grouped @@ Fpp.hvsep @@
@@ -144,9 +139,6 @@ struct
       fun processSrcGenJdg sign (bs, seq) =
         (bs, processSrcSeq sign seq)
 
-      fun processSrcRuleSpec sign (premises, goal) =
-        (List.map (processSrcGenJdg sign) premises, processSrcSeq sign goal)
-
     in
       fun processDecl sign =
         fn DEF {arguments, params, sort, definiens} => DEF {arguments = arguments, params = params, sort = sort, definiens = processTerm sign definiens}
@@ -267,15 +259,6 @@ struct
         val varctx' = Sym.Ctx.insert varctx x tau
       in
         (env', symctx', varctx', x)
-      end
-
-    fun addSymName (env, symctx) (srcname, psort) =
-      let
-        val u = Sym.named srcname
-        val env' = NameEnv.insert env srcname u
-        val symctx' = Sym.Ctx.insert symctx u psort
-      in
-        (env', symctx')
       end
 
     fun elabSrcSeqHyp (metactx, symctx, varctx, env) (srcname, srcjdg) : Tm.symctx * Tm.varctx * symbol NameEnv.dict * symbol * CJ.jdg =

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -406,7 +406,7 @@ struct
                       val taux = CJ.synthesis jdgx
                     in
                       (ps,
-                       Tm.Sym.Ctx.insert ctx x RedPrlSortData.HYP,
+                       Tm.Sym.Ctx.insert ctx x taux,
                        NameEnv.insert env (Sym.toString x) x)
                     end)
                   (params', symctx, env)

--- a/src/redprl/signature_mini.sml
+++ b/src/redprl/signature_mini.sml
@@ -22,7 +22,7 @@ struct
      spec : jdg,
      state : names -> Lcf.jdg Lcf.state}
 
-  type src_catjdg = (string, ast) RedPrlCategoricalJudgment.jdg
+  type src_catjdg = RedPrlCategoricalJudgment.astjdg
   type src_seqhyp = string * src_catjdg
   type src_sequent = src_seqhyp list * src_catjdg
   type src_genjdg = (string * psort) list * src_sequent

--- a/src/redprl/signature_mini.sml
+++ b/src/redprl/signature_mini.sml
@@ -26,7 +26,6 @@ struct
   type src_seqhyp = string * src_catjdg
   type src_sequent = src_seqhyp list * src_catjdg
   type src_genjdg = (string * psort) list * src_sequent
-  type src_rulespec = src_genjdg list * src_sequent
 
   datatype src_decl =
       DEF of {arguments : string arguments, params : string params, sort : sort, definiens : ast}

--- a/src/redprl/tactic_elaborator.fun
+++ b/src/redprl/tactic_elaborator.fun
@@ -279,10 +279,10 @@ struct
      | O.MONO (O.RULE_EXACT _) $ [_ \ tm] => R.Exact (expandHypVars tm)
      | O.MONO O.RULE_HEAD_EXP $ _ => R.Computation.EqHeadExpansion sign
      | O.MONO O.RULE_SYMMETRY $ _ => R.Equality.Symmetry
-     | O.MONO O.RULE_CUT $ [_ \ catjdg] => R.Cut (CJ.fromAbt (expandHypVars catjdg))
+     | O.MONO O.RULE_CUT $ [_ \ catjdg] => R.Cut (CJ.out (expandHypVars catjdg))
      | O.POLY (O.RULE_UNFOLD opid) $ _ => R.Computation.Unfold sign opid
      | O.MONO (O.RULE_PRIM ruleName) $ _ => R.lookupRule ruleName
-     | O.MONO O.DEV_LET $ [_ \ jdg, _ \ tm1, ([u],_) \ tm2] => R.Cut (CJ.fromAbt (expandHypVars jdg)) thenl' ([u], [tactic sign env tm1, tactic sign env tm2])
+     | O.MONO O.DEV_LET $ [_ \ jdg, _ \ tm1, ([u],_) \ tm2] => R.Cut (CJ.out (expandHypVars jdg)) thenl' ([u], [tactic sign env tm1, tactic sign env tm2])
      | O.MONO (O.DEV_DFUN_INTRO pats) $ [(us, _) \ tm] => dfunIntros sign (pats, us) (tactic sign env tm)
      | O.MONO (O.DEV_RECORD_INTRO lbls) $ args => recordIntro sign lbls (List.map (fn _ \ tm => tactic sign env tm) args)
      | O.MONO (O.DEV_PATH_INTRO _) $ [(us, _) \ tm] => pathIntros sign us (tactic sign env tm)
@@ -359,7 +359,7 @@ struct
      | O.MONO O.DEV_QUERY_GOAL $ [(_,[x]) \ tm] =>
        (fn alpha => fn jdg as _ >> cj =>
          let
-           val tm' = substVar (CJ.toAbt cj, x) tm
+           val tm' = substVar (CJ.into cj, x) tm
          in
            tactic sign env tm' alpha jdg
          end)


### PR DESCRIPTION
@jonsterling I would like to refactor categorical judgments first before refactoring levels in the same way. The idea is that everything should be (1) fully polymorphic, or (2) specialized to abt with resolved names, or (3) specialized to ast with strings. Nothing in the middle. See https://github.com/RedPRL/sml-redprl/blob/6b38bba850b74bc75dde831db443632fe1b8f353/src/redprl/categorical_judgment.sig for the style I am going for.