### PR TITLE
Fix pretty printer of universe levels (#435)

### DIFF
--- a/src/redprl/list_util.sml
+++ b/src/redprl/list_util.sml
@@ -28,6 +28,14 @@ struct
       go 0
     end
 
+  fun revMap f l =
+    let
+      fun go [] acc = acc
+        | go (x :: xs) acc = go xs (f x :: acc)
+    in
+      go l []
+    end
+
   (* From MLton: https://github.com/MLton/mlton/blob/master/lib/mlton/basic/list.sml *)
   fun splitAt (xs, i) = 
     let

--- a/src/redprl/pretty.sml
+++ b/src/redprl/pretty.sml
@@ -277,6 +277,20 @@ struct
          [seq [ppTerm r1, Atomic.equals, ppTerm r2],
           nest 1 @@ ppTerm m]
      | O.MK_ANY _ $ [_ \ m] => ppTerm m
+
+     | O.LCONST i $ _ => ppIntInf i
+     | O.LPLUS 0 $ [_ \ l] => ppTerm l
+     | O.LPLUS 1 $ [_ \ l] => Atomic.parens @@ expr @@ hvsep @@ [text "++", ppTerm l]
+     | O.LPLUS i $ [_ \ l] => Atomic.parens @@ expr @@ hvsep @@ [text "+", ppTerm l, ppIntInf i]
+     | O.LMAX $ [_ \ vec] =>
+         (case RedPrlAbt.out vec of
+             O.MK_VEC _ $ [] => ppIntInf 0
+           | O.MK_VEC _ $ [_ \ t] => ppTerm t
+           | O.MK_VEC _ $ ts =>
+               Atomic.parens @@ expr @@ hvsep @@
+                 (text "lmax" :: List.rev (List.map (fn _ \ t => ppTerm t) ts))
+           | _ => raise Fail "invalid vector")
+
      | theta $ [] =>
         ppOperator theta
      | theta $ [[] \ arg] =>

--- a/src/redprl/pretty.sml
+++ b/src/redprl/pretty.sml
@@ -285,10 +285,10 @@ struct
      | O.LMAX $ [_ \ vec] =>
          (case RedPrlAbt.out vec of
              O.MK_VEC _ $ [] => ppIntInf 0
-           | O.MK_VEC _ $ [_ \ t] => ppTerm t
-           | O.MK_VEC _ $ ts =>
+           | O.MK_VEC _ $ [_ \ l] => ppTerm l
+           | O.MK_VEC _ $ ls =>
                Atomic.parens @@ expr @@ hvsep @@
-                 (text "lmax" :: List.rev (List.map (fn _ \ t => ppTerm t) ts))
+                 (text "lmax" :: ListUtil.revMap (fn _ \ l => ppTerm l) ls)
            | _ => raise Fail "invalid vector")
 
      | theta $ [] =>

--- a/src/redprl/refiner_kit.fun
+++ b/src/redprl/refiner_kit.fun
@@ -285,13 +285,13 @@ struct
       if L.<= (l1, l2) then
         ()
       else
-        raise E.error [Fpp.text "Expected level", L.pretty l1, Fpp.text "to be less than or equal to", L.pretty l2]
+        raise E.error [Fpp.text "Expected level", TermPrinter.ppTerm (L.into l1), Fpp.text "to be less than or equal to", TermPrinter.ppTerm (L.into l2)]
 
     fun levelEq (l1, l2) =
       if L.eq (l1, l2) then
         ()
       else
-        raise E.error [Fpp.text "Expected level", L.pretty l1, Fpp.text "to be equal to", L.pretty l2]
+        raise E.error [Fpp.text "Expected level", TermPrinter.ppTerm (L.into l1), Fpp.text "to be equal to", TermPrinter.ppTerm (L.into l2)]
 
     fun kindLeq (k1, k2) =
       if K.<= (k1, k2) then

--- a/src/redprl/refiner_types.fun
+++ b/src/redprl/refiner_types.fun
@@ -2402,8 +2402,9 @@ struct
             if member ((l0,k0), (l1,k1)) then ()
             else E.raiseError @@ E.GENERIC
               [Fpp.hvsep
-                [Fpp.text "Expected universe", L.pretty l0, TermPrinter.ppKind k0,
-                 Fpp.text "be at level", L.pretty l1, Fpp.text "with kind", TermPrinter.ppKind k1]]
+                [Fpp.text "Expected universe", TermPrinter.ppTerm (L.into l0), TermPrinter.ppKind k0,
+                 Fpp.text "be at level", TermPrinter.ppTerm (L.into l1),
+                 Fpp.text "with kind", TermPrinter.ppKind k1]]
         in
           fun univMem ((l0,k0), (l1,k1))  = Option.app (fn l1 => univMem' ((l0,k0), (l1,k1))) l1
         end

--- a/src/redprl/signature.sml
+++ b/src/redprl/signature.sml
@@ -22,8 +22,8 @@ struct
 
   fun prettyArgs args =
     Fpp.Atomic.parens @@ Fpp.grouped @@ Fpp.hvsep @@
-      intersperse (Fpp.text ";") @@
-        List.map (fn (x, vl) => Fpp.hsep [Fpp.text (Metavar.toString x), Fpp.Atomic.colon, TermPrinter.ppValence vl]) args
+      intersperse (Fpp.text ",") @@
+        List.map (fn (x, vl) => Fpp.hsep [Fpp.text ("#" ^ Metavar.toString x), Fpp.Atomic.colon, TermPrinter.ppValence vl]) args
 
   fun prettyEntry (_ : sign) (opid : opid, entry as {spec, state,...} : entry) : Fpp.doc =
     let

--- a/src/redprl/univ_level.sig
+++ b/src/redprl/univ_level.sig
@@ -18,8 +18,6 @@ sig
 
   val residual : level * level -> level option
 
-  val pretty : level -> Fpp.doc
-
   val into : level -> term
   val out : term -> level
   val map : (term -> term) -> level -> level


### PR DESCRIPTION
@favonia I took a first crack at this; please take a look. I have a few questions.

1. You have something more complicated in `univ_level.sml`, but I'm not clear on why this normalization code is necessary both on the input and the output. Do you want something fancier than what I've written, which already looks much better than the default pretty-printing?
2. Should we get rid of `RedPrlRawLevel.pretty` and instead use the main pretty-printer, once the latter is satisfactory?
3. Is there a `revMap` function lying around somewhere?
4. Why do the arguments to a `Thm` print as `i` and `j` in the argument list but `#i` and `#j` in the `Thm` body? Is this intended?