### PR TITLE
use {} rather than <> for record decomposition in tactics

### DIFF
--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -436,6 +436,7 @@ end
  | tactics of ast list
 
  | recordFieldTactics of (string * ast) list
+
  | devAppSpine of ast list
  | bracketedDevAppSpine of ast list
  | devDecompPattern of string O.dev_pattern
@@ -825,7 +826,7 @@ bracketedDevAppSpine
 
 devDecompPattern
   : VARNAME (O.PAT_VAR VARNAME)
-  | LANGLE tupleDecompPattern RANGLE (O.PAT_TUPLE tupleDecompPattern)
+  | LBRACKET tupleDecompPattern RBRACKET (O.PAT_TUPLE tupleDecompPattern)
 
 devDecompPatterns
   : devDecompPattern COMMA devDecompPatterns (devDecompPattern :: devDecompPatterns)
@@ -894,7 +895,8 @@ atomicRawTac
 
   | LAMBDA devDecompPatterns DOT tactic (Pattern.makeLambda devDecompPatterns tactic)
   | LANGLE boundVars RANGLE tactic (Ast.$$ (O.MONO (O.DEV_PATH_INTRO (List.length boundVars)), [\ ((Multi.addUnderscores boundVars, []), tactic)]))
-  | LANGLE recordFieldTactics RANGLE (Multi.recordIntro (Pos.pos (LANGLE1left fileName) (RANGLE1right fileName)) recordFieldTactics)
+  | LBRACKET recordFieldTactics RBRACKET (Multi.recordIntro (Pos.pos (LBRACKET1left fileName) (RBRACKET1right fileName)) recordFieldTactics)
+  
   | IF VARNAME THEN tactic ELSE tactic
       (Ast.$$ (O.POLY (O.DEV_BOOL_ELIM VARNAME), [\ (([],[]), tactic1), \ (([],[]), tactic2)]))
 

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -184,6 +184,14 @@ struct
       checkNoDuplicates pos lbls;
       O.MONO (O.DEV_RECORD_INTRO lbls) $$ List.map (fn tac => ([],[]) \ tac) tacs
     end
+
+
+  fun sigmaIntro tacs =
+    let
+      val lbls = List.tabulate (List.length tacs, anonRecordLabelForIndex)
+    in
+      O.MONO (O.DEV_RECORD_INTRO lbls) $$ List.map (fn tac => ([],[]) \ tac) tacs
+    end
 end
 
 structure Pattern =
@@ -896,6 +904,7 @@ atomicRawTac
   | LAMBDA devDecompPatterns DOT tactic (Pattern.makeLambda devDecompPatterns tactic)
   | LANGLE boundVars RANGLE tactic (Ast.$$ (O.MONO (O.DEV_PATH_INTRO (List.length boundVars)), [\ ((Multi.addUnderscores boundVars, []), tactic)]))
   | LBRACKET recordFieldTactics RBRACKET (Multi.recordIntro (Pos.pos (LBRACKET1left fileName) (RBRACKET1right fileName)) recordFieldTactics)
+  | LBRACKET tactics RBRACKET (Multi.sigmaIntro tactics)
   
   | IF VARNAME THEN tactic ELSE tactic
       (Ast.$$ (O.POLY (O.DEV_BOOL_ELIM VARNAME), [\ (([],[]), tactic1), \ (([],[]), tactic2)]))
@@ -930,7 +939,7 @@ atomicRawMultitac
   | MTAC_AUTO (Tac.autoMtac)
   | MTAC_PROGRESS LBRACKET multitac RBRACKET (Ast.$$ (O.MONO O.MTAC_PROGRESS, [\ (([], []), multitac)]))
   | MTAC_REC VARNAME IN LBRACKET multitac RBRACKET (Ast.$$ (O.MONO O.MTAC_REC, [\ (([],[VARNAME]), multitac)]))
-  | LBRACKET multitac RBRACKET (multitac)
+  | LPAREN multitac RPAREN (multitac)
   | FRESH hypBindings RIGHT_ARROW atomicRawMultitac SEMI multitac %prec LEFT_ARROW (Tac.makeSeq atomicRawMultitac hypBindings multitac)
   | atomicTac %prec SEMI (Ast.$$ (O.MONO O.MTAC_ALL, [\ (([],[]), atomicTac)]))
   | QUESTION ident (Ast.$$ (O.MONO (O.MTAC_HOLE (SOME ident)), []))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -198,6 +198,13 @@ structure Pattern =
 struct
   infix $$ $ \
 
