### PR TITLE
Add the other connection to examples/connection.prl.

### DIFF
--- a/example/connection.prl
+++ b/example/connection.prl
@@ -8,26 +8,11 @@ Thm Connection/And(#l:lvl) : [
   lam ty a b p =>
     abs i j =>
       `(hcom 0~>1 ty a
-        [i=0 [k]
-         (hcom 1~>0 ty (@ p k)
-          [k=0 [_] a]
-          [k=1 [l] (@ p l)])]
-        [i=1 [k]
-         (hcom 1~>j ty (@ p k)
-          [k=0 [_] a]
-          [k=1 [l] (@ p l)])]
-        [j=0 [k]
-         (hcom 1~>0 ty (@ p k)
-          [k=0 [_] a]
-          [k=1 [l] (@ p l)])]
-        [j=1 [k]
-         (hcom 1~>i ty (@ p k)
-          [k=0 [_] a]
-          [k=1 [l] (@ p l)])]
-        [i=j [k]
-         (hcom 1~>i ty (@ p k)
-          [k=0 [_] a]
-          [k=1 [l] (@ p l)])])
+        [i=0 [k] (hcom 1~>0 ty (@ p k) [k=0 [_] a] [k=1 [l] (@ p l)])]
+        [i=1 [k] (hcom 1~>j ty (@ p k) [k=0 [_] a] [k=1 [l] (@ p l)])]
+        [j=0 [k] (hcom 1~>0 ty (@ p k) [k=0 [_] a] [k=1 [l] (@ p l)])]
+        [j=1 [k] (hcom 1~>i ty (@ p k) [k=0 [_] a] [k=1 [l] (@ p l)])]
+        [i=j [k] (hcom 1~>i ty (@ p k) [k=0 [_] a] [k=1 [l] (@ p l)])])
 ].
 
 Thm Connection/And/Diagonal (#l:lvl) : [

--- a/example/connection.prl
+++ b/example/connection.prl
@@ -1,4 +1,4 @@
-Thm Connection(#l:lvl) : [
+Thm Connection/And(#l:lvl) : [
   (->
    [ty : (U #l hcom)]
    [a b : ty]
@@ -30,12 +30,39 @@ Thm Connection(#l:lvl) : [
           [k=1 [l] (@ p l)])])
 ].
 
-Thm Connection/Test0 (#l:lvl) : [
+Thm Connection/And/Diagonal (#l:lvl) : [
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    [p : (path [_] ty a b)]
-   (= (path [_] ty a b) (abs [i] (@ ($ (Connection #l) ty a b p) i i)) p))
+   (= (path [_] ty a b) (abs [i] (@ ($ (Connection/And #l) ty a b p) i i)) p))
 ] by [
-  lam ty a b p => unfold Connection; auto
+  lam ty a b p => unfold Connection/And; auto
+].
+
+Thm Connection/Or(#l:lvl) : [
+  (->
+   [ty : (U #l hcom)]
+   [a b : ty]
+   [p : (path [_] ty a b)]
+   (path [i] (path [_] ty (@ p i) b) p (abs [_] b)))
+] by [
+  lam ty a b p =>
+   abs i j =>
+     `(hcom 1~>0 ty b
+       [i=0 [k] (hcom 0~>j ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
+       [i=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
+       [j=0 [k] (hcom 0~>i ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
+       [j=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
+       [i=j [k] (hcom 0~>i ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])])
+].
+
+Thm Connection/Or/Diagonal (#l:lvl) : [
+  (->
+   [ty : (U #l hcom)]
+   [a b : ty]
+   [p : (path [_] ty a b)]
+   (= (path [_] ty a b) (abs [i] (@ ($ (Connection/Or #l) ty a b p) i i)) p))
+] by [
+  lam ty a b p => unfold Connection/Or; auto
 ].


### PR DESCRIPTION
I needed the other kind of connection (although not the correct diagonal) to prove something in `examples/tutorial.prl`, and I figured it should also be in `examples/connection.prl`.