### PR TITLE
Don't search the context during 'auto'

### DIFF
--- a/example/omega1s1.prl
+++ b/example/omega1s1.prl
@@ -52,7 +52,8 @@ Thm IntSuccIsEquiv : [
     claim eq : [(= int ($ IntSucc ($ IntPred i)) i)] by [use IntSuccIntPred [`i]];
     unfold IntSucc IntPred in eq; reduce at left in eq;
     {
-      {use IntPred [`i], abs _ => `i}
+      {use IntPred [`i], abs _ => `i};
+       symmetry; unfold IntSucc; reduce at left; assumption
     , lam {i',p'} =>
         claim eq0 : [(= int i ($ IntSucc i'))] by [`(coe 1~>0 [x] (= int i (@ p' x)) ax)];
         claim eq1 : [(= int ($ IntPred i) i')] by [
@@ -65,8 +66,10 @@ Thm IntSuccIsEquiv : [
         (abs x =>
           {`($ IntPred i), abs y => `(hcom 1~>y int i [x=0 [y] (@ p' y)] [x=1 [_] i])});
 
-        auto; unfold IntPred in eq1; reduce at left in eq1; auto
+        auto; unfold IntPred in eq1; reduce at left in eq1; auto; assumption
     }
+
+    // use eq; auto-step; auto-step; reduce at right; auto; ?
 ].
 
 Thm IntSuccEquiv : [

--- a/example/semi-simplicial.prl
+++ b/example/semi-simplicial.prl
@@ -15,6 +15,7 @@ Thm Pick : [
   auto
 ].
 
+
 Thm Pick/zero/L : [
   (-> [n : nat] (= (U 0) ($ Pick zero n) record))
 ] by [
@@ -38,12 +39,14 @@ Thm Pick/succ/0/succ/1 : [
   lam n m =>
     claim aux0 : [($ Pick n m) in (U 0)] by [auto];
     claim aux1 : [($ Pick (succ n) m) in (U 0)] by [auto];
-    unfold Pick; reduce at left in aux0; reduce at left in aux1; auto
+    unfold Pick; reduce at left in aux0; reduce at left in aux1; auto;
+    assumption
 ].
 
 Tac Replace(#z, #A) = [
   fresh ty -> rewrite #A in #z; [`ty]; auto
 ].
+
 
 Tac ReplaceGoal(#A:exp) = [
   fresh ty -> rewrite #A in concl; [`ty]; auto
@@ -118,7 +121,7 @@ Thm Pick/compose/tt/4/0/tt/5/0 : [
     reduce at type left right in aux0;
     reduce at left right in aux1;
     reduce at left in aux2;
-    auto
+    repeat {auto-step || assumption}
 ].
 
 Thm Pick/compose/tt/4/0/ff/5/0 : [
@@ -143,7 +146,7 @@ Thm Pick/compose/tt/4/0/ff/5/0 : [
     unfold Pick Pick/compose;
     reduce at type left right in aux0;
     reduce at left in aux2;
-    auto
+    repeat {auto-step || assumption}
 ].
 
 Thm Pick/compose/ff/4/0 : [
@@ -168,5 +171,5 @@ Thm Pick/compose/ff/4/0 : [
     unfold Pick Pick/compose;
     reduce at type left right in aux0;
     reduce at left in aux2;
-    auto
+    repeat {auto-step || assumption}
 ].

--- a/example/theorem-of-choice.prl
+++ b/example/theorem-of-choice.prl
@@ -10,7 +10,7 @@ Thm Choice(#i:lvl) : [
   lam a b r f =>
     {lam x => let {y,_} = f [`x]; `y,
      lam x => let {_,z} = f [`x]; `z};
-    fresh aux0 _ -> inversion; reduce at left in aux0; auto
+    fresh aux0 _ -> inversion; reduce at left in aux0; auto; assumption
 ].
 
 Print Choice.

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -78,6 +78,9 @@ struct
   val inversion = 
     O.DEV_INVERSION $$ []
 
+  val assumption = 
+    O.TAC_ASSUMPTION $$ []
+
 end
 
 structure Multi =
@@ -362,6 +365,7 @@ end
  | TAC_ID | TAC_FAIL | TAC_AUTO_STEP | TAC_SYMMETRY | TAC_ELIM | TAC_REWRITE | TAC_REDUCE | TAC_UNFOLD
  | RULE_EXACT
  | TAC_INVERSION
+ | TAC_ASSUMPTION
  | MATCH
  | QUERY | CONCL
  | PRINT
@@ -922,6 +926,7 @@ atomicRawTac
   | RULE_EXACT termAnySort (Tac.exact termAnySort)
 
   | TAC_INVERSION (Tac.inversion)
+  | TAC_ASSUMPTION (Tac.assumption)
 
   | atomicTac DOUBLE_PIPE tactic %prec DOUBLE_PIPE (Tac.orElse (atomicTac, tactic))
 

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -179,6 +179,7 @@ whitespace = [\ \t];
 "unfold"           => (Tokens.TAC_UNFOLD (posTuple (size yytext)));
 "exact"            => (Tokens.RULE_EXACT (posTuple (size yytext)));
 "inversion"        => (Tokens.TAC_INVERSION (posTuple (size yytext)));
+"assumption"       => (Tokens.TAC_ASSUMPTION (posTuple (size yytext)));
 
 "match"            => (Tokens.MATCH (posTuple (size yytext)));
 "query"            => (Tokens.QUERY (posTuple (size yytext)));

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -775,15 +775,16 @@ struct
           | (z, _) => fail @@ E.NOT_APPLICABLE (Fpp.text "TrueFromHyp", Fpp.hsep [Fpp.text "hyp", TermPrinter.ppVar z]))
 
       val NondetSynthFromHyp = NondetFromHypDelegate (fn (z, _) => SynthFromHyp z)
-
+    in
       val NondetStepJdgFromHyp = matchGoal
         (fn _ >> AJ.TRUE _ => NondetTrueFromHyp
           | _ >> AJ.EQ_TYPE _ => NondetEqTypeFromHyp
           | _ >> AJ.SYNTH _ => NondetSynthFromHyp
           | seq => fail @@ E.NOT_APPLICABLE (Fpp.text "non-deterministic search", Seq.pretty seq))
-    in
+
       fun AutoStep sign =
         StepJdg sign
+
     end
 
     local

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -784,8 +784,6 @@ struct
     in
       fun AutoStep sign =
         StepJdg sign
-          orelse_
-            NondetStepJdgFromHyp
     end
 
     local

--- a/src/redprl/refiner.sig
+++ b/src/redprl/refiner.sig
@@ -13,6 +13,8 @@ sig
   val CutLemma : sign -> abt -> rule
 
   val AutoStep : sign -> tactic
+  val NondetStepJdgFromHyp : tactic
+  
   val Elim : sign -> hyp -> tactic
   val Exact : abt -> tactic
   val Rewrite : sign -> hyp Selector.t * Accessor.t -> abt -> tactic

--- a/src/redprl/syntax/operator.sig
+++ b/src/redprl/syntax/operator.sig
@@ -81,7 +81,6 @@ struct
    | TAC_FAIL
    | TAC_MTAC
 
-   (* primitive rules *)
    | TAC_ID | TAC_AUTO_STEP | TAC_SYMMETRY | RULE_EXACT
    | RULE_CUT
    | RULE_PRIM of string
@@ -91,6 +90,7 @@ struct
    | TAC_REDUCE_ALL
    | TAC_REDUCE
    | TAC_REDUCE_PART
+   | TAC_ASSUMPTION
 
    (* development calculus terms *)
    | DEV_FUN_INTRO of unit dev_pattern list

--- a/src/redprl/syntax/operator.sml
+++ b/src/redprl/syntax/operator.sml
@@ -139,6 +139,8 @@ struct
      | TAC_ELIM => [[] |: ANY] ->> TAC
      | TAC_REWRITE => [[] |: SEL, [] |: ACC, [] |: EXP] ->> TAC
 
+     | TAC_ASSUMPTION => [] ->> TAC
+
      | DEV_FUN_INTRO pats => [List.concat (List.map devPatternValence pats) |: TAC] ->> TAC
      | DEV_RECORD_INTRO lbls => List.map (fn _ => [] |: TAC) lbls ->> TAC
      | DEV_PATH_INTRO n => [List.tabulate (n, fn _ => DIM) |: TAC] ->> TAC

--- a/src/redprl/tactic_elaborator.fun
+++ b/src/redprl/tactic_elaborator.fun
@@ -285,6 +285,7 @@ struct
      | O.TAC_REDUCE_PART $ [_ \ sel, _ \ accs] => Lcf.rule o R.Computation.ReducePart sign (Syn.outSelector sel, Syn.outVec' Syn.outAccessor accs)
      | O.TAC_UNFOLD_ALL opids $ _ => Lcf.rule o R.Custom.UnfoldAll sign opids
      | O.TAC_UNFOLD opids $ [_ \ vec] => Lcf.rule o R.Custom.Unfold sign opids (Syn.outVec' Syn.outSelector vec)
+     | O.TAC_ASSUMPTION $ _ => R.NondetStepJdgFromHyp
      | O.RULE_PRIM ruleName $ _ => R.lookupRule sign ruleName
      | O.DEV_LET _ $ [_ \ jdg, _ \ tm1, [u] \ tm2] => Lcf.rule o R.Cut (AJ.out jdg) thenl' ([u], [tactic sign env tm1, tactic sign env tm2])
      | O.DEV_FUN_INTRO pats $ [us \ tm] => funIntros sign (pats, us) (tactic sign env tm)

--- a/test/success/V-types.prl
+++ b/test/success/V-types.prl
@@ -115,7 +115,7 @@ Thm NotIsEquiv : [
               [i=0 [j] (@ p' j)]
               [i=1 [j] b])
         }
-      ); auto; (Bool/contra/inverse p')
+      ); auto; (Bool/contra/inverse p'); assumption
   }
 ].
 

--- a/test/success/num.prl
+++ b/test/success/num.prl
@@ -111,13 +111,13 @@ Thm Plus/test0 : [
 ] by [
   lam n m eq =>
     fresh x -> rewrite ($ Plus/zero/R n) in eq;
-    [ `(= nat x m) ]; auto
+    [ `(= nat x m) ]; auto; use eq
 ].
 
 Thm Eq/sym : [
   (-> [ty : (U 0)] [a b : ty] (= ty a b) (= ty b a))
 ] by [
-  lam ty a b eq => symmetry; auto
+  lam ty a b eq => symmetry; auto; use eq
 ].
 
 Thm Plus/comm : [
@@ -137,15 +137,16 @@ Thm Plus/comm : [
     auto
 ].
 
+
 Thm NatSymm : [
   (->
    [a b : nat]
    (path [_] nat a b)
    (path [_] nat b a))
 ] by [
-  lam a b pab => 
+  lam a b pab =>
   abs i =>
-    `(hcom 0~>1 nat a 
+    `(hcom 0~>1 nat a
       [i=0 [j] (@ pab j)]
       [i=1 [_] a])
 ].

--- a/vim/syntax/redprl.vim
+++ b/vim/syntax/redprl.vim
@@ -25,7 +25,7 @@ syn match   redExpr '[$*!@=+]\|->\|\~>\|<\~'
 syn keyword redTac auto auto-step case cut-lemma elim else exact fresh goal
 syn keyword redTac hyp id lemma let claim match of print progress
 syn keyword redTac query rec reduce refine repeat rewrite symmetry
-syn keyword redTac then unfold use with fail inversion concl
+syn keyword redTac then unfold use with fail inversion concl assumption
 syn match   redTac '[;`]'
 
 syn keyword redSeq at by in true type synth discrete kan hcom coe stable


### PR DESCRIPTION
Surprisingly few proofs are broken by this, and these can be repaired easily. This makes all our proofs a lot faster to execute.

Related: #472