### PR TITLE
add an abstract type of metalanguage ids, use it for operator names

### DIFF
--- a/src/redprl/pretty.sml
+++ b/src/redprl/pretty.sml
@@ -56,8 +56,8 @@ struct
   val ppIntInf = text o IntInf.toString
 
   fun ppOperator theta =
-    case theta of 
-       O.CUST (opid, _) => text opid
+    case theta of
+       O.CUST (opid, _) => text @@ MlId.toString opid
      | _ => text @@ RedPrlOperator.toString theta
 
   val ppLabel = text

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -414,7 +414,7 @@ end
  | metavar of string
  | patvar of string * O.sort
  | patvarBindings of string list
- | customOpTerm of string * ast abs list
+ | customOpTerm of MlId.t * ast abs list
 
 
  | typedBinder of (string option list, ast) Multi.binder
@@ -483,14 +483,14 @@ end
  | selectors of ast list
  | accessor of ast
  | accessors of ast list
- | opnames of string list
+ | opnames of MlId.t list
 
  | declArgument of metavariable * Ar.valence
  | declArguments of Signature.Src.arguments
  | declArgumentsParens of Signature.Src.arguments
 
    (* a declaration, annotated with source position *)
- | decl of string * Signature.Src.decl * Pos.t
+ | decl of MlId.t * Signature.Src.decl * Pos.t
    (* a RedPRL signature *)
  | rawCmd of Signature.Src.cmd
  | cmd of Signature.Src.cmd * Pos.t
@@ -686,8 +686,8 @@ multinaryOperator
 
 
 customOpTerm
-  : OPNAME (OPNAME, [])
-  | LPAREN OPNAME bindings RPAREN (OPNAME, bindings)
+  : OPNAME (MlId.const OPNAME, [])
+  | LPAREN OPNAME bindings RPAREN (MlId.const OPNAME, bindings)
 
 patvar
   : PERCENT LSQUARE VARNAME COLON sort RSQUARE ((VARNAME, sort))
@@ -880,8 +880,8 @@ selectors
   | selector ([selector])
 
 opnames
-  : OPNAME opnames (OPNAME :: opnames)
-  | OPNAME ([OPNAME])
+  : OPNAME opnames (MlId.const OPNAME :: opnames)
+  | OPNAME ([MlId.const OPNAME])
 
 termAnySort
   : term (Ast.setAnnotation (Ast.getAnnotation term) (Ast.$$ (O.MK_ANY NONE, [Ast.\ ([], term)])))
@@ -1014,17 +1014,17 @@ declArgumentsParens
 
 decl
   : DCL_DEF OPNAME declArgumentsParens COLON sort EQUALS LSQUARE term RSQUARE
-      (OPNAME, Signature.Src.DEF {arguments = declArgumentsParens, definiens = term, sort = sort}, Pos.pos (OPNAMEleft fileName) (OPNAMEright fileName))
+      (MlId.const OPNAME, Signature.Src.DEF {arguments = declArgumentsParens, definiens = term, sort = sort}, Pos.pos (OPNAMEleft fileName) (OPNAMEright fileName))
   | DCL_DEF OPNAME declArgumentsParens EQUALS LSQUARE term RSQUARE
-      (OPNAME, Signature.Src.DEF {arguments = declArgumentsParens, definiens = term, sort = O.EXP}, Pos.pos (OPNAMEleft fileName) (OPNAMEright fileName))
+      (MlId.const OPNAME, Signature.Src.DEF {arguments = declArgumentsParens, definiens = term, sort = O.EXP}, Pos.pos (OPNAMEleft fileName) (OPNAMEright fileName))
   | DCL_TAC OPNAME declArgumentsParens EQUALS LSQUARE tactic RSQUARE
-      (OPNAME, Signature.Src.TAC {arguments = declArgumentsParens, script = tactic}, Pos.pos (OPNAMEleft fileName) (OPNAMEright fileName))
+      (MlId.const OPNAME, Signature.Src.TAC {arguments = declArgumentsParens, script = tactic}, Pos.pos (OPNAMEleft fileName) (OPNAMEright fileName))
   | DCL_THM OPNAME declArgumentsParens COLON LSQUARE src_atjdg RSQUARE BY LSQUARE tactic RSQUARE
