### PR TITLE
Treat kinds as expressions

### DIFF
--- a/src/redprl/machine.fun
+++ b/src/redprl/machine.fun
@@ -608,8 +608,8 @@ struct
            (STEP @@ m || (syms, stk))
            (fn u => COMPAT @@ m || (syms, VPROJ (u, HOLE, f) :: stk))
 
-     | O.MONO (O.UNIVERSE _) $ _ || (_, []) => raise Final
-     | O.MONO (O.UNIVERSE _) $ _ || (syms, HCOM (dir, HOLE, cap, tubes) :: stk) =>
+     | O.MONO O.UNIVERSE $ _ || (_, []) => raise Final
+     | O.MONO O.UNIVERSE $ _ || (syms, HCOM (dir, HOLE, cap, tubes) :: stk) =>
        let
          val fcom =
            Syn.into @@ Syn.FCOM
@@ -619,7 +619,7 @@ struct
        in
          CRITICAL @@ fcom || (syms, stk)
        end
-     | O.MONO (O.UNIVERSE _) $ _ || (syms, COE (_, (u, _), coercee) :: stk) => CRITICAL @@ coercee || (SymSet.remove syms u, stk)
+     | O.MONO O.UNIVERSE $ _ || (syms, COE (_, (u, _), coercee) :: stk) => CRITICAL @@ coercee || (SymSet.remove syms u, stk)
 
      | _ => raise Stuck
 

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -15,6 +15,7 @@ struct
    | MATCH_CLAUSE of sort
    | PARAM_EXP of param_sort
    | LVL
+   | KIND
 
   val rec sortToString = 
     fn EXP => "exp"
@@ -25,6 +26,7 @@ struct
      | MATCH_CLAUSE tau => "match-clause"
      | PARAM_EXP sigma => "param-exp{" ^ paramSortToString sigma ^ "}"
      | LVL => "lvl"
+     | KIND => "kind"
 
   and paramSortToString = 
     fn DIM => "dim"
@@ -239,7 +241,7 @@ struct
    (* equality *)
    | EQUALITY
    (* universe *)
-   | UNIVERSE of kind
+   | UNIVERSE
 
 
    (* level expressions *)
@@ -247,11 +249,13 @@ struct
    | LPLUS of IntInf.int
    | LMAX of int
 
-   | JDG_EQ of bool * kind
-   | JDG_TRUE of bool * kind
-   | JDG_EQ_TYPE of bool * kind
-   | JDG_SUB_UNIVERSE of bool * kind
-   | JDG_SYNTH of bool * kind
+   | KCONST of kind
+
+   | JDG_EQ of bool
+   | JDG_TRUE of bool 
+   | JDG_EQ_TYPE of bool 
+   | JDG_SUB_UNIVERSE of bool 
+   | JDG_SYNTH of bool
 
    (* primitive tacticals and multitacticals *)
    | MTAC_SEQ of psort list | MTAC_ORELSE | MTAC_REC
@@ -383,20 +387,21 @@ struct
      | PATH_TY => [[DIM] * [] <> EXP, [] * [] <> EXP, [] * [] <> EXP] ->> EXP
      | PATH_ABS => [[DIM] * [] <> EXP] ->> EXP
 
-     | UNIVERSE _ => [[] * [] <> LVL] ->> EXP
+     | UNIVERSE => [[] * [] <> LVL, [] * [] <> KIND] ->> EXP
      | EQUALITY => [[] * [] <> EXP, [] * [] <> EXP, [] * [] <> EXP] ->> EXP
 
      | LCONST i => [] ->> LVL
      | LPLUS i => [[] * [] <> LVL] ->> LVL
      | LMAX n => List.tabulate (n, fn _ => [] * [] <> LVL) ->> LVL
 
+     | KCONST _ => [] ->> KIND
 
-     | JDG_EQ (b, k) => (if b then [[] * [] <> LVL] else []) @ [[] * [] <> EXP, [] * [] <> EXP, [] * [] <> EXP] ->> JDG
-     | JDG_TRUE (b, k) => (if b then [[] * [] <> LVL] else []) @ [[] * [] <> EXP] ->> JDG
-     | JDG_EQ_TYPE (b, k) => (if b then [[] * [] <> LVL] else []) @ [[] * [] <> EXP, [] * [] <> EXP] ->> JDG
-     | JDG_SUB_UNIVERSE (b, k) => (if b then [[] * [] <> LVL] else []) @ [[] * [] <> EXP] ->> JDG
-     | JDG_SYNTH (b, k) => (if b then [[] * [] <> LVL] else []) @ [[] * [] <> EXP] ->> JDG
 
