### PR TITLE
Fix a few tiny "bugs"

### DIFF
--- a/src/redprl/name_seq.sml
+++ b/src/redprl/name_seq.sml
@@ -13,7 +13,7 @@ struct
         if i < n then
           List.nth (us, i)
         else
-          alpha (i + n)
+          alpha (i - n)
     end
 
   fun bite n alpha =

--- a/src/redprl/refiner_types.fun
+++ b/src/redprl/refiner_types.fun
@@ -1685,9 +1685,9 @@ struct
 
         (* glue branch *)
         val (goalTyC, holeTyC) = makeMatch (O.PUSHOUT, 2, holeTyPushout, [])
-        val v = alpha 2
+        val v = alpha 3
         val vtm = VarKit.toDim v
-        val c = alpha 3
+        val c = alpha 4
         val ctm = VarKit.toExp c
         val q0vc = VarKit.renameMany [(v, v0), (c, c0)] q0v0c0
         val q1vc = VarKit.renameMany [(v, v1), (c, c1)] q1v1c1

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -419,16 +419,11 @@ struct
       end
 
     fun elabDecl (sign : sign) opid (decl : src_decl, pos) : elab_sign =
-      let
-        val esign' = Telescope.truncateFrom (#elabSign sign) opid
-        val sign' = {sourceSign = #sourceSign sign, elabSign = esign', nameEnv = #nameEnv sign}
-      in
-        Telescope.snoc esign' opid (E.delay (fn _ =>
-          case processDecl sign decl of
-             DEF defn => elabDef sign' opid defn
-           | THM defn => elabThm sign' opid pos defn
-           | TAC defn => elabTac sign' opid defn))
-      end
+      Telescope.snoc (#elabSign sign) opid (E.delay (fn _ =>
+	case processDecl sign decl of
+	   DEF defn => elabDef sign opid defn
+	 | THM defn => elabThm sign opid pos defn
+	 | TAC defn => elabTac sign opid defn))
 
     fun elabPrint (sign : sign) (pos, opid : opid) =
       E.hush (Telescope.lookup (#elabSign sign) opid) >>= (fn edecl =>
@@ -474,11 +469,7 @@ struct
 
 
     fun insertAstDecl sign opid (decl, pos) =
-      let
-        val sign' = Telescope.truncateFrom sign opid
-      in
-        Telescope.snoc sign' opid (decl, pos)
-      end
+      Telescope.snoc sign opid (decl, pos)
       handle Telescope.Duplicate l => error pos [Fpp.text "Duplicate identitifier:", Fpp.text l]
 
   in

--- a/src/redprl/tactical.fun
+++ b/src/redprl/tactical.fun
@@ -60,9 +60,8 @@ struct
 
     fun seq (mt1 : multitactic, (us : Sym.t list, mt2 : multitactic)) : multitactic = fn alpha => fn st =>
       let
-        val beta = Spr.prepend us alpha
-        val (beta', modulus) = Spr.probe (Spr.prepend us beta)
-        val st' = mt1 beta' st
+        val (beta, modulus) = Spr.probe (Spr.prepend us alpha)
+        val st' = mt1 beta st
         val l = Int.max (0, !modulus - List.length us)
       in
         Lcf.M.mul (Lcf.M.map (mt2 (Spr.bite l alpha) o Lcf.mul Lcf.isjdg) st')


### PR DESCRIPTION
- `seq` was biting off unnecessarily many names
- Pushout.EqElim used `alpha 2` twice
- `insertAstDecl` and `elabDecl` were mysteriously truncating the input signature