### PR TITLE
More refined unfolding.

### DIFF
--- a/example/univalence.prl
+++ b/example/univalence.prl
@@ -238,7 +238,9 @@ Thm UARet(#l:lvl) : [
       , `e
       , abs x => lam a =>
           use (UABeta #l) [`ty/a, `ty/b, `e, `(coe 1~>x [_] ty/a a), `x]
-      ]
+      ];
+
+      unfold PathToEquiv at right in concl; auto
 ].
 
 Thm IsContrPath(#l:lvl) : [

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -917,7 +917,10 @@ atomicRawTac
   | TAC_REDUCE IN selector AT accessors (Ast.$$ (O.TAC_REDUCE_PART, [\\ selector, \\ (Multi.makeVec O.ACC accessors)]))
   | TAC_REDUCE AT accessors IN selector (Ast.$$ (O.TAC_REDUCE_PART, [\\ selector, \\ (Multi.makeVec O.ACC accessors)]))
   | TAC_UNFOLD opnames (Ast.$$ (O.TAC_UNFOLD_ALL opnames, []))
-  | TAC_UNFOLD opnames IN selectors (Ast.$$ (O.TAC_UNFOLD (opnames), [Ast.\ ([], Multi.makeVec O.SEL selectors)]))
+  | TAC_UNFOLD opnames IN selectors (Ast.$$ (O.TAC_UNFOLD opnames, [Ast.\ ([], Multi.makeVec O.SEL selectors)]))
+  | TAC_UNFOLD opnames AT accessors (Ast.$$ (O.TAC_UNFOLD_PART opnames, [\\ (Ast.$$ (O.SEL_CONCL, [])), Ast.\ ([], Multi.makeVec O.ACC accessors)]))
+  | TAC_UNFOLD opnames IN selector AT accessors (Ast.$$ (O.TAC_UNFOLD_PART opnames, [\\ selector, Ast.\ ([], Multi.makeVec O.ACC accessors)]))
+  | TAC_UNFOLD opnames AT accessors IN selector (Ast.$$ (O.TAC_UNFOLD_PART opnames, [\\ selector, Ast.\ ([], Multi.makeVec O.ACC accessors)]))
 
   | BACK_TICK termAnySort (Tac.exactAuto termAnySort)
   | RULE_EXACT termAnySort (Tac.exact termAnySort)

--- a/src/redprl/refiner.sig
+++ b/src/redprl/refiner.sig
@@ -33,6 +33,7 @@ sig
   sig
     val UnfoldAll : sign -> opid list -> rule
     val Unfold : sign -> opid list -> hyp Selector.t list -> rule
+    val UnfoldPart : sign -> opid list -> hyp Selector.t * Accessor.t list -> rule
   end
 
   structure Computation :

--- a/src/redprl/refiner_misc.fun
+++ b/src/redprl/refiner_misc.fun
@@ -163,6 +163,16 @@ struct
         |>: goal #> (H, hole)
       end
 
+    fun UnfoldPart sign opids (selector, accessors) _ jdg =
+      let
+        val tr = ["Custom.UnfoldPart"]
+        val H >> ajdg = jdg
+        val (H', ajdg') = Sequent.mapSelector selector (AJ.multiMapAccessor accessors (unfold sign opids)) (H, ajdg)
+        val (goal, hole) = makeGoal tr @@ H' >> ajdg'
+      in
+        |>: goal #> (H, hole)
+      end
+
     fun Eq sign _ jdg =
       let
         val tr = ["Custom.Eq"]

--- a/src/redprl/syntax/operator.sig
+++ b/src/redprl/syntax/operator.sig
@@ -118,6 +118,7 @@ struct
    | CUST of opid * RedPrlArity.t option
    | TAC_UNFOLD_ALL of opid list
    | TAC_UNFOLD of opid list
+   | TAC_UNFOLD_PART of opid list
 
    | DEV_USE_LEMMA
    | DEV_APPLY_LEMMA of unit dev_pattern

--- a/src/redprl/syntax/operator.sml
+++ b/src/redprl/syntax/operator.sml
@@ -177,6 +177,7 @@ struct
      | CUST (_, ar) => Option.valOf ar
      | TAC_UNFOLD_ALL _ => [] ->> TAC
      | TAC_UNFOLD _ => [[] |: VEC SEL] ->> TAC
+     | TAC_UNFOLD_PART _ => [[] |: SEL, [] |: VEC ACC] ->> TAC
      | DEV_APPLY_LEMMA pat => [[] |: ANY, [] |: VEC TAC, devPatternValence pat |: TAC] ->> TAC
      | DEV_USE_LEMMA => [[] |: ANY, [] |: VEC TAC] ->> TAC
 
@@ -324,6 +325,7 @@ struct
      | CUST (opid, _) => MlId.toString opid
      | TAC_UNFOLD_ALL os => "unfold-all{" ^ opidsToString os ^ "}"
      | TAC_UNFOLD os => "unfold{" ^ opidsToString os ^ "}"
+     | TAC_UNFOLD_PART os => "unfold-part{" ^ opidsToString os ^ "}"
      | DEV_APPLY_LEMMA _ => "apply-lemma"
      | DEV_USE_LEMMA => "use-lemma"
 end

--- a/src/redprl/tactic_elaborator.fun
+++ b/src/redprl/tactic_elaborator.fun
@@ -273,6 +273,7 @@ struct
      | O.TAC_REDUCE_PART $ [_ \ sel, _ \ accs] => Lcf.rule o R.Computation.ReducePart sign (Syn.outSelector sel, Syn.outVec' Syn.outAccessor accs)
      | O.TAC_UNFOLD_ALL opids $ _ => Lcf.rule o R.Custom.UnfoldAll sign opids
      | O.TAC_UNFOLD opids $ [_ \ vec] => Lcf.rule o R.Custom.Unfold sign opids (Syn.outVec' Syn.outSelector vec)
+     | O.TAC_UNFOLD_PART opids $ [_ \ sel, _ \ accs] => Lcf.rule o R.Custom.UnfoldPart sign opids (Syn.outSelector sel, Syn.outVec' Syn.outAccessor accs)
      | O.TAC_ASSUMPTION $ _ => R.NondetStepJdgFromHyp
      | O.RULE_PRIM ruleName $ _ => R.lookupRule sign ruleName
      | O.DEV_LET _ $ [_ \ jdg, _ \ tm1, [u] \ tm2] => Lcf.rule o R.Cut (AJ.out jdg) thenl' ([u], [tactic sign env tm1, tactic sign env tm2])


### PR DESCRIPTION
This is an attempt to have more refined unfolding. With this, it is possible to unfold only in some parts of a judgment, just like the enhanced `reduce` after #382. The refiner was also updated to minimize unfolding. The only change in the examples is a new manual unfolding in `univalence.prl`.