### PR TITLE
Update README to point to example/.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ ML installed. Then, simply run
 Then, a binary will be placed in `./bin/redprl`, which you may run as
 follows
 
-    ./bin/redprl test/examples.prl
+    ./bin/redprl example/univalence.prl
 
 
 ### Editor Support: Visual Studio Code

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ ML installed. Then, simply run
 Then, a binary will be placed in `./bin/redprl`, which you may run as
 follows
 
-    ./bin/redprl example/univalence.prl
+    ./bin/redprl example/README.prl
 
 
 ### Editor Support: Visual Studio Code


### PR DESCRIPTION
The README currently points to a nonexistent file. I'm changing it to point to the univalence development.