-      (OPNAME, Signature.Src.THM {arguments = declArgumentsParens, goal = src_atjdg, script = tactic}, Pos.pos (OPNAMEleft fileName) (OPNAMEright fileName))
+      (MlId.const OPNAME, Signature.Src.THM {arguments = declArgumentsParens, goal = src_atjdg, script = tactic}, Pos.pos (OPNAMEleft fileName) (OPNAMEright fileName))
 
 rawCmd
-  : CMD_PRINT OPNAME (Signature.Src.PRINT OPNAME)
-  | CMD_EXTRACT OPNAME (Signature.Src.EXTRACT OPNAME)
+  : CMD_PRINT OPNAME (Signature.Src.PRINT (MlId.const OPNAME))
+  | CMD_EXTRACT OPNAME (Signature.Src.EXTRACT (MlId.const OPNAME))
   | CMD_QUIT (Signature.Src.QUIT)
 
 cmd : rawCmd (rawCmd, (Pos.pos (rawCmd1left fileName) (rawCmd1right fileName)))

--- a/src/redprl/signature/signature.sig
+++ b/src/redprl/signature/signature.sig
@@ -19,12 +19,12 @@ sig
      | TAC of {arguments : arguments, script : ast}
 
     datatype cmd =
-       PRINT of string
-     | EXTRACT of string
+       PRINT of MlId.t
+     | EXTRACT of MlId.t
      | QUIT
 
     datatype elt = 
-       DECL of string * decl * Pos.t
+       DECL of MlId.t * decl * Pos.t
      | CMD of cmd * Pos.t
 
     type sign = elt list

--- a/src/redprl/syntax/operator.sig
+++ b/src/redprl/syntax/operator.sig
@@ -1,6 +1,49 @@
+signature ML_ID = 
+sig
+  eqtype t
+
+  val eq : t * t -> bool
+  val compare : t * t -> order
+
+  val new : unit -> t
+  val fresh : string -> t
+  val const : string -> t
+  val toString : t -> string
+end
+
+structure MlId :> ML_ID = 
+struct
+  datatype t = CONST of string | VAR of int * string option
+
+  val eq : t * t -> bool = op=
+
+  val compare = 
+    fn (CONST s1, CONST s2) => String.compare (s1, s2)
+     | (VAR (i1, _), VAR (i2, _)) => Int.compare (i1, i2)
+     | (CONST _, VAR _) => LESS
+     | _ => GREATER
+
+  val counter = ref 0
+  
+  fun new () = 
+    (counter := !counter + 1;
+     VAR (!counter, NONE))
+  
+  fun const a = CONST a
+  
+  fun fresh str = 
+    (counter := !counter + 1;
+     VAR (!counter, SOME str))
+
+  val toString = 
+    fn CONST str => str
+     | VAR (i, NONE) => "$" ^ Int.toString i
+     | VAR (_, SOME str) => str
+end
+
 structure RedPrlOpData =
 struct
-  type opid = string (* TODO: structured representation to allow namespacing!! *)
+  type opid = MlId.t
 
   open RedPrlSort
   structure K = RedPrlKind

--- a/src/redprl/syntax/operator.sml
+++ b/src/redprl/syntax/operator.sml
@@ -174,7 +174,7 @@ struct
   fun eq (th1, th2) = th1 = th2
 
   val opidsToString =
-   ListUtil.joinWith (fn x => x) ","
+   ListUtil.joinWith MlId.toString ","
 
   val toString =
     fn AX => "ax"
@@ -307,7 +307,7 @@ struct
      | JDG_SUB_KIND => "sub-kind"
      | JDG_SYNTH => "synth"
      | JDG_TERM tau => RedPrlSort.toString tau
-     | CUST (opid, _) => opid
+     | CUST (opid, _) => MlId.toString opid
      | TAC_UNFOLD_ALL os => "unfold-all{" ^ opidsToString os ^ "}"
      | TAC_UNFOLD os => "unfold{" ^ opidsToString os ^ "}"
      | DEV_APPLY_LEMMA _ => "apply-lemma"


### PR DESCRIPTION
This is abstract, so we can be sure of freshness of names when we need to (in the signature language / metalanguage); but it is also `eqtype`, so it works well to be used for operator names.

This type can be thought of as the collection of all string constants, plus an infinite supply of unique / fresh names. `MlId.const` is functional, in the sense that `MlId.const str = MlConst.const str`. We use this for operator names at the moment because it simplifies name resolution, but later on we may wish to phase that out. Doesn't matter yet.

Because it is abstract, later on we can easily extend it to support things like namespacing.
  