### PR TITLE
Update mlton compile options

### DIFF
--- a/script/mlton.sh
+++ b/script/mlton.sh
@@ -6,4 +6,4 @@ mlyacc src/redprl/redprl.grm
 mllex src/redprl/redprl.lex
 
 mkdir -p bin
-mlton -native-live-transfer 0 -verbose 2 -mlb-path-var "LIBS $LIBS" -output bin/redprl src/frontend.mlb
+mlton -verbose 2 -polyvariance false -mlb-path-var "LIBS $LIBS" -output bin/redprl src/frontend.mlb

--- a/script/profile.sh
+++ b/script/profile.sh
@@ -6,4 +6,4 @@ mlyacc src/redprl/redprl.grm
 mllex src/redprl/redprl.lex
 
 mkdir -p bin
-mlton -profile time -mlb-path-var "LIBS $LIBS" -output bin/redprl-profile src/frontend.mlb
+mlton -profile time -polyvariance false -mlb-path-var "LIBS $LIBS" -output bin/redprl-profile src/frontend.mlb


### PR DESCRIPTION
Closes RedPRL/sml-redprl#437

MLton's `polyvariance` optimization duplicates small higher-order
functions.

One (unresolved, though usually not significant) issue is that
polyvariance can duplicate code local to a function, even if it
doesn't depend on the higher-orderness (see
http://www.mlton.org/pipermail/mlton-devel/2002-January/021211.html).
This seems consistent with the discussion at MLton/mlton#196.