### PR TITLE
Remove most kind annotations.

### DIFF
--- a/example/README.prl
+++ b/example/README.prl
@@ -192,7 +192,7 @@ Print FunExt.
 Tac FunExtTac(#l : lvl) = [
   query gl <- concl;
   match gl {
-    [a b f g k | #jdg{(path [_] (-> %a %b) %f %g) true with %[k:knd]} =>
+    [a b f g | #jdg{(path [_] (-> %a %b) %f %g) true} =>
       use (FunExt #l) [`%a, `%b, `%f, `%g, id]
     ]
   }

--- a/example/univalence.prl
+++ b/example/univalence.prl
@@ -15,7 +15,10 @@ Def Retract (#A,#f,#g) = [(-> [a : #A] (path [_] #A ($ #g ($ #f a)) a))].
 Tac ReflectUniv(#l:lvl, #k:knd, #t:tac) = [
   query goal <- concl;
   match goal {
-    [a b k l | #jdg{%a = %b type at %l with %[k:knd]} =>
+    [a b l k | #jdg{%a = %b type at %l with %[k:knd]} =>
+      claim aux : [%a = %b in (U #l #k)] by [#t]; auto
+    ]
+    [a b k | #jdg{%a = %b type with %[k:knd]} =>
       claim aux : [%a = %b in (U #l #k)] by [#t]; auto
     ]
   }

--- a/src/redprl/atomic_judgment.sig
+++ b/src/redprl/atomic_judgment.sig
@@ -10,29 +10,29 @@ struct
   in
     datatype jdg =
 
-     (* `EQ ((m, n), (a, l, k))`:
-      *   `EQ_TYPE ((a, a), l, k)` and `m` and `n` are related by the PER
-      *   associated with `a`. Moreover, `a` was already defined at the
-      *   `l'`th iteration if `l = SOME l'`. If `l = NONE` it means `a`
-      *   was defined at some level but we do not care.
+     (* `EQ ((m, n), (a, l))`:
+      *   Already in the `l`th iteration of universe hierarchy construction,
+      *   the term `a` was associated with a PER and terms `m` and `n` were
+      *   related by that PER.
+      *
       *   The realizer is `TV` of sort `TRV`.
       *)
-       EQ of (abt * abt) * (abt * level * kind)
+       EQ of (abt * abt) * (abt * level)
 
-     (* `TRUE (a, l, k)`:
-      *   `EQ_TYPE ((a, a), l, k)` and there exists a term `m` such that
-      *   `EQ ((m, m), (a, l, k))` is provable.
+     (* `TRUE (a, l)`:
+      *   Already in the `l`th iteration of universe hierarchy construction,
+      *   the term `a` was associated with a PER and there existed a term `m`
+      *   such that `m` was related to itself in that PER.
+      *
       *   The realizer is such an `m` of sort `EXP`.
       *)
-     | TRUE of abt * level * kind
+     | TRUE of abt * level
 
      (* `EQ_TYPE ((a, b), l, k)`:
-      *   `a` and `b` are equal types, even taking into the structures
-      *   specified by `k`. Both were already defined at the `l'`th iteration
-      *   if `l = SOME l'`. If `l = NONE` it means both will be defined
-      *   eventually but we do not care about when. For example,
-      *   `EQ_TYPE ((a, b), SOME 2, KAN)` means `a` and `b` are equally Kan
-      *   in the second iterated type theory.
+      *   Already in the `l`th iteration of universe hierarchy construction,
+      *   `a` and `b` are equal types and have equal structures specified by `k`.
+      *   This implies they have the same PER.
+      *
       *   The realizer is `TV` of sort `TRV`.
       *)
      | EQ_TYPE of (abt * abt) * level * kind
@@ -42,14 +42,17 @@ struct
       *)
      | SUB_UNIVERSE of abt * level * kind
 
-     (* `TERM tau`:
-      *   There exists some `m` of sort `tau`.
-      *   The realizer is such an `m` of sort `tau`.
+     (* `SYNTH (m, l)`:
+      *   Already in the `l`th iteration of universe hierarchy construction,
+      *   there existed a term `a` associated with a PER and the term `m`
+      *   was related to itself in that PER.
+      *
+      *   The realizer is such an `a` of sort `exp`.
       *)
-     | SYNTH of abt * level * kind
+     | SYNTH of abt * level
 
      (* `TERM tau`:
-      *   There exists some `m` of sort `tau`.
+      *   There exists some term `m` of sort `tau`.
       *   The realizer is such an `m` of sort `tau`.
       *)
      | TERM of sort
@@ -63,8 +66,8 @@ sig
   type level = RedPrlLevel.t
   type kind = RedPrlKind.t
 
-  val MEM : abt * (abt * level * RedPrlKind.t) -> jdg
   val TYPE : abt * level * RedPrlKind.t -> jdg
+  val MEM : abt * (abt * level) -> jdg
 
   val map : (abt -> abt) -> jdg -> jdg
 

--- a/src/redprl/atomic_judgment.sml
+++ b/src/redprl/atomic_judgment.sml
@@ -3,18 +3,18 @@ struct
   open RedPrlAtomicJudgmentData
   type abt = RedPrlAbt.abt
 
-  fun MEM (m, (a, l, k)) =
-    EQ ((m, m), (a, l, k))
+  fun MEM (m, (a, l)) =
+    EQ ((m, m), (a, l))
 
   fun TYPE (a, l, k) =
     EQ_TYPE ((a, a), l, k)
 
   fun map f =
-    fn EQ ((m, n), (a, l, k)) => EQ ((f m, f n), (f a, RedPrlLevel.map f l, k))
-     | TRUE (a, l, k) => TRUE (f a, RedPrlLevel.map f l, k)
+    fn EQ ((m, n), (a, l)) => EQ ((f m, f n), (f a, RedPrlLevel.map f l))
+     | TRUE (a, l) => TRUE (f a, RedPrlLevel.map f l)
      | EQ_TYPE ((a, b), l, k) => EQ_TYPE ((f a, f b), RedPrlLevel.map f l, k)
      | SUB_UNIVERSE (u, l, k) => SUB_UNIVERSE (f u, RedPrlLevel.map f l, k)
-     | SYNTH (a, l, k) => SYNTH (f a, RedPrlLevel.map f l, k)
+     | SYNTH (a, l) => SYNTH (f a, RedPrlLevel.map f l)
      | TERM tau => TERM tau
 
   fun @@ (f, x) = f x
@@ -24,21 +24,15 @@ struct
     open Fpp
   in
     val pretty =
-      fn EQ ((m, n), (a, l, k)) => expr @@ hvsep @@ List.concat
+      fn EQ ((m, n), (a, l)) => expr @@ hvsep @@ List.concat
            [ if RedPrlAbt.eq (m, n) then [TermPrinter.ppTerm m]
              else [TermPrinter.ppTerm m, Atomic.equals, TermPrinter.ppTerm n]
            , [hsep [text "in", TermPrinter.ppTerm a]]
-           , if RedPrlLevel.eq (l, RedPrlLevel.top) then []
-             else [hsep [text "at", RedPrlLevel.pretty l]]
-           , if k = RedPrlKind.top then []
-             else [hsep [text "with", TermPrinter.ppKind k]]
+           , [hsep [text "at", RedPrlLevel.pretty l]]
            ]
-       | TRUE (a, l, k) => expr @@ hvsep @@ List.concat
-           [ [TermPrinter.ppTerm a]
-           , if RedPrlLevel.eq (l, RedPrlLevel.top) then []
-             else [hsep [text "at", RedPrlLevel.pretty l]]
-           , if k = RedPrlKind.top then []
-             else [hsep [text "with", TermPrinter.ppKind k]]
+       | TRUE (a, l) => expr @@ hvsep
+           [ TermPrinter.ppTerm a
+           , hsep [text "at", RedPrlLevel.pretty l]
            ]
        | EQ_TYPE ((a, b), l, k) => expr @@ hvsep @@ List.concat
            [ if RedPrlAbt.eq (a, b) then [TermPrinter.ppTerm a]
@@ -52,18 +46,11 @@ struct
        | SUB_UNIVERSE (u, l, k) => expr @@ hvsep
            [ TermPrinter.ppTerm u
            , text "<="
-           , Atomic.parens @@ expr @@ hsep
-               [ text "U"
-               , RedPrlLevel.pretty l
-               , if k = RedPrlKind.top then empty else TermPrinter.ppKind k
-               ]
+           , TermPrinter.ppTerm (Syntax.intoU (l, k))
            ]
-       | SYNTH (m, l, k) => expr @@ hvsep @@ List.concat
-           [ [TermPrinter.ppTerm m, text "synth"]
-           , if RedPrlLevel.eq (l, RedPrlLevel.top) then []
-             else [hsep [text "at", RedPrlLevel.pretty l]]
-           , if k = RedPrlKind.top then []
-             else [hsep [hsep [text "with", TermPrinter.ppKind k]]]
+       | SYNTH (m, l) => expr @@ hvsep
+           [ TermPrinter.ppTerm m, text "synth"
+           , hsep [text "at", RedPrlLevel.pretty l]
            ]
        | TERM tau => TermPrinter.ppSort tau
   end
@@ -84,30 +71,30 @@ struct
     structure O = RedPrlOpData
     infix $ $$ \
   in
-    fun kconst k = 
+    fun kconst k =
       O.KCONST k $$ []
 
     val into : jdg -> abt =
-      fn EQ ((m, n), (a, l, k)) => O.JDG_EQ $$ [[] \ L.into l, [] \ kconst k, [] \ m, [] \ n, [] \ a]
-       | TRUE (a, l, k) => O.JDG_TRUE $$ [[] \ L.into l, [] \ kconst k, [] \ a]
+      fn EQ ((m, n), (a, l)) => O.JDG_EQ $$ [[] \ L.into l, [] \ m, [] \ n, [] \ a]
+       | TRUE (a, l) => O.JDG_TRUE $$ [[] \ L.into l, [] \ a]
        | EQ_TYPE ((a, b), l, k) => O.JDG_EQ_TYPE $$ [[] \ L.into l, [] \ kconst k, [] \ a, [] \ b]
        | SUB_UNIVERSE (u, l, k) => O.JDG_SUB_UNIVERSE $$ [[] \ L.into l, [] \ kconst k, [] \ u]
-       | SYNTH (m, l, k) => O.JDG_SYNTH $$ [[] \ L.into l, [] \ kconst k, [] \ m]
+       | SYNTH (m, l) => O.JDG_SYNTH $$ [[] \ L.into l, [] \ m]
 
        | TERM tau => O.JDG_TERM tau $$ []
 
-    fun outk kexpr = 
+    fun outk kexpr =
       case RedPrlAbt.out kexpr of
          O.KCONST k $ _ => k
        | _ => raise RedPrlError.error [Fpp.text "Invalid kind expression"]
 
     fun out jdg =
       case RedPrlAbt.out jdg of
-         O.JDG_EQ $ [_ \ l, _ \ k, _ \ m, _ \ n, _ \ a] => EQ ((m, n), (a, L.out l, outk k))
-       | O.JDG_TRUE $ [_ \ l, _ \ k, _ \ a] => TRUE (a, L.out l, outk k)
+         O.JDG_EQ $ [_ \ l, _ \ m, _ \ n, _ \ a] => EQ ((m, n), (a, L.out l))
+       | O.JDG_TRUE $ [_ \ l, _ \ a] => TRUE (a, L.out l)
        | O.JDG_EQ_TYPE $ [_ \ l, _ \ k, _ \ a, _ \ b] => EQ_TYPE ((a, b), L.out l, outk k)
        | O.JDG_SUB_UNIVERSE $ [_ \ l, _ \ k, _ \ u] => SUB_UNIVERSE (u, L.out l, outk k)
-       | O.JDG_SYNTH $ [_ \ l, _ \ k, _ \ m] => SYNTH (m, L.out l, outk k)
+       | O.JDG_SYNTH $ [_ \ l, _ \ m] => SYNTH (m, L.out l)
 
        | O.JDG_TERM tau $ [] => TERM tau
        | _ => raise RedPrlError.error [Fpp.text "Invalid judgment:", TermPrinter.ppTerm jdg]

--- a/src/redprl/operator.sml
+++ b/src/redprl/operator.sml
@@ -366,11 +366,11 @@ struct
      | KCONST _ => [] ->> KND
 
 
-     | JDG_EQ => [[] |: LVL, [] |: KND, [] |: EXP, [] |: EXP, [] |: EXP] ->> JDG
-     | JDG_TRUE => [[] |: LVL, [] |: KND, [] |: EXP] ->> JDG
+     | JDG_EQ => [[] |: LVL, [] |: EXP, [] |: EXP, [] |: EXP] ->> JDG
+     | JDG_TRUE => [[] |: LVL, [] |: EXP] ->> JDG
      | JDG_EQ_TYPE => [[] |: LVL, [] |: KND, [] |: EXP, [] |: EXP] ->> JDG
      | JDG_SUB_UNIVERSE => [[] |: LVL, [] |: KND, [] |: EXP] ->> JDG
-     | JDG_SYNTH => [[] |: LVL, [] |: KND, [] |: EXP] ->> JDG
+     | JDG_SYNTH => [[] |: LVL, [] |: EXP] ->> JDG
 
      | MTAC_SEQ sorts => [[] |: MTAC, sorts |: MTAC] ->> MTAC
      | MTAC_ORELSE => [[] |: MTAC, [] |: MTAC] ->> MTAC

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -272,7 +272,9 @@ end
 structure Jdg = 
 struct
   open Ast infix $$ \
-  fun makeAtLvl theta (lvl, k : ast) es = 
+  fun makeAtLvl theta (lvl : ast) es =
+     theta $$ List.map (fn e => [] \ e) (lvl :: es)
+  fun makeAtLvlWithKind theta (lvl : ast, k) es =
      theta $$ List.map (fn e => [] \ e) (lvl :: k :: es)
 end
 
@@ -431,7 +433,8 @@ end
  | terms of ast list
 
  | kind of O.K.kind
- | withKindAtLevel of ast * ast
+ | atLevel of ast
+ | atLevelWithKind of ast * ast
 
  | rawJudgment of ast
  | judgment of ast
@@ -782,21 +785,25 @@ kind
   | COE (O.K.COE)
   | STABLE (O.K.STABLE)
 
-withKindAtLevel
+atLevel
+  : AT level (level)
+  | (Ast.$$ (O.LOMEGA, []))
+
+atLevelWithKind
   : WITH term AT level (level, term)
   | AT level WITH term (level, term)
   | WITH term (Ast.$$ (O.LOMEGA, []), term)
-  | AT level (level, Ast.$$ (O.KCONST (O.K.top), []))
-  | (Ast.$$ (O.LOMEGA, []), Ast.$$ (O.KCONST (O.K.top), []))
+  | AT level (level, Ast.$$ (O.KCONST O.K.top, []))
+  | (Ast.$$ (O.LOMEGA, []), Ast.$$ (O.KCONST O.K.top, []))
 
 rawJudgment
-  : term EQUALS term IN term withKindAtLevel (Jdg.makeAtLvl O.JDG_EQ withKindAtLevel [term1, term2, term3])
-  | term IN term withKindAtLevel (Jdg.makeAtLvl O.JDG_EQ withKindAtLevel [term1, term1, term2])
-  | term TRUE withKindAtLevel (Jdg.makeAtLvl O.JDG_TRUE withKindAtLevel [term])
-  | term withKindAtLevel (Jdg.makeAtLvl O.JDG_TRUE withKindAtLevel [term])
-  | term EQUALS term TYPE withKindAtLevel (Jdg.makeAtLvl O.JDG_EQ_TYPE withKindAtLevel [term1, term2])
-  | term TYPE withKindAtLevel (Jdg.makeAtLvl O.JDG_EQ_TYPE withKindAtLevel [term, term])
-  | term SYNTH withKindAtLevel (Jdg.makeAtLvl O.JDG_SYNTH withKindAtLevel [term])
+  : term EQUALS term IN term atLevel (Jdg.makeAtLvl O.JDG_EQ atLevel [term1, term2, term3])
+  | term IN term atLevel (Jdg.makeAtLvl O.JDG_EQ atLevel [term1, term1, term2])
+  | term TRUE atLevel (Jdg.makeAtLvl O.JDG_TRUE atLevel [term])
+  | term atLevel (Jdg.makeAtLvl O.JDG_TRUE atLevel [term])
+  | term EQUALS term TYPE atLevelWithKind (Jdg.makeAtLvlWithKind O.JDG_EQ_TYPE atLevelWithKind [term1, term2])
+  | term TYPE atLevelWithKind (Jdg.makeAtLvlWithKind O.JDG_EQ_TYPE atLevelWithKind [term, term])
+  | term SYNTH atLevel (Jdg.makeAtLvl O.JDG_SYNTH atLevel [term])
 
 judgment : rawJudgment (annotate (Pos.pos (rawJudgment1left fileName) (rawJudgment1right fileName)) rawJudgment)
 

--- a/src/redprl/tactic_elaborator.fun
+++ b/src/redprl/tactic_elaborator.fun
@@ -141,7 +141,7 @@ struct
   fun apply sign z names (appTac, contTac) alpha jdg = 
     let
       val H >> _ = jdg
-      val AJ.TRUE (ty, _, _) = RT.Hyps.lookup H z
+      val AJ.TRUE (ty, _) = RT.Hyps.lookup H z
     in
       case Syn.out ty of 
          Syn.FUN _ => (Lcf.rule o RT.Fun.Elim z thenl' (names, [appTac, contTac])) alpha jdg


### PR DESCRIPTION
The level checking is suboptimal because this patch was extracted from PR #466, but most level checking will be removed anyways.