+     | JDG_EQ b => (if b then [[] * [] <> LVL] else []) @ [[] * [] <> KIND, [] * [] <> EXP, [] * [] <> EXP, [] * [] <> EXP] ->> JDG
+     | JDG_TRUE b => (if b then [[] * [] <> LVL] else []) @ [[] * [] <> KIND, [] * [] <> EXP] ->> JDG
+     | JDG_EQ_TYPE b => (if b then [[] * [] <> LVL] else []) @ [[] * [] <> KIND, [] * [] <> EXP, [] * [] <> EXP] ->> JDG
+     | JDG_SUB_UNIVERSE b => (if b then [[] * [] <> LVL] else []) @ [[] * [] <> KIND, [] * [] <> EXP] ->> JDG
+     | JDG_SYNTH b => (if b then [[] * [] <> LVL] else []) @ [[] * [] <> KIND, [] * [] <> EXP] ->> JDG
 
      | MTAC_SEQ psorts => [[] * [] <> MTAC, psorts * [] <> MTAC] ->> MTAC
      | MTAC_ORELSE => [[] * [] <> MTAC, [] * [] <> MTAC] ->> MTAC
@@ -725,12 +730,14 @@ struct
      | PATH_TY => "path"
      | PATH_ABS => "abs"
 
-     | UNIVERSE k => "universe{" ^ K.toString k ^ "}"
+     | UNIVERSE => "U"
      | EQUALITY => "equality"
 
      | LCONST i => "{lconst " ^ IntInf.toString i  ^ "}"
      | LPLUS i => "{lsuc " ^ IntInf.toString i ^ "}"
      | LMAX n => "lmax"
+
+     | KCONST k => RedPrlKind.toString k
 
      | MTAC_SEQ psorts => "seq{" ^ ListSpine.pretty RedPrlParamSort.toString "," psorts ^ "}"
      | MTAC_ORELSE => "orelse"

--- a/src/redprl/pretty.sml
+++ b/src/redprl/pretty.sml
@@ -254,11 +254,8 @@ struct
          Atomic.parens @@ expr @@ hvsep @@ text "Vin" :: ppParam r :: List.map ppBinder args
      | O.POLY (O.VPROJ r) $ args =>
          Atomic.parens @@ expr @@ hvsep @@ text "Vproj" :: ppParam r :: List.map ppBinder args
-     | O.MONO (O.UNIVERSE k) $ [_ \ l] =>
-         if k = RedPrlKind.top then
-           Atomic.parens @@ expr @@ hvsep @@ [text "U", ppTerm l]
-         else
-           Atomic.parens @@ expr @@ hvsep @@ [text "U", ppTerm l, ppKind k]
+     | O.MONO O.UNIVERSE $ [_ \ l, _ \ k] =>
+         Atomic.parens @@ expr @@ hvsep @@ [text "U", ppTerm l, ppTerm k]
      | O.POLY (O.HCOM (dir, eqs)) $ (ty :: cap :: tubes) =>
          Atomic.parens @@ expr @@ hvsep @@
            hvsep [ppComHead "hcom" dir, ppBinder ty, ppBinder cap]

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -306,7 +306,7 @@ end
  (* parameter sorts *)
  | DIM | HYP | META_NAME
  (* sorts *)
- | EXP | TAC | TRIV | JDG | LVL
+ | EXP | TAC | TRIV | JDG | LVL | KIND
 
  (* keywords and symbols in parameters *)
  | LMAX
@@ -521,6 +521,7 @@ sort
   | TRIV (O.TRIV)
   | JDG (O.JDG)
   | LVL (P.LVL)
+  | KIND (P.KIND)
 
 sorts
   : sort ([sort])

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -261,10 +261,10 @@ end
 structure Jdg = 
 struct
   open Ast infix $$ \
-  fun makeAtLvl theta (lvl, k) es = 
+  fun makeAtLvl theta (lvl, k : ast) es = 
     case lvl of
-       NONE => O.MONO (theta (false, k)) $$ List.map (fn e => ([],[]) \ e) es
-     | SOME lvl => O.MONO (theta (true, k)) $$ List.map (fn e => ([],[]) \ e) (lvl :: es)
+       NONE => O.MONO (theta false) $$ List.map (fn e => ([],[]) \ e) (k :: es)
+     | SOME lvl => O.MONO (theta true) $$ List.map (fn e => ([],[]) \ e) (lvl :: k :: es)
 end
 
 %%
@@ -428,7 +428,7 @@ end
  | typedTerms of (ast * O.sort) list
 
  | kind of O.K.kind
- | withKindAtLevel of ast option * O.K.kind
+ | withKindAtLevel of ast option * ast
 
  | rawJudgment of ast
  | judgment of ast
@@ -647,6 +647,7 @@ monoNullaryOperator
   (* circle *)
   | S1 (O.MONO O.S1)
   | BASE (O.MONO O.BASE)
+  | kind (O.MONO (O.KCONST kind))
 
 (* built-in nullary operators that take parameters *)
 polyNullaryOperator