+  fun labelAnonTuplePattern pats = 
+    let
+      val lbls = List.tabulate (List.length pats, Multi.anonRecordLabelForIndex)
+    in
+      ListPair.zip (lbls, pats)
+    end
+
   (* this code is kind of crappy, feel free to improve it *)
   fun unstitchPattern (pat : 'a O.dev_pattern) : unit O.dev_pattern * 'a list =
     case pat of
@@ -450,6 +457,8 @@ end
  | devDecompPattern of string O.dev_pattern
  | devDecompPatterns of string O.dev_pattern list
  | labeledDecompPattern of string * string O.dev_pattern
+ | anonTupleDecompPattern of string O.dev_pattern list
+ | labeledTupleDecompPattern of (string * string O.dev_pattern) list
  | tupleDecompPattern of (string * string O.dev_pattern) list
  | devMatchClause of string list * (ast * ast)
  | devMatchClauses of (string list * (ast * ast)) list
@@ -834,6 +843,7 @@ bracketedDevAppSpine
 
 devDecompPattern
   : VARNAME (O.PAT_VAR VARNAME)
+  | UNDER (O.PAT_VAR "_")
   | LBRACKET tupleDecompPattern RBRACKET (O.PAT_TUPLE tupleDecompPattern)
 
 devDecompPatterns
@@ -842,12 +852,19 @@ devDecompPatterns
 
 labeledDecompPattern
   : VARNAME EQUALS devDecompPattern (VARNAME, devDecompPattern)
-  | VARNAME (VARNAME, O.PAT_VAR VARNAME)
 
-tupleDecompPattern
-   : labeledDecompPattern COMMA tupleDecompPattern (labeledDecompPattern :: tupleDecompPattern)
+labeledTupleDecompPattern
+   : labeledDecompPattern COMMA labeledTupleDecompPattern (labeledDecompPattern :: labeledTupleDecompPattern)
    | labeledDecompPattern ([labeledDecompPattern])
    | ([])
+
+anonTupleDecompPattern
+   : devDecompPattern COMMA anonTupleDecompPattern (devDecompPattern :: anonTupleDecompPattern)
+   | devDecompPattern ([devDecompPattern])
+
+tupleDecompPattern
+  : labeledTupleDecompPattern (labeledTupleDecompPattern)
+  | anonTupleDecompPattern (Pattern.labelAnonTuplePattern anonTupleDecompPattern)
 
 devMatchClause
   : LSQUARE patvarBindings PIPE term DOUBLE_RIGHT_ARROW tactic RSQUARE (patvarBindings, (term, tactic))

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -3,7 +3,7 @@ Thm BoolTest : [
 ] by [
   // A term/witness can be supplied to the refiner at any point in a tactic script
   // using the quotation operator `.
-  {lam x. if x then `tt else `ff}; auto
+  (lam x. if x then `tt else `ff); auto
 ].
 
 
@@ -99,7 +99,7 @@ Print BoolEta.
 Thm BoolEtaFunction : [
   (-> wbool wbool)
 ] by [
-  {lam b. if b then `tt else `ff}; auto
+  (lam b. if b then `tt else `ff); auto
 ].
 
 Extract BoolEtaFunction.
@@ -123,7 +123,7 @@ Thm PathTest2 : [
   <x>
     // now, we are constructing a line of functions; so we use a
     // lambda.
-    {lam b.
+    (lam b.
       // for our b:wbool, we will construct a path between b and
       // (BoolEta b).
       let p : [(path {_} wbool ,b (BoolEta ,b))] =
@@ -133,8 +133,8 @@ Thm PathTest2 : [
       // interactive tactic environment, dimension expressions are
       // supplied to the refiner using the '@' "dimension quotation"
       // operator.
-      use p [@x]
-    }; auto
+      use p [@x]);
+     auto
 ].
 
 // It turns out that it is just as good to figure out what the witness
@@ -161,8 +161,7 @@ Thm PathTest3 : [
 Print PathTest3.
 
 Thm PairTest : [ (* [a : S1] (path {_} S1 a base)) ] by [
-  {proj1 = `base,
-   proj2 = <x> `(loop x)}
+  {`base, <x> `(loop x)}
 ].
 
 
@@ -190,7 +189,7 @@ Thm StrictBoolTest : [ SNot = (Cmp SNot (Cmp SNot SNot)) in (-> bool bool) ] by 
 ].
 
 Thm Not : [(-> [_ : wbool] wbool)] by [
-  {lam x. if x then `ff else `tt}; auto
+  (lam x. if x then `ff else `tt); auto
 ].
 
 Thm FunExt(#l:lvl) : [
@@ -219,7 +218,7 @@ Print FunExtTac.
 
 Thm NotNotPath : [(path {_} (-> wbool wbool) (Cmp Not Not) (lam [x] x))] by [
   (FunExtTac #lvl{0});
-  {lam x. if x then <_> `tt else <_> `ff};
+  (lam x. if x then <_> `tt else <_> `ff);
   auto
 ].
 
@@ -228,8 +227,7 @@ Print FunExtTac.
 Print NotNotPath.
 
 Thm Singleton : [(* [x : wbool] (path {_} wbool x tt))] by [
-  {proj1 = `tt,
-   proj2 = <_> `tt}
+  {`tt, <_> `tt}
 ].
 
 Thm PathElimTest : [(-> (path {_} bool tt tt) bool)] by [

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -161,7 +161,8 @@ Thm PathTest3 : [
 Print PathTest3.
 
 Thm PairTest : [ (* [a : S1] (path {_} S1 a base)) ] by [
-  <proj1 = `base, proj2 = <x> `(loop x)>
+  {proj1 = `base,
+   proj2 = <x> `(loop x)}
 ].
 
 
@@ -203,7 +204,7 @@ Thm FunExt(#l:lvl) : [
     <i> lam x. use p [use x, @i]
 ].
 
-// Print FunExt.
+Print FunExt.
 
 Tac FunExtTac(#l : lvl) = [
   query gl <- goal.
@@ -227,7 +228,8 @@ Print FunExtTac.
 Print NotNotPath.
 
 Thm Singleton : [(* [x : wbool] (path {_} wbool x tt))] by [
-  <proj1 = `tt, proj2 = <_> `tt>
+  {proj1 = `tt,
+   proj2 = <_> `tt}
 ].
 
 Thm PathElimTest : [(-> (path {_} bool tt tt) bool)] by [

--- a/test/failure/bad-hcom-empty.prl
+++ b/test/failure/bad-hcom-empty.prl
@@ -1,5 +1,5 @@
 Thm MalformedTube : [
   wbool true
 ] by [
-  {`(hcom{0 ~> 1} wbool tt)}
+  `(hcom{0 ~> 1} wbool tt)
 ].

--- a/test/failure/bad-hcom-stuck.prl
+++ b/test/failure/bad-hcom-stuck.prl
@@ -1,6 +1,6 @@
 Thm Bool : [
   wbool true
 ] by [
-  {`(hcom{0 ~> 1} wbool tt [0=1 {_} tt])};
+  `(hcom{0 ~> 1} wbool tt [0=1 {_} tt]);
   auto
 ].

--- a/test/failure/bad-param-sort.prl
+++ b/test/failure/bad-param-sort.prl
@@ -1,5 +1,5 @@
-Thm Cap{i : lvl}(#A) : [ 
-  a/type : #A hcom type,
+Thm Cap{i : hyp}(#A) : [ 
+  a/type : #A type with hcom,
   x : #A
   >> (hcom{0 ~> 0} #A x [i=0 {_} x] [i=1 {_} x]) = x in #A
 ] by [

--- a/test/failure/freemeta.prl
+++ b/test/failure/freemeta.prl
@@ -1,3 +1,3 @@
 Def Cmp(#f : exp; #g : exp) : exp = [
-  (lam [x] (#f (#h x)))
+  (lam [x] ($ #f ($ #h x)))
 ].

--- a/test/failure/kind-hcom.prl
+++ b/test/failure/kind-hcom.prl
@@ -1,7 +1,7 @@
-Thm Path/Symm{l:lvl} : [
-  ty : (U l)
+Thm Path/Symm(#l:lvl) : [
+  ty : (U #l)
   >>
-  ty hcom type
+  ty type with hcom
 ] by [
   auto
 ].

--- a/test/failure/lexical-error.prl
+++ b/test/failure/lexical-error.prl
@@ -1,3 +1,3 @@
 Thm LexicalError : [ (-> bool bool) true ] by [
-  { lam x. `_tt }; auto
+  (lam x. `_tt); auto
 ].

--- a/test/success/V-types.prl
+++ b/test/success/V-types.prl
@@ -105,7 +105,7 @@ Thm NotIsEquiv : [
       proj2 = <_> use b}
   , proj2 =
       lam {proj2 = p}, {proj2 = p'}.
-        {<i>
+        (<i>
           { proj1 =
              `($ Not (hcom{1~>0} bool ,b
                       [i=0 {j} (@ ,p j)]
@@ -115,7 +115,7 @@ Thm NotIsEquiv : [
                    [i=0 {j} (@ ,p j)]
                    [i=1 {j} (@ ,p' j)])
           }
-        };
+        );
         (Bool/contra/inverse ,p);
         (Bool/contra/inverse ,p')
   }
@@ -124,8 +124,7 @@ Thm NotIsEquiv : [
 Thm NotEquiv : [
   (Equiv bool bool)
 ] by [
-  {proj1 = `Not,
-   proj2 = `NotIsEquiv}
+  {`Not, `NotIsEquiv}
 ].
 
 Def NotV {i:dim} = [(V i bool bool NotEquiv)].

--- a/test/success/V-types.prl
+++ b/test/success/V-types.prl
@@ -14,12 +14,12 @@ Thm IdIsEquiv(#l:lvl) : [
   (-> [ty : (U #l hcom)] (IsEquiv ty ty Id))
 ] by [
   lam ty, a.
-  < proj1 =
-     <proj1 = use a,
-      proj2 = <_> use a>
+  { proj1 =
+     {proj1 = use a,
+      proj2 = <_> use a}
   , proj2 =
-     lam <proj2 = c>, <proj2 = c'>. <i>
-       < proj1 =
+     lam {proj2 = c}, {proj2 = c'}. <i>
+       { proj1 =
           `(hcom{1~>0} ,ty ,a
             [i=0 {j} (@ ,c j)]
             [i=1 {j} (@ ,c' j)])
@@ -27,16 +27,16 @@ Thm IdIsEquiv(#l:lvl) : [
            <j> `(hcom{1~>j} ,ty ,a
                  [i=0 {j} (@ ,c j)]
                  [i=1 {j} (@ ,c' j)])
-       >
-  >
+       }
+  }
 ].
 
 Thm IdEquiv(#l:lvl) : [
   (-> [ty : (U #l hcom)] (Equiv ty ty))
 ] by [
   lam ty.
-    <proj1 = `Id,
-     proj2 = use (IdIsEquiv #l) [use ty]>
+    {proj1 = `Id,
+     proj2 = use (IdIsEquiv #l) [use ty]}
 ].
 
 Print IdEquiv.
@@ -100,14 +100,13 @@ Thm NotIsEquiv : [
   (IsEquiv bool bool Not)
 ] by [
   lam b.
-  < proj1 =
-     <proj1 = `($ Not ,b),
-      proj2 = <_> use b
-     >
+  { proj1 =
+     {proj1 = `($ Not ,b),
+      proj2 = <_> use b}
   , proj2 =
-      lam <proj2 = p>, <proj2 = p'>.
+      lam {proj2 = p}, {proj2 = p'}.
         {<i>
-          < proj1 =
+          { proj1 =
              `($ Not (hcom{1~>0} bool ,b
                       [i=0 {j} (@ ,p j)]
                       [i=1 {j} (@ ,p' j)]))
@@ -115,18 +114,18 @@ Thm NotIsEquiv : [
              <j> `(hcom{1~>j} bool ,b
                    [i=0 {j} (@ ,p j)]
                    [i=1 {j} (@ ,p' j)])
-          >
+          }
         };
         (Bool/contra/inverse ,p);
         (Bool/contra/inverse ,p')
-  >
+  }
 ].
 
 Thm NotEquiv : [
   (Equiv bool bool)
 ] by [
-  <proj1 = `Not,
-   proj2 = `NotIsEquiv>
+  {proj1 = `Not,
+   proj2 = `NotIsEquiv}
 ].
 
 Def NotV {i:dim} = [(V i bool bool NotEquiv)].

--- a/test/success/V-types.prl
+++ b/test/success/V-types.prl
@@ -14,19 +14,14 @@ Thm IdIsEquiv(#l:lvl) : [
   (-> [ty : (U #l hcom)] (IsEquiv ty ty Id))
 ] by [
   lam ty, a.
-  { proj1 =
-     {proj1 = use a,
-      proj2 = <_> use a}
-  , proj2 =
-     lam {proj2 = c}, {proj2 = c'}. <i>
-       { proj1 =
-          `(hcom{1~>0} ,ty ,a
-            [i=0 {j} (@ ,c j)]
-            [i=1 {j} (@ ,c' j)])
-       , proj2 =
-           <j> `(hcom{1~>j} ,ty ,a
-                 [i=0 {j} (@ ,c j)]
-                 [i=1 {j} (@ ,c' j)])
+  { {use a, <_> use a}
+  , lam {_,c}, {_,c'}. <i>
+       { `(hcom{1~>0} ,ty ,a
+           [i=0 {j} (@ ,c j)]
+           [i=1 {j} (@ ,c' j)])
+       , <j> `(hcom{1~>j} ,ty ,a
+               [i=0 {j} (@ ,c j)]
+               [i=1 {j} (@ ,c' j)])
        }
   }
 ].
@@ -35,8 +30,7 @@ Thm IdEquiv(#l:lvl) : [
   (-> [ty : (U #l hcom)] (Equiv ty ty))
 ] by [
   lam ty.
-    {proj1 = `Id,
-     proj2 = use (IdIsEquiv #l) [use ty]}
+    {`Id, use (IdIsEquiv #l) [use ty]}
 ].
 
 Print IdEquiv.
@@ -100,20 +94,15 @@ Thm NotIsEquiv : [
   (IsEquiv bool bool Not)
 ] by [
   lam b.
-  { proj1 =
-     {proj1 = `($ Not ,b),
-      proj2 = <_> use b}
-  , proj2 =
-      lam {proj2 = p}, {proj2 = p'}.
+  { {`($ Not ,b), <_> use b}
+  , lam {_,p}, {_,p'}.
         (<i>
-          { proj1 =
-             `($ Not (hcom{1~>0} bool ,b
-                      [i=0 {j} (@ ,p j)]
-                      [i=1 {j} (@ ,p' j)]))
-          , proj2 =
-             <j> `(hcom{1~>j} bool ,b
-                   [i=0 {j} (@ ,p j)]
-                   [i=1 {j} (@ ,p' j)])
+          { `($ Not (hcom{1~>0} bool ,b
+                     [i=0 {j} (@ ,p j)]
+                     [i=1 {j} (@ ,p' j)]))
+          , <j> `(hcom{1~>j} bool ,b
+                  [i=0 {j} (@ ,p j)]
+                  [i=1 {j} (@ ,p' j)])
           }
         );
         (Bool/contra/inverse ,p);

--- a/test/success/dashes-n-slashes.prl
+++ b/test/success/dashes-n-slashes.prl
@@ -1,4 +1,4 @@
 // Identifiers can contain hyphens and slashes
 Thm Ident-test/ : [ bool ] by [
-  { `tt }
+  `tt
 ].

--- a/test/success/decomposition.prl
+++ b/test/success/decomposition.prl
@@ -3,7 +3,7 @@ Thm Decomposition : [
    (record [foo : (record [a : bool] [b : (* bool bool)])] [bar : S1])
    bool)
 ] by [
-  lam <foo = <a, b = <proj1>>>.
+  lam {foo = {a, b = {proj1}}}.
   use proj1
 ].
 
@@ -21,8 +21,8 @@ Thm Apply : [
    S1)
 ] by [
   lam f.
-    let <a> = f [`tt, `ff, @0].
-    use a 
+    let {a} = f [`tt, `ff, @0].
+    use a
 ].
 
 Extract Apply.
@@ -48,13 +48,13 @@ Thm UseLemmaTest : [
 Thm MyLemma(#m: {dim,dim}[exp,exp].exp) : [
   (-> [b : bool] [p : (path {_} bool b tt)] (* bool (path {_} bool tt b)))
 ] by [
-  lam b, p. <proj1 = `tt, proj2 = <i> `(hcom{0~>1} bool ,b [i=0 {j} (@ ,p j)] [i=1 {_} ,b])>
+  lam b, p. {proj1 = `tt, proj2 = <i> `(hcom{0~>1} bool ,b [i=0 {j} (@ ,p j)] [i=1 {_} ,b])}
 ].
 
 Thm UsingLemma : [
   (path {_} bool tt tt)
 ] by [
-  let <proj2 = lem> = (MyLemma {i j} [x y] (@ (abs {_} y) i)) [`tt, <_> `tt].
+  let {proj2 = lem} = (MyLemma {i j} [x y] (@ (abs {_} y) i)) [`tt, <_> `tt].
   use lem
 ].
 

--- a/test/success/decomposition.prl
+++ b/test/success/decomposition.prl
@@ -3,8 +3,8 @@ Thm Decomposition : [
    (record [foo : (record [a : bool] [b : (* bool bool)])] [bar : S1])
    bool)
 ] by [
-  lam {foo = {a, b = {proj1}}}.
-  use proj1
+  lam {foo = {a = a, b = {welp}}}.
+  use welp
 ].
 
 Extract Decomposition.
@@ -21,7 +21,7 @@ Thm Apply : [
    S1)
 ] by [
   lam f.
-    let {a} = f [`tt, `ff, @0].
+    let {a = a} = f [`tt, `ff, @0].
     use a
 ].
 
@@ -48,13 +48,13 @@ Thm UseLemmaTest : [
 Thm MyLemma(#m: {dim,dim}[exp,exp].exp) : [
   (-> [b : bool] [p : (path {_} bool b tt)] (* bool (path {_} bool tt b)))
 ] by [
-  lam b, p. {proj1 = `tt, proj2 = <i> `(hcom{0~>1} bool ,b [i=0 {j} (@ ,p j)] [i=1 {_} ,b])}
+  lam b, p. {`tt, <i> `(hcom{0~>1} bool ,b [i=0 {j} (@ ,p j)] [i=1 {_} ,b])}
 ].
 
 Thm UsingLemma : [
   (path {_} bool tt tt)
 ] by [
-  let {proj2 = lem} = (MyLemma {i j} [x y] (@ (abs {_} y) i)) [`tt, <_> `tt].
+  let {_,lem} = (MyLemma {i j} [x y] (@ (abs {_} y) i)) [`tt, <_> `tt].
   use lem
 ].
 

--- a/test/success/num.prl
+++ b/test/success/num.prl
@@ -35,11 +35,12 @@ Thm Pred : [
 Tac SimpleNatRecEq = [
   query gl <- goal.
   match [gl:jdg] {
-    [n,z,s,ty | #jdg{(nat-rec %n %z [x y] (%s x y)) in %ty} => {
-      refine nat/eq/nat-rec; [`%ty]; auto
-    }]
+    [n,z,s,ty | #jdg{(nat-rec %n %z [x y] (%s x y)) in %ty} =>
+      refine nat/eq/nat-rec; [`%ty]; auto]
   }
 ].
+
+Print SimpleNatRecEq.
 
 Thm Plus : [
   (-> nat nat nat)
@@ -83,6 +84,7 @@ Thm Plus/succ/L : [
 ] by [
   lam n, m. auto; refine fun/eq/app; [`(-> nat nat)]; auto; SimpleNatRecEq
 ].
+
 
 Thm Plus/succ/R : [
   (-> [n m : nat] (= nat ($ Plus n (succ m)) (succ ($ Plus n m))))

--- a/test/success/record.prl
+++ b/test/success/record.prl
@@ -49,7 +49,7 @@ Thm RecordTest6 : [
     [p : (record [a : bool] [b c : record])]
     bool)
 ] by [
-  lam <a>. use a
+  lam {a}. use a
 ].
 
 Thm RecordTest7 : [
@@ -57,7 +57,7 @@ Thm RecordTest7 : [
    [a : S1]
    [b : (path {_} S1 a a)])
 ] by [
-  <a = `base, b = <i> `(loop i)>
+  {a = `base, b = <i> `(loop i)}
 ].
 
 Thm RecordElimTest : [
@@ -68,9 +68,9 @@ Thm RecordElimTest : [
     [p : (path {_} bool b b)])
    (* [b : bool] (path {_} bool b b)))
 ] by [
-  lam <b = welp, p = hello>.
-    <proj2 = use hello,
-     proj1 = use welp>
+  lam {b = welp, p = hello}.
+    {proj2 = use hello,
+     proj1 = use welp}
 ].
 
 Print RecordElimTest.

--- a/test/success/record.prl
+++ b/test/success/record.prl
@@ -49,7 +49,7 @@ Thm RecordTest6 : [
     [p : (record [a : bool] [b c : record])]
     bool)
 ] by [
-  lam {a}. use a
+  lam {a = a}. use a
 ].
 
 Thm RecordTest7 : [
@@ -69,8 +69,7 @@ Thm RecordElimTest : [
    (* [b : bool] (path {_} bool b b)))
 ] by [
   lam {b = welp, p = hello}.
-    {proj2 = use hello,
-     proj1 = use welp}
+    {use welp, use hello}
 ].
 
 Print RecordElimTest.

--- a/test/success/semi-simplicial.prl
+++ b/test/success/semi-simplicial.prl
@@ -1,24 +1,20 @@
 Tac EqNatRec = [
   query gl <- goal.
   match [gl:jdg] {
-    [n,z,s,ty | #jdg{(nat-rec %n %z [x y] (%s x y)) in %ty} => {
-      refine nat/eq/nat-rec; [`%ty]; auto
-    }]
-    [n,z,s,l | #jdg{(nat-rec %n %z [x y] (%s x y)) type at %l} => {
-      refine nat/eqtype/nat-rec; [`(U 0)]; auto
-    }]
+    [n,z,s,ty | #jdg{(nat-rec %n %z [x y] (%s x y)) in %ty} =>
+      refine nat/eq/nat-rec; [`%ty]; auto]
+    [n,z,s,l | #jdg{(nat-rec %n %z [x y] (%s x y)) type at %l} =>
+      refine nat/eqtype/nat-rec; [`(U 0)]; auto]
   }
 ].
 
 Tac NatArg = [
   query gl <- goal.
   match [gl:jdg] {
-    [tm, ty, l | #jdg{%tm in %ty at %l} => {
-      refine fun/eq/app; [`(-> nat %ty)]; auto
-    }]
-    [tm, l | #jdg{%tm type at %l} => {
-      refine fun/eqtype/app; [`(-> nat (U 0))]; auto
-    }]
+    [tm, ty, l | #jdg{%tm in %ty at %l} =>
+      refine fun/eq/app; [`(-> nat %ty)]; auto]
+    [tm, l | #jdg{%tm type at %l} =>
+      refine fun/eqtype/app; [`(-> nat (U 0))]; auto]
   }
 ].
 

--- a/test/success/semi-simplicial.prl
+++ b/test/success/semi-simplicial.prl
@@ -86,22 +86,22 @@ Thm Pick/compose : [
     , lam c. fresh c', c'/ih -> elim c;
       [ lam p1. elim p1
       , lam p1. ({Replace p1} ($ Pick/succ ,b' ,c'));
-        let < head = p1/h, tail = p1/t > = p1. elim p1/h;
+        let {head = p1/h, tail = p1/t} = p1. elim p1/h;
         [ lam p2. ({Replace p2} ($ Pick/succ ,a' ,b'));
-          let < head = p2/h, tail = p2/t > = p2. elim p2/h;
+          let {head = p2/h, tail = p2/t} = p2. elim p2/h;
           (ReplaceGoal ($ Pick/succ ,a' ,c'));
-          [ < head = `tt
+          [ { head = `tt
             , tail = `($ ,a'/ih ,b' ,c' ,p1/t ,p2/t)
-            >
-          , < head = `ff
+          }
+          , { head = `ff
             , tail = `($ ,b'/ih ,c' ,p1/t ,p2/t)
-            >
+            }
           ]
         , lam p2.
           (ReplaceGoal ($ Pick/succ ,a' ,c'));
-          < head = `ff
+          { head = `ff
           , tail = `($ ,c'/ih ,p1/t ,p2)
-          >
+          }
         ]
       ]
     ]

--- a/test/success/unfold.prl
+++ b/test/success/unfold.prl
@@ -3,12 +3,12 @@ Def Times(#A; #B) = [
 ].
 
 Tac Proj1{z:hyp} = [
-  let <proj1> = z.
+  let {proj1} = z.
   use proj1
 ].
 
 Tac Proj2{z:hyp} = [
-  let <proj2> = z.
+  let {proj2} = z.
   use proj2
 ].
 

--- a/test/success/unfold.prl
+++ b/test/success/unfold.prl
@@ -3,13 +3,13 @@ Def Times(#A; #B) = [
 ].
 
 Tac Proj1{z:hyp} = [
-  let {proj1} = z.
-  use proj1
+  let {x} = z.
+  use x
 ].
 
 Tac Proj2{z:hyp} = [
-  let {proj2} = z.
-  use proj2
+  let {welp, x} = z.
+  use x
 ].
 
 Thm Times/Proj(#A) : [

--- a/test/success/wbool-fhcom.prl
+++ b/test/success/wbool-fhcom.prl
@@ -4,7 +4,7 @@ Thm WBoolSym : [
    (path {_} wbool a b)
    (path {_} wbool b a))
 ] by [
-  {lam a, b, p. <i> 
-     exact (hcom{0 ~> 1} wbool ,a [i=0 {j} (@ ,p j)] [i=1 {_} ,a])};
+  (lam a, b, p. <i> 
+     exact (hcom{0 ~> 1} wbool ,a [i=0 {j} (@ ,p j)] [i=1 {_} ,a]));
   auto
 ].

--- a/test/wip/adjointify.prl
+++ b/test/wip/adjointify.prl
@@ -37,9 +37,9 @@ Def Iso(#A; #B) = [
    [coh2 : (-> [a : #A] (path {_} #A ($ from ($ to a)) a))])
 ].
 
-Thm Path/Symm{l:lvl} : [
+Thm Path/Symm(#l:lvl) : [
  (->
-  [ty : (U l kan)]
+  [ty : (U #l kan)]
   [a b : ty]
   (path {_} ty a b)
   (path {_} ty b a))
@@ -51,22 +51,22 @@ Thm Path/Symm{l:lvl} : [
        [i=1 {_} ,a])
 ].
 
-Thm Adointify{l:lvl} : [
+Thm Adointify(#l:lvl) : [
   (->
-   [ty1 : (U l kan)]
-   [ty2 : (U l kan)]
+   [ty1 : (U #l kan)]
+   [ty2 : (U #l kan)]
    (Iso ty1 ty2)
    (Equiv ty1 ty2))
 ] by [
-  lam ty1, ty2, <to, from, coh1, coh2>.
-    <to = use to,
+  lam ty1, ty2, {to, from, coh1, coh2}.
+    {to = use to,
      to/equiv =
        lam b.
-         <point =
-          <point = use from [use b],
-           ray = use coh1 [use b]>,
+         {point =
+          {point = use from [use b],
+           ray = use coh1 [use b]},
           rays =
-            lam <point = point1, ray = r1>, <point = point2, ray = r2>.
+            lam {point = point1, ray = r1}, {point = point2, ray = r2}.
 
               let alpha : [ (path {_} ,ty1 ($ ,from ,b) ($ ,from ($ ,to ,point1))) ] =
                 use {Path/Symm l}
@@ -101,6 +101,6 @@ Thm Adointify{l:lvl} : [
                let welp : [ (path {_} ,ty1 (@ ,point12 i) ,point1) ] =
                  id.
 
-               <point = use point12 [@i],
-                ray = ?>>>
+               {point = use point12 [@i],
+                ray = ?}}}
 ].

--- a/test/wip/adjointify.prl
+++ b/test/wip/adjointify.prl
@@ -58,7 +58,7 @@ Thm Adointify(#l:lvl) : [
    (Iso ty1 ty2)
    (Equiv ty1 ty2))
 ] by [
-  lam ty1, ty2, {to, from, coh1, coh2}.
+  lam ty1, ty2, {to=to, from=from, coh1=coh1, coh2=coh2}.
     {to = use to,
      to/equiv =
        lam b.
@@ -69,14 +69,14 @@ Thm Adointify(#l:lvl) : [
             lam {point = point1, ray = r1}, {point = point2, ray = r2}.
 
               let alpha : [ (path {_} ,ty1 ($ ,from ,b) ($ ,from ($ ,to ,point1))) ] =
-                use {Path/Symm l}
+                use (Path/Symm #l)
                   [use ty1,
                    use from [use to [use point1]],
                    use from [use b],
                    <i> use from [use r1 [@i]]].
 
               let beta : [ (path {_} ,ty1 ($ ,from ,b) ($ ,from ($ ,to ,point2))) ] =
-                use {Path/Symm l}
+                use (Path/Symm #l)
                   [use ty1,
                    use from [use to [use point2]],
                    use from [use b],


### PR DESCRIPTION
I didn't like the angle brackets; I felt they made things very hard to read. Open to better suggestions than this though.