### PR TITLE
fix issue #442

### DIFF
--- a/src/redprl/error.sig
+++ b/src/redprl/error.sig
@@ -8,6 +8,7 @@ struct
    | NOT_APPLICABLE of Fpp.doc * Fpp.doc
    | UNIMPLEMENTED of Fpp.doc
    | GENERIC of Fpp.doc list
+   | INCORRECT_ARITY of RedPrlAst.ast * RedPrlArity.t
 end
 
 signature REDPRL_ERROR =

--- a/src/redprl/error.sml
+++ b/src/redprl/error.sml
@@ -35,6 +35,10 @@ struct
         [tool, Fpp.text "is not applicable to:", Fpp.nest 2 obj]
      | UNIMPLEMENTED doc => Fpp.hsep
         [Fpp.text "Not implemented:", Fpp.nest 2 doc]
+     | INCORRECT_ARITY (ast, ar) =>
+        Fpp.vsep
+          [Fpp.hsep [Fpp.text "Incorrect arity in term:", Fpp.text (RedPrlAst.toString ast)],
+           Fpp.hsep [Fpp.text "Expected: ", Fpp.text (RedPrlArity.toString ar)]]
      | GENERIC doc => Fpp.hsep doc
 
   val rec format =

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -145,11 +145,14 @@ struct
            end
          | th $ es =>
            let
-             val th' = processOp (getAnnotation m) sign varctx th
-             val (vls, _) = Tm.O.arity th'
-             val es' = ListPair.map (fn (e, vl) => processBinder sign varctx vl e) (es, vls)
+             val pos = getAnnotation m
+             val th' = processOp pos sign varctx th
+             val ar as (vls, _) = Tm.O.arity th'
            in
-             th' $$ es'
+             if List.length vls = List.length es then
+               th' $$ ListPair.map (fn (e, vl) => processBinder sign varctx vl e) (es, vls)
+             else
+               RedPrlError.raiseAnnotatedError' (pos, RedPrlError.INCORRECT_ARITY (m, ar))
            end
          | x $# ms => x $$# List.map (processTerm sign varctx) ms
 


### PR DESCRIPTION
Fixing this was a tiny bit subtle; one can't just use `mapEq` and catch `UnequalLengths`, because this might come from one of the recursive calls.