### PR TITLE
Performance tuning

### DIFF
--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -152,6 +152,7 @@ struct
       let
         val tr = ["True.Witness"]
         val H >> AJ.TRUE ty = jdg
+        val () = assertWellScoped H tm
         val goal = makeMem tr H (tm, ty)
       in
         |>: goal #> (H, tm)
@@ -166,6 +167,7 @@ struct
       let
         val tr = ["Term.Exact"]
         val H >> AJ.TERM tau = jdg
+        val () = assertWellScoped H tm
         val tau' = Abt.sort tm
         val _ = Assert.sortEq (tau, tau')
       in

--- a/src/redprl/refiner_kit.fun
+++ b/src/redprl/refiner_kit.fun
@@ -35,24 +35,21 @@ struct
       end
   end
 
-  (* assert that the term 'm' has only free variables 'us' and free variables 'xs' at most. *)
-  fun assertWellScoped xs m = 
+  (* assert that the term 'm' has only free variables from 'H' at most. *)
+  fun assertWellScoped H m = 
     let
-      val vars = List.foldl (fn (x, vars) => Var.Ctx.remove vars x) (Abt.varctx m) xs
-      fun ppVars us = Fpp.Atomic.squares @@ Fpp.hsep @@ List.map TermPrinter.ppVar us
+      val vars = Hyps.foldl (fn (x, tau, vars) => Var.Ctx.remove vars x) (Abt.varctx m) H
+      fun ppVars xs = Fpp.Atomic.squares @@ Fpp.hsep @@ List.map TermPrinter.ppVar xs
       val varsOk = Var.Ctx.isEmpty vars
     in
       if varsOk then
         ()
       else
         raise E.error
-          [Fpp.text "Internal Error:",
-           Fpp.text "Validation term",
+          [Fpp.text "Term",
            TermPrinter.ppTerm m,
            Fpp.text "had unbound variables",
-           ppVars (Var.Ctx.domain vars),
-           Fpp.text "whereas we expected only",
-           ppVars xs]
+           ppVars (Var.Ctx.domain vars)]
     end
 
   (* hypotheses *)
@@ -67,7 +64,6 @@ struct
     let
       val (xs, taus) = Hyps.foldr (fn (x, jdg, (xs, taus)) => (x::xs, AJ.synthesis jdg::taus)) ([],[]) H
     in
-      assertWellScoped xs m;
       Abt.checkb (Abt.\ (xs, m), (taus, Abt.sort m))
     end
 


### PR DESCRIPTION
I remove the scope-check that occurs between every refinement step, and insert a few scope-checks where it is needed in order to maintain semantic correctness.

The only place the scope-check is really semantically necessary is when a term comes from the user and not from the refiner. For instance, in the `Exact` rules.

Elsewhere, having this check would help us catch bugs in the refiner, but generally it is an invariant that the refiner must produce terms that are well-scoped wrt. their context anyway. In light of https://github.com/RedPRL/sml-typed-abts/pull/110, it becomes expensive to wastefully calculate free variables, so I want to minimize calls to `varctx` in RedPRL.

I am trying out a number of performance tweaks, and may add more things to this PR.