@@ -715,8 +716,8 @@ rawTermAndTac
   | LPAREN polyNullaryOperator RPAREN (Ast.$$ (polyNullaryOperator, []))
   | LPAREN regularMultinaryOperator bindings RPAREN (Ast.$$ (regularMultinaryOperator, bindings))
 
-  | LPAREN UNIVERSE level RPAREN (Ast.$$ (O.MONO (O.UNIVERSE RedPrlKind.top), [Ast.\ (([],[]), level)]))
-  | LPAREN UNIVERSE level kind RPAREN (Ast.$$ (O.MONO (O.UNIVERSE kind), [Ast.\ (([],[]), level)]))
+  | LPAREN UNIVERSE level RPAREN (Ast.$$ (O.MONO O.UNIVERSE, [Ast.\ (([],[]), level), Ast.\ (([],[]), Ast.$$ (O.MONO (O.KCONST RedPrlKind.top), []))]))
+  | LPAREN UNIVERSE level term RPAREN (Ast.$$ (O.MONO O.UNIVERSE, [Ast.\ (([],[]), level), Ast.\ (([],[]), term)]))
 
   (* compositions *)
   | LPAREN FCOM LBRACKET dir RBRACKET binding tubes RPAREN
@@ -794,11 +795,11 @@ kind
   | CUBICAL (O.K.CUBICAL)
 
 withKindAtLevel
-  : WITH kind AT level (SOME level, kind)
-  | AT level WITH kind (SOME level, kind)
-  | WITH kind (NONE, kind)
-  | AT level (SOME level, O.K.top)
-  | (NONE, O.K.top)
+  : WITH term AT level (SOME level, term)
+  | AT level WITH term (SOME level, term)
+  | WITH term (NONE, term)
+  | AT level (SOME level, Ast.$$ (O.MONO (O.KCONST (O.K.top)), []))
+  | (NONE, Ast.$$ (O.MONO (O.KCONST (O.K.top)), []))
 
 rawJudgment
   : term EQUALS term IN term withKindAtLevel (Jdg.makeAtLvl O.JDG_EQ withKindAtLevel [term1, term2, term3])

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -129,6 +129,7 @@ whitespace = [\ \t];
 
 "dim"              => (Tokens.DIM (posTuple (size yytext)));
 "lvl"              => (Tokens.LVL (posTuple (size yytext)));
+"kind"             => (Tokens.KIND (posTuple (size yytext)));
 "meta-name"        => (Tokens.META_NAME (posTuple (size yytext)));
 
 "lmax"             => (Tokens.LMAX (posTuple (size yytext)));

--- a/src/redprl/syntax.sml
+++ b/src/redprl/syntax.sml
@@ -242,7 +242,7 @@ struct
        | VIN (r, m, n) => O.POLY (O.VIN r) $$ [([],[]) \ m, ([],[]) \ n]
        | VPROJ (r, m, f) => O.POLY (O.VPROJ r) $$ [([],[]) \ m, ([],[]) \ f]
 
-       | UNIVERSE (l, k) => O.MONO (O.UNIVERSE k) $$ [([],[]) \ L.into l]
+       | UNIVERSE (l, k) => O.MONO O.UNIVERSE $$ [([],[]) \ L.into l, ([],[]) \ (O.MONO (O.KCONST k) $$ [])]
 
        | HCOM args => intoHcom args
        | COE {dir, ty = (u, a), coercee} =>
@@ -331,7 +331,12 @@ struct
        | O.POLY (O.VIN r) $ [_ \ m, _ \ n] => VIN (r, m, n)
        | O.POLY (O.VPROJ r) $ [_ \ m, _ \ f] => VPROJ (r, m, f)
 
-       | O.MONO (O.UNIVERSE k) $ [_ \ l] => UNIVERSE (L.out l, k)
+       | O.MONO O.UNIVERSE $ [_ \ l, _ \ k] =>
+         let
+           val O.MONO (O.KCONST k) $ _ = Tm.out k
+         in
+           UNIVERSE (L.out l, k)
+         end
 
        | O.POLY (O.HCOM (dir, eqs)) $ (_ \ ty) :: (_ \ cap) :: tubes =>
            HCOM {dir = dir, ty = ty, cap = cap, tubes = outTubes (eqs, tubes)}

--- a/test/examples.prl
+++ b/test/examples.prl
@@ -208,7 +208,7 @@ Print FunExt.
 Tac FunExtTac(#l : lvl) = [
   query gl <- goal.
   match [gl:jdg] {
-    [a, b, f, g | #jdg{(path {_} (-> %a %b) %f %g) true} =>
+    [a, b, f, g, k| #jdg{(path {_} (-> %a %b) %f %g) true with %[k:kind]} =>
       use (FunExt #l) [`%a, `%b, `%f, `%g, id]
     ]
   }


### PR DESCRIPTION
This lets us do unification and matching in tactics with kinds.

No support is yet available for "kind-polymorphic assertions": things just fail if a kind is a metavariable rather than a constant. That's ok for now, since that's a separate issue.