### PR TITLE
idea: for 'program tactics', *REQUIRE* auto to completely discharge aux goals

### DIFF
--- a/src/redprl/tactic_elaborator.fun
+++ b/src/redprl/tactic_elaborator.fun
@@ -63,7 +63,7 @@ struct
 
   val autoMtac = mrepeat o all o try o R.AutoStep
   val autoTac = multitacToTac o autoMtac
-  fun autoTacComplete sign = autoTac sign then_ fail "'auto' failed to discharge this auxiliary goal"
+  fun autoTacComplete sign = try (autoTac sign then_ fail "'auto' failed to discharge this auxiliary goal")
 
   fun unfoldCustomOperator sign (opid, args) = 
     Sig.unfoldCustomOperator (Sig.lookup sign opid) args

--- a/test/success/V-types.prl
+++ b/test/success/V-types.prl
@@ -108,7 +108,7 @@ Thm NotIsEquiv : [
   lam b.
   { {`($ Not b), <_> use b}
   , lam {_,p'}.
-      fresh i:dim -> refine path/intro; [
+     (<i>
         { `($ Not (hcom 1~>0 bool b
                     [i=0 [j] (@ p' j)]
                     [i=1 [j] b]))
@@ -116,7 +116,7 @@ Thm NotIsEquiv : [
                 [i=0 [j] (@ p' j)]
                 [i=1 [j] b])
         }
-      ];
+      );
       auto; (Bool/contra/inverse p')
   }
 ].

--- a/test/success/V-types.prl
+++ b/test/success/V-types.prl
@@ -108,16 +108,16 @@ Thm NotIsEquiv : [
   lam b.
   { {`($ Not b), <_> use b}
   , lam {_,p'}.
-        (<i>
-          { `($ Not (hcom 1~>0 bool b
-                     [i=0 [j] (@ p' j)]
-                     [i=1 [j] b]))
-          , <j> `(hcom 1~>j bool b
-                  [i=0 [j] (@ p' j)]
-                  [i=1 [j] b])
-          }
-        );
-        (Bool/contra/inverse p')
+      fresh i:dim -> refine path/intro; [
+        { `($ Not (hcom 1~>0 bool b
+                    [i=0 [j] (@ p' j)]
+                    [i=1 [j] b]))
+        , <j> `(hcom 1~>j bool b
+                [i=0 [j] (@ p' j)]
+                [i=1 [j] b])
+        }
+      ];
+      auto; (Bool/contra/inverse p')
   }
 ].
 

--- a/test/success/pi1s1.prl
+++ b/test/success/pi1s1.prl
@@ -59,9 +59,12 @@ Thm IntSuccIsEquiv : [
           rewrite eq0;
           [`(= int ($ IntPred i'') i'), `($ IntPredIntSucc i')];
           auto.
-        (<x>
+
+        fresh x:dim -> refine path/intro; [
           {`($ IntPred i), <y> `(hcom 1~>y int i [x=0 [y] (@ p' y)] [x=1 [_] i])}
-        ); fresh eq1' -> elim eq1; unfold IntPred in eq1'; reduce in eq1'; auto
+        ];
+        
+        auto; fresh eq1' -> elim eq1; unfold IntPred in eq1'; reduce in eq1'; auto
     }
 ].
 

--- a/test/success/pi1s1.prl
+++ b/test/success/pi1s1.prl
@@ -60,9 +60,8 @@ Thm IntSuccIsEquiv : [
           [`(= int ($ IntPred i'') i'), `($ IntPredIntSucc i')];
           auto.
 
-        fresh x:dim -> refine path/intro; [
-          {`($ IntPred i), <y> `(hcom 1~>y int i [x=0 [y] (@ p' y)] [x=1 [_] i])}
-        ];
+        (<x>
+          {`($ IntPred i), <y> `(hcom 1~>y int i [x=0 [y] (@ p' y)] [x=1 [_] i])});
         
         auto; fresh eq1' -> elim eq1; unfold IntPred in eq1'; reduce in eq1'; auto
     }


### PR DESCRIPTION
If `auto` doesn't completely discharge the auxiliary subgoals, require the user to use a low-level script. This makes problems easier to diagnose, since otherwise the user is left in the middle of a weird proof search state which might have impossible goals.

Another less drastic option would be to make these program tactics still work if auto doesn't discharge the subgoals, but return these subgoals in their initial state rather than where 'auto' left off.

@cangiuli What do you think of this?