### PR TITLE
polish up ML elaborator; new concrete syntax

### DIFF
--- a/doc/src/language.rst
+++ b/doc/src/language.rst
@@ -30,11 +30,11 @@ the signature.
 
 ::
 
-  Thm OpName(#p : ...) : [
+  theorem OpName(#p : ...) :
     // goal here (object language expression)
-  ] by [
+  by {
     // script here (tactic expression)
-  ].
+  }.
 
 
 Most definitions in a |RedPRL| signature will take the form of theorems; but
@@ -46,16 +46,16 @@ other forms of definition may be preferable, :ref:`depending on circumstances
 Defining new operators
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The most primitive way to define a new operator in |RedPRL| is to use the ``Def``
+The most primitive way to define a new operator in |RedPRL| is to use the ``define``
 command. A definition is specified by giving an operator name (which must be
 capitalized), together with a (possibly empty) sequence of parameters together
 with their valences, and an object-language term which shall be the definiens:
 
 ::
 
-  Def OpName(#p : [dim].exp, ...) : exp = [
+  define OpName(#p : [dim].exp, ...) : exp =
     // object language expression here
-  ].
+  .
 
 A parameter is referenced using a *metavariable* (which is
 distinguished syntactically using the ``#`` sigil); the valence of a parameter
@@ -67,9 +67,9 @@ A simple definition of sort ``exp`` without parameters can be abbreviated as fol
 
 ::
 
-  Def OpName = [
+  define OpName =
     // object language expression here
-  ].
+  .
 
 Definitions of this kind are not subject to any typing conditions in CHTT;
 instead, if you use a primitive definition within a proof, you will have to
@@ -81,16 +81,16 @@ prove that it is well-typed.
 Defining tactics
 ^^^^^^^^^^^^^^^^
 
-A tactic can be defined using the special ``Tac`` command:
+A tactic can be defined using the special ``tactic`` command:
 
 ::
 
-  Tac OpName(#p : ...) = [
+  tactic OpName(#p : ...) =
     // tactic expression here
-  ].
+  .
 
 
-This desugars to an instance of the ``Def`` command, and differs only in that the
+This desugars to an instance of the ``define`` command, and differs only in that the
 body of the definiens is here parsed using the grammar of tactic expressions.
 
 
@@ -111,7 +111,7 @@ When to use theorems or definitions?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 As a rule of thumb, in most cases it is simpler to interactively construct an
-element of a type using a ``Thm`` declaration than it is to define a code for
+element of a type using a ``theorem`` declaration than it is to define a code for
 an element, and then prove that it has the intended type. This is why theorems
 are usually preferred to definitions in |RedPRL|.
 
@@ -121,14 +121,14 @@ As a theorem, this definition must take a universe level as a parameter
 
 ::
 
-  Thm Sequence(#l : lvl) : [
+  define Sequence(#l : lvl) :
     (-> [ty : (U #l)] (U #l))
-  ] by [
+  by {
     // apply function introduction rule in the tactic language
     lam ty =>
       // explicitly give the body of the function in the object language
       `(-> nat ty)
-  ].
+  }.
 
 Later, when using this definition, one would have to explicitly provide the
 universe level, even though it does not play a part in the actual defined
@@ -139,9 +139,9 @@ definition, we can write the following:
 
 ::
 
-  Def Sequence = [
+  define Sequence =
     (lam [ty] (-> nat ty))
-  ].
+  .
 
 
 One advantage of theorems over definitions is that |RedPRL| knows their type

--- a/doc/src/redprl.py
+++ b/doc/src/redprl.py
@@ -23,7 +23,7 @@ class RedPRLLexer(RegexLexer):
             'print', 'trace', 'progress', 'query', 'reduce', 'refine', 'repeat',
             'rewrite', 'symmetry', 'then', 'unfold', 'use', 'with', 'without',
             'fail', 'inversion', 'concl', 'assumption', '\;']
-    cmds = ['Print', 'Extract', 'Quit', 'Def', 'Tac', 'Thm']
+    cmds = ['print', 'extract', 'quit', 'define', 'tactic', 'theorem']
     misc = ['at', 'by', 'in', 'true', 'type', 'synth', 'discrete', 'kan', 'pre',
             'dim', 'hyp', 'exp', 'lvl', 'tac', 'jdg', 'knd']
     types = ['bool', 'nat', 'int', 'void', 's1', 'fun', 'record', 'path',

--- a/doc/src/tutorial.rst
+++ b/doc/src/tutorial.rst
@@ -13,116 +13,223 @@ in the ``examples/`` subdirectory.
 
 ::
 
-  Thm Not : [
+  theorem Not :
     (-> bool bool)
-  ] by [
+  by {
     lam b =>
     if b then `ff else `tt
-  ].
+  }.
 
-  Print Not.
+  print Not.
 
   // (not(not(b)) == b) because it holds for every closed boolean.
-  Thm NotNot : [
+  theorem NotNot :
     (->
      [b : bool]
      (= bool ($ Not ($ Not b)) b))
-  ] by [
+  by {
     lam b =>
     // The next four lines can be replaced by auto.
     unfold Not;
     if b
     then (reduce at left; refine bool/eq/tt)
     else (reduce at left; refine bool/eq/ff)
-  ].
+  }.
 
-  Print NotNot.
+  print NotNot.
 
   // Type families respect equality proofs.
-  Thm RespectEquality : [
+  theorem RespectEquality :
     (->
      [family : (-> [b : bool] (U 0))]
      [b : bool]
      ($ family b)
      ($ family ($ Not ($ Not b))))
-  ] by [
+  by {
     lam family b pf =>
     rewrite ($ NotNot b);
     [ with b' => `($ family b')
     , use pf
     ];
     auto
-  ].
+  }.
 
 
-  // Extract does not mention the equality proof!
+  // print does not mention the equality proof!
   // (No need to ``transport'' at runtime.)
-  Print RespectEquality.
+  print RespectEquality.
 
   // In fact, all proofs of (not(not(b)) == b) are equal.
-  Thm EqualityIrrelevant : [
+  theorem EqualityIrrelevant :
     (=
       (-> [b : bool] (= bool ($ Not ($ Not b)) b))
       NotNot
       (lam [b] ax))
-  ] by [
+  by {
     auto
-  ].
+  }.
 
-  Print EqualityIrrelevant.
+  print EqualityIrrelevant.
 
   // Paths (cf equalities), like those arising from
   // equivalences via univalence, do induce computation.
-  Thm FunToPair : [
+  theorem FunToPair :
     (->
      [ty : (U 0 kan)]
      (-> bool ty)
      (* ty ty))
-  ] by [
+  by {
     lam ty fun =>
     {`($ fun tt), `($ fun ff)}
-  ].
+  }.
+
+  // {{{ Univalence
+
+  define HasAllPathsTo (#C,#c) = (-> [c' : #C] (path [_] #C c' #c)).
+  define IsContr (#C) = (* [c : #C] (HasAllPathsTo #C c)).
+  define Fiber (#A,#B,#f,#b) = (* [a : #A] (path [_] #B ($ #f a) #b)).
+  define IsEquiv (#A,#B,#f) = (-> [b : #B] (IsContr (Fiber #A #B #f b))).
+  define Equiv (#A,#B) = (* [f : (-> #A #B)] (IsEquiv #A #B f)).
+
+  theorem WeakConnection(#l:lvl) :
+    (->
+     [ty : (U #l hcom)]
+     [a b : ty]
+     [p : (path [_] ty a b)]
+     (path [i] (path [_] ty (@ p i) b) p (abs [_] b)))
+  by {
+    (lam ty a b p =>
+      abs i j =>
+        `(hcom 1~>0 ty b
+          [i=0 [k] (hcom 0~>j ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
+          [i=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
+          [j=0 [k] (hcom 0~>i ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
+          [j=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]))
+  }.
+
+  tactic GetEndpoints(#p, #t:[exp,exp].tac) = {
+    query pty <- #p;
+    match pty  {
+      [ty l r | #jdg{(path [_] %ty %l %r)} =>
+        claim p/0 : (@ #p 0) = %l in %ty by {auto};
+        claim p/1 : (@ #p 1) = %r in %ty by {auto};
+        (#t p/0 p/1)
+      ]
+    }
+  }.
+
+
+  print WeakConnection.
+
+  theorem FunToPairIsEquiv :
+    (->
+     [ty : (U 0 kan)]
+     (IsEquiv (-> bool ty) (* ty ty) ($ FunToPair ty)))
+  by {
+    lam ty pair =>
+    { { lam b => if b then `(!proj1 pair) else `(!proj2 pair)
+      , abs _ => `pair }
+    , unfold Fiber;
+      lam {fun,p} =>
+       (GetEndpoints p [p/0 p/1] #tac{
+        (abs x =>
+          {lam b => if b then `(!proj1 (@ p x)) else `(!proj2 (@ p x)),
+           abs y =>
+             `(@ ($ (WeakConnection #lvl{0}) (* ty ty) ($ FunToPair ty fun) pair p) x y)
+          });
+        [ unfold FunToPair in p/0; reduce in p/0 at right;
+          inversion; with q3 q2 q1 q0 =>
+            reduce at right in q2;
+            reduce at right in q3;
+            auto; with b =>
+              elim b; reduce at right; symmetry; assumption
+        , unfold FunToPair in p/1; reduce in p/1 at right;
+          inversion; with q3 q2 q1 q0 => elim pair;
+          reduce at right in q0; reduce at right in q1;
+          auto; assumption
+        ]
+       })
+    }
+  }.
+
+  theorem PathFunToPair :
+    (->
+     [ty : (U 0 kan)]
+     (path [_] (U 0 kan) (-> bool ty) (* ty ty)))
+  by {
+    lam ty => abs x =>
+    `(V x (-> bool ty) (* ty ty)
+      (tuple [proj1 ($ FunToPair ty)] [proj2 ($ FunToPairIsEquiv ty)]))
+  }.
+
+  // }}}
+
+  print PathFunToPair.
+
+  // We can coerce elements of (bool -> ty) to (ty * ty).
+  theorem RespectPaths :
+    (->
+     [ty : (U 0 kan)]
+     (-> bool ty)
+     (* ty ty))
+  by {
+    lam ty fun =>
+    `(coe 0~>1 [x] (@ ($ PathFunToPair ty) x) fun)
+  }.
+
+  print RespectPaths.
+
+  // When coercing, the choice of PathFunToPair matters!
+  theorem ComputeCoercion :
+    (=
+     (* bool bool)
+     ($ RespectPaths bool (lam [b] b))
+     (tuple [proj1 tt] [proj2 ff]))
+  by {
+    auto
+  }.
+
 
   // ---------------------------------------------------------
   // Part Two
   // ---------------------------------------------------------
 
   // A constant path does not depend on its dimension.
-  Thm Refl : [
+  theorem Refl :
     (->
      [ty : (U 0)]
      [a : ty]
      (path [_] ty a a))
-  ] by [
+  by {
     lam ty a =>
     abs _ => `a
-  ].
+  }.
 
   // The path structure of each type is defined in terms of
   // its constituent types.
-  Thm FunPath : [
+  theorem FunPath :
     (->
      [a b : (U 0)]
      [f g : (-> a b)]
      (path [_] (-> a b) f g)
      [arg : a]
      (path [_] b ($ f arg) ($ g arg)))
-  ] by [
+  by {
     lam a b f g p =>
     lam arg => abs x =>
       `($ (@ p x) arg)
-  ].
+  }.
 
 
-  Print FunPath.
+  print FunPath.
 
-  Thm PathInv : [
+  theorem PathInv :
     (->
      [ty : (U 0 kan)]
      [a b : ty]
      [p : (path [_] ty a b)]
      (path [_] ty b a))
-  ] by [
+  by {
   //        a          -- x
   //     -------      |
   //    |      |      y
@@ -133,16 +240,16 @@ in the ``examples/`` subdirectory.
     lam ty a b p =>
     abs x =>
     `(hcom 0~>1 ty a [x=0 [y] (@ p y)] [x=1 [_] a])
-  ].
+  }.
 
-  Thm PathConcat : [
+  theorem PathConcat :
     (->
      [ty : (U 0 kan)]
      [a b c : ty]
      [p : (path [_] ty a b)]
      [q : (path [_] ty b c)]
      (path [_] ty a c))
-  ] by [
+  by {
   //        p          -- x
   //     -------      |
   //    |      |      y
@@ -153,9 +260,9 @@ in the ``examples/`` subdirectory.
     lam ty a b c p q =>
     abs x =>
     `(hcom 0~>1 ty (@ p x) [x=0 [_] a] [x=1 [y] (@ q y)])
-  ].
+  }.
 
-  Thm InvRefl : [
+  theorem InvRefl :
     (->
      [ty : (U 0 kan)]
      [a : ty]
@@ -163,7 +270,7 @@ in the ``examples/`` subdirectory.
        [_] (path [_] ty a a)
        ($ PathInv ty a a (abs [_] a))
        (abs [_] a)))
-  ] by [
+  by {
     // See diagram!
     lam ty a =>
     abs x y =>
@@ -172,12 +279,12 @@ in the ``examples/`` subdirectory.
       [x=1 [_] a]
       [y=0 [_] a]
       [y=1 [_] a])
-  ].
+  }.
 
   // Although the path type is not defined by refl and J
   // (as in HoTT), we can still define J using hcom + coe.
   // The #l is an example of a parametrized definition.
-  Thm J(#l:lvl) : [
+  theorem J(#l:lvl) :
     (->
      [ty : (U #l kan)]
      [a : ty]
@@ -186,21 +293,21 @@ in the ``examples/`` subdirectory.
      [x : ty]
      [p : (path [_] ty a x)]
      ($ fam x p))
-  ] by [
+  by {
     lam ty a fam d x p =>
     `(coe 0~>1
       [i] ($ fam
              (hcom 0~>1 ty a [i=0 [_] a] [i=1 [j] (@ p j)])
              (abs [j] (hcom 0~>j ty a [i=0 [_] a] [i=1 [j] (@ p j)]))) d)
-  ].
+  }.
 
-  Thm JInv : [
+  theorem JInv :
     (->
      [ty : (U 0 kan)]
      [a b : ty]
      [p : (path [_] ty a b)]
      (path [_] ty b a))
-  ] by [
+  by {
     lam ty a b p =>
     exact
       ($ (J #lvl{0})
@@ -212,6 +319,21 @@ in the ``examples/`` subdirectory.
          p)
     ; auto
     //; unfold J; reduce at left right; ?
-  ].
+  }.
 
-  Print JInv.
+  print JInv.
+
+  // Computing winding numbers in the circle.
+
+  // Bonus material:
+
+  theorem Shannon :
+    (->
+     [ty  : (-> bool (U 0))]
+     [elt : (-> [b : bool] ($ ty b))]
+     [b : bool]
+     (= ($ ty b) ($ elt b) (if [b] ($ ty b) b ($ elt tt) ($ elt ff))))
+  by {
+    lam ty elt b =>
+    elim b; auto
+  }.

--- a/emacs/redprl.el
+++ b/emacs/redprl.el
@@ -104,7 +104,7 @@
   "Syntax table for RedPRL.")
 
 (defconst redprl-declaration-keywords
-  '("Def" "Extract" "Print" "Quit" "Tac" "Thm")
+  '("define" "extract" "print" "quit" "tactic" "theorem")
   "RedPRL's keywords.")
 
 (defconst redprl-sort-keywords
@@ -136,7 +136,7 @@
 
 (defconst redprl-tactic-keywords
   '("auto" "auto-step" "case" "concl" "cut-lemma" "elim" "else" "exact" "goal"
-    "hyp" "id" "lemma" "let" "claim" "match" "of" "print" "progress"
+    "hyp" "id" "lemma" "let" "claim" "match" "of" "progress"
     "query" "rec" "reduce" "refine" "repeat" "rewrite" "symmetry" "inversion" "assumption"
     "then" "unfold" "use" "with")
   "RedPRL's tactic keywords.")

--- a/example/J.prl
+++ b/example/J.prl
@@ -12,7 +12,7 @@ define J/coe(#j:dim, #ty, #a, #fam, #d, #p) =
    #d)
 .
 
-theorem J(#l:lvl) :
+theorem J(#l:lvl) : 
   (->
    [ty : (U #l kan)]
    [a : ty]
@@ -21,9 +21,9 @@ theorem J(#l:lvl) :
    [x : ty]
    [p : (path [_] ty a x)]
    ($ fam x p))
-by
+by {
   lam ty a fam d x p => `(J/coe (dim 1) ty a fam d p)
-.
+}.
 
 define J/comp/cube(#i:dim,#j:dim,#k:dim, #ty, #a) = 
   (hcom 0~>#j #ty #a
@@ -33,7 +33,7 @@ define J/comp/cube(#i:dim,#j:dim,#k:dim, #ty, #a) =
    [#i=1 [_] #a])
 .
 
-theorem J/comp(#l:lvl) :
+theorem J/comp(#l:lvl) : 
   (->
    [ty : (U #l kan)]
    [a : ty]
@@ -42,7 +42,7 @@ theorem J/comp(#l:lvl) :
    (path [_] ($ fam a (abs [_] a))
     ($ (J #l) ty a fam d a (abs [_] a))
     d))
-by
+by {
   lam ty a fam d => abs k =>
     `(com 0~>1
       [i] ($ fam (J/comp/cube i (dim 1) k ty a)
@@ -50,4 +50,4 @@ by
       d
       [k=0 [i] (J/coe i ty a fam d (abs [_] a))]
       [k=1 [_] d])
-.
+}.

--- a/example/J.prl
+++ b/example/J.prl
@@ -1,10 +1,10 @@
-define J/square(#i:dim,#j:dim, #ty, #a, #p) = 
+define J/square(#i:dim,#j:dim, #ty, #a, #p) =
   (hcom 0~>#j #ty #a
    [#i=0 [_] #a]
    [#i=1 [j] (@ #p j)])
 .
 
-define J/coe(#j:dim, #ty, #a, #fam, #d, #p) = 
+define J/coe(#j:dim, #ty, #a, #fam, #d, #p) =
   (coe 0~>#j
    [i] ($ #fam
         (J/square i (dim 1) #ty #a #p)
@@ -12,7 +12,7 @@ define J/coe(#j:dim, #ty, #a, #fam, #d, #p) =
    #d)
 .
 
-theorem J(#l:lvl) : 
+theorem J(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [a : ty]
@@ -25,7 +25,7 @@ by {
   lam ty a fam d x p => `(J/coe (dim 1) ty a fam d p)
 }.
 
-define J/comp/cube(#i:dim,#j:dim,#k:dim, #ty, #a) = 
+define J/comp/cube(#i:dim,#j:dim,#k:dim, #ty, #a) =
   (hcom 0~>#j #ty #a
    [#k=0 [j] (J/square #i j #ty #a (abs [_] #a))]
    [#k=1 [_] #a]
@@ -33,7 +33,7 @@ define J/comp/cube(#i:dim,#j:dim,#k:dim, #ty, #a) =
    [#i=1 [_] #a])
 .
 
-theorem J/comp(#l:lvl) : 
+theorem J/comp(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [a : ty]

--- a/example/J.prl
+++ b/example/J.prl
@@ -1,18 +1,18 @@
-Def J/square(#i:dim,#j:dim, #ty, #a, #p) = [
+define J/square(#i:dim,#j:dim, #ty, #a, #p) = 
   (hcom 0~>#j #ty #a
    [#i=0 [_] #a]
    [#i=1 [j] (@ #p j)])
-].
+.
 
-Def J/coe(#j:dim, #ty, #a, #fam, #d, #p) = [
+define J/coe(#j:dim, #ty, #a, #fam, #d, #p) = 
   (coe 0~>#j
    [i] ($ #fam
         (J/square i (dim 1) #ty #a #p)
         (abs [j] (J/square i j #ty #a #p)))
    #d)
-].
+.
 
-Thm J(#l:lvl) : [
+theorem J(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [a : ty]
@@ -21,19 +21,19 @@ Thm J(#l:lvl) : [
    [x : ty]
    [p : (path [_] ty a x)]
    ($ fam x p))
-] by [
+by
   lam ty a fam d x p => `(J/coe (dim 1) ty a fam d p)
-].
+.
 
-Def J/comp/cube(#i:dim,#j:dim,#k:dim, #ty, #a) = [
+define J/comp/cube(#i:dim,#j:dim,#k:dim, #ty, #a) = 
   (hcom 0~>#j #ty #a
    [#k=0 [j] (J/square #i j #ty #a (abs [_] #a))]
    [#k=1 [_] #a]
    [#i=0 [_] #a]
    [#i=1 [_] #a])
-].
+.
 
-Thm J/comp(#l:lvl) : [
+theorem J/comp(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [a : ty]
@@ -42,7 +42,7 @@ Thm J/comp(#l:lvl) : [
    (path [_] ($ fam a (abs [_] a))
     ($ (J #l) ty a fam d a (abs [_] a))
     d))
-] by [
+by
   lam ty a fam d => abs k =>
     `(com 0~>1
       [i] ($ fam (J/comp/cube i (dim 1) k ty a)
@@ -50,4 +50,4 @@ Thm J/comp(#l:lvl) : [
       d
       [k=0 [i] (J/coe i ty a fam d (abs [_] a))]
       [k=1 [_] d])
-].
+.

--- a/example/README.prl
+++ b/example/README.prl
@@ -1,96 +1,96 @@
-Thm BoolTest : [
+theorem BoolTest :
   (-> bool bool)
-] by [
+by
   // A term/witness can be supplied to the refiner at any point in a tactic script
   // using the quotation operator `.
   lam x => if x then `tt else `ff
-].
+.
 
 
-Thm PathTest : [
+theorem PathTest :
   (path [_] S1 base base)
-] by [
+by
   abs x => `(loop x)
-].
+.
 
-Thm LowLevel : [
+theorem LowLevel :
   (->
     (-> bool bool)
     bool)
-] by [
+by
   refine fun/intro;
   [ with f =>
     elim f; [`tt, with x/eq x => use x]
   , refine fun/eqtype;
     refine bool/eqtype
   ]
-].
+.
 
-Extract LowLevel.
+do let val M = extract LowLevel; print M.
 
-Thm LowLevel2 : [
+theorem LowLevel2 :
   (->
     (-> bool bool)
     bool
     bool)
-] by [
+by
   repeat {refine fun/intro; [id, auto]};
   with x f =>
     elim f; 
     [ use x
     , with y/eq y => use y
     ]
-].
+.
 
 
-Extract LowLevel2.
+do let val M = extract LowLevel2; print M.
 
-Thm FunElimTest : [
+theorem FunElimTest :
   (->
    (-> bool bool)
    bool)
-] by [
+by
   lam f => use f [`tt]
-].
+.
 
-Thm S1ElimTest : [ (-> S1 S1) ] by [
+theorem S1ElimTest : (-> S1 S1)  by
   lam s =>
     case s of
        base => `base
      | loop x => `(loop x)
-].
+.
 
-Tac Try(#t : tac) = [
+tactic Try(#t : tac) = 
   #t || id
-].
+.
 
 // Useful for stepping through a proof RedPRL completes automatically, to see
 // what is being done.
-Tac TryStep = [
+tactic TryStep = 
   // We can call our Try tactical. But tactics are parsed with a different grammar than terms,
   // so to avoid ambiguity, when we need to provide a tactic expression as an argument to
   // an operator, we wrap it in (tactic ....).
   (Try #tac{auto-step})
-].
+.
 
 // 'if' is the recursor for booleans.  It takes the motive of induction as an argument
 // in order to facilitate type synthesizing.
-Def BoolEta(#M) = [
+define BoolEta(#M) = 
   (if [a] bool #M tt ff)
-].
+.
 
-Print BoolEta.
+print BoolEta.
 
 // If we define such a function in the refiner using tactics, we can use the
 // built-in 'if x then t1 else t2' tactical, and the extracted witness will be
 // an 'if' form with the motive already filled in.
-Thm BoolEtaFunction : [
+theorem BoolEtaFunction :
   (-> bool bool)
-] by [
+by
   lam b => if b then `tt else `ff
-].
+.
 
-Extract BoolEtaFunction.
+print BoolEtaFunction.
 
 // Let's prove the existence of a path between the identity function
 // on booleans, and the function that takes a boolean to a vacuous if
@@ -101,12 +101,12 @@ Extract BoolEtaFunction.
 // proof is that we can leave holes, and interactively figure out what
 // we need to do.
 //
-Thm PathTest2 : [
+theorem PathTest2 :
   (path
     [_] (-> bool bool)
     (lam [b] b)
     (lam [b] (BoolEta b)))
-] by [
+by
   // abstract a dimension
   abs x =>
     // now, we are constructing a line of functions; so we use a
@@ -123,7 +123,7 @@ Thm PathTest2 : [
       // supplied to the refiner using the '@' "dimension quotation"
       // operator.
       use p [`x]
-].
+.
 
 
 // It turns out that it is just as good to figure out what the witness
@@ -133,105 +133,105 @@ Thm PathTest2 : [
 // time the entirety of the program, and cannot take advantage of
 // types in order to guide its construction, or even synthesize part
 // of it.
-Thm PathTest3 : [
+theorem PathTest3 :
   (path
     [_] (-> bool bool)
     (lam [b] b)
     (lam [b] (BoolEta b)))
-] by [
+by
   // I'm surprised that RedPRL can typecheck this properly! Quite
   // encouraging.
   `(abs [x]
     (lam [b]
      (@ (if [b] (path [_] bool b (BoolEta b)) b (abs [_] tt) (abs [_] ff))
         x)))
-].
+.
 
-Print PathTest3.
+print PathTest3.
 
-Thm PairTest : [ (* [a : S1] (path [_] S1 a base)) ] by [
+theorem PairTest : (* [a : S1] (path [_] S1 a base))  by
   {`base, abs x => `(loop x)}
-].
+.
 
 
-Def Cmp(#f, #g) = [
+define Cmp(#f, #g) = 
   (lam [x] ($ #f ($ #g x)))
-].
+.
 
 
-Def MyLoop(#x:dim, #m) = [
+define MyLoop(#x:dim, #m) = 
   (tuple [proj1 #m] [proj2 (loop #x)])
-].
+.
 
-Def Test = [
+define Test = 
   (MyLoop (dim 0) (loop 1))
-].
+.
 
-Print Test.
+print Test.
 
-Thm SNot : [(-> bool bool)] by [
+theorem SNot : (-> bool bool) by
   lam b => if b then `ff else `tt
-].
+.
 
-Thm StrictBoolTest : [ SNot = (Cmp SNot (Cmp SNot SNot)) in (-> bool bool) ] by [
+theorem StrictBoolTest : SNot = (Cmp SNot (Cmp SNot SNot)) in (-> bool bool)  by
   auto
-].
+.
 
-Thm Not : [(-> [_ : bool] bool)] by [
+theorem Not : (-> [_ : bool] bool) by
   lam x => if x then `ff else `tt
-].
+.
 
-Thm FunExt(#l:lvl) : [
+theorem FunExt(#l:lvl) :
   (->
    [a b : (U #l)]
    [f g : (-> a b)]
    [p : (-> [y : a] (path [_] b ($ f y) ($ g y)))]
    (path [_] (-> a b) f g))
-] by [
+by
   lam a b f g p =>
     abs i => lam x => use p [use x, `i]
-].
+.
 
-Print FunExt.
+print FunExt.
 
-Tac FunExtTac(#l : lvl) = [
+tactic FunExtTac(#l : lvl) = 
   query gl <- concl;
   match gl {
     [a b f g | #jdg{(path [_] (-> %a %b) %f %g) true} =>
       use (FunExt #l) [`%a, `%b, `%f, `%g, id]
     ]
   }
-].
+.
 
-Print FunExtTac.
+print FunExtTac.
 
-Thm NotNotPath : [(path [_] (-> bool bool) (Cmp Not Not) (lam [x] x))] by [
+theorem NotNotPath : (path [_] (-> bool bool) (Cmp Not Not) (lam [x] x)) by
   (FunExtTac #lvl{0});
   lam x => if x then abs _ => `tt else abs _ => `ff
-].
+.
 
-Extract NotNotPath.
-Print FunExtTac.
-Print NotNotPath.
+print NotNotPath.
+print FunExtTac.
+print NotNotPath.
 
-Thm Singleton : [(* [x : bool] (path [_] bool x tt))] by [
+theorem Singleton : (* [x : bool] (path [_] bool x tt)) by
   {`tt, abs _ => `tt}
-].
+.
 
-Thm PathElimTest : [(-> (path [_] bool tt tt) bool)] by [
+theorem PathElimTest : (-> (path [_] bool tt tt) bool) by
   lam x => use x [`(dim 0)]
-].
+.
 
-Thm PathEta(#l:lvl) : [
+theorem PathEta(#l:lvl) :
   (->
    [a : (U #l)]
    [m n : a]
    (path [_] a m n)
    (path [_] a m n))
-] by [
+by
   lam a m n p => abs j => use p [`j]
-].
+.
 
-Print PathEta.
+print PathEta.
 
-Print PathElimTest.
+print PathElimTest.

--- a/example/README.prl
+++ b/example/README.prl
@@ -1,77 +1,77 @@
-theorem BoolTest :
+theorem BoolTest : 
   (-> bool bool)
-by
+by {
   // A term/witness can be supplied to the refiner at any point in a tactic script
   // using the quotation operator `.
   lam x => if x then `tt else `ff
-.
+}.
 
 
-theorem PathTest :
+theorem PathTest : 
   (path [_] S1 base base)
-by
+by {
   abs x => `(loop x)
-.
+}.
 
-theorem LowLevel :
+theorem LowLevel : 
   (->
     (-> bool bool)
     bool)
-by
+by {
   refine fun/intro;
   [ with f =>
     elim f; [`tt, with x/eq x => use x]
   , refine fun/eqtype;
     refine bool/eqtype
   ]
-.
+}.
 
-do let val M = extract LowLevel; print M.
+print LowLevel.
 
-theorem LowLevel2 :
+theorem LowLevel2 : 
   (->
     (-> bool bool)
     bool
     bool)
-by
+by {
   repeat {refine fun/intro; [id, auto]};
   with x f =>
     elim f; 
     [ use x
     , with y/eq y => use y
     ]
-.
+}.
 
 
-do let val M = extract LowLevel2; print M.
+print LowLevel2.
 
-theorem FunElimTest :
+theorem FunElimTest : 
   (->
    (-> bool bool)
    bool)
-by
+by {
   lam f => use f [`tt]
-.
+}.
 
-theorem S1ElimTest : (-> S1 S1)  by
+theorem S1ElimTest :  (-> S1 S1) by {
   lam s =>
     case s of
        base => `base
      | loop x => `(loop x)
-.
+}.
 
-tactic Try(#t : tac) = 
+tactic Try(#t : tac) = {
   #t || id
-.
+}.
 
 // Useful for stepping through a proof RedPRL completes automatically, to see
 // what is being done.
-tactic TryStep = 
+tactic TryStep = {
   // We can call our Try tactical. But tactics are parsed with a different grammar than terms,
   // so to avoid ambiguity, when we need to provide a tactic expression as an argument to
   // an operator, we wrap it in (tactic ....).
   (Try #tac{auto-step})
-.
+}.
 
 // 'if' is the recursor for booleans.  It takes the motive of induction as an argument
 // in order to facilitate type synthesizing.
@@ -84,11 +84,11 @@ print BoolEta.
 // If we define such a function in the refiner using tactics, we can use the
 // built-in 'if x then t1 else t2' tactical, and the extracted witness will be
 // an 'if' form with the motive already filled in.
-theorem BoolEtaFunction :
+theorem BoolEtaFunction : 
   (-> bool bool)
-by
+by {
   lam b => if b then `tt else `ff
-.
+}.
 
 print BoolEtaFunction.
 
@@ -101,12 +101,12 @@ print BoolEtaFunction.
 // proof is that we can leave holes, and interactively figure out what
 // we need to do.
 //
-theorem PathTest2 :
+theorem PathTest2 : 
   (path
     [_] (-> bool bool)
     (lam [b] b)
     (lam [b] (BoolEta b)))
-by
+by {
   // abstract a dimension
   abs x =>
     // now, we are constructing a line of functions; so we use a
@@ -123,7 +123,7 @@ by
       // supplied to the refiner using the '@' "dimension quotation"
       // operator.
       use p [`x]
-.
+}.
 
 
 // It turns out that it is just as good to figure out what the witness
@@ -133,25 +133,25 @@ by
 // time the entirety of the program, and cannot take advantage of
 // types in order to guide its construction, or even synthesize part
 // of it.
-theorem PathTest3 :
+theorem PathTest3 : 
   (path
     [_] (-> bool bool)
     (lam [b] b)
     (lam [b] (BoolEta b)))
-by
-  // I'm surprised that RedPRL can typecheck this properly! Quite
+by {
+  // I'm surprised that RedPRL can typecheck this properly! quite
   // encouraging.
   `(abs [x]
     (lam [b]
      (@ (if [b] (path [_] bool b (BoolEta b)) b (abs [_] tt) (abs [_] ff))
         x)))
-.
+}.
 
 print PathTest3.
 
-theorem PairTest : (* [a : S1] (path [_] S1 a base))  by
+theorem PairTest :  (* [a : S1] (path [_] S1 a base)) by {
   {`base, abs x => `(loop x)}
-.
+}.
 
 
 define Cmp(#f, #g) = 
@@ -169,68 +169,68 @@ define Test =
 
 print Test.
 
-theorem SNot : (-> bool bool) by
+theorem SNot : (-> bool bool)by {
   lam b => if b then `ff else `tt
-.
+}.
 
-theorem StrictBoolTest : SNot = (Cmp SNot (Cmp SNot SNot)) in (-> bool bool)  by
+theorem StrictBoolTest :  SNot = (Cmp SNot (Cmp SNot SNot)) in (-> bool bool) by {
   auto
-.
+}.
 
-theorem Not : (-> [_ : bool] bool) by
+theorem Not : (-> [_ : bool] bool)by {
   lam x => if x then `ff else `tt
-.
+}.
 
-theorem FunExt(#l:lvl) :
+theorem FunExt(#l:lvl) : 
   (->
    [a b : (U #l)]
    [f g : (-> a b)]
    [p : (-> [y : a] (path [_] b ($ f y) ($ g y)))]
    (path [_] (-> a b) f g))
-by
+by {
   lam a b f g p =>
     abs i => lam x => use p [use x, `i]
-.
+}.
 
 print FunExt.
 
-tactic FunExtTac(#l : lvl) = 
+tactic FunExtTac(#l : lvl) = {
   query gl <- concl;
   match gl {
     [a b f g | #jdg{(path [_] (-> %a %b) %f %g) true} =>
       use (FunExt #l) [`%a, `%b, `%f, `%g, id]
     ]
   }
-.
+}.
 
 print FunExtTac.
 
-theorem NotNotPath : (path [_] (-> bool bool) (Cmp Not Not) (lam [x] x)) by
+theorem NotNotPath : (path [_] (-> bool bool) (Cmp Not Not) (lam [x] x))by {
   (FunExtTac #lvl{0});
   lam x => if x then abs _ => `tt else abs _ => `ff
-.
+}.
 
 print NotNotPath.
 print FunExtTac.
 print NotNotPath.
 
-theorem Singleton : (* [x : bool] (path [_] bool x tt)) by
+theorem Singleton : (* [x : bool] (path [_] bool x tt))by {
   {`tt, abs _ => `tt}
-.
+}.
 
-theorem PathElimTest : (-> (path [_] bool tt tt) bool) by
+theorem PathElimTest : (-> (path [_] bool tt tt) bool)by {
   lam x => use x [`(dim 0)]
-.
+}.
 
-theorem PathEta(#l:lvl) :
+theorem PathEta(#l:lvl) : 
   (->
    [a : (U #l)]
    [m n : a]
    (path [_] a m n)
    (path [_] a m n))
-by
+by {
   lam a m n p => abs j => use p [`j]
-.
+}.
 
 print PathEta.
 

--- a/example/README.prl
+++ b/example/README.prl
@@ -169,7 +169,7 @@ define Test =
 
 print Test.
 
-theorem SNot : (-> bool bool)by {
+theorem SNot : (-> bool bool) by {
   lam b => if b then `ff else `tt
 }.
 
@@ -177,7 +177,7 @@ theorem StrictBoolTest :  SNot = (Cmp SNot (Cmp SNot SNot)) in (-> bool bool) by
   auto
 }.
 
-theorem Not : (-> [_ : bool] bool)by {
+theorem Not : (-> [_ : bool] bool) by {
   lam x => if x then `ff else `tt
 }.
 
@@ -205,7 +205,7 @@ tactic FunExtTac(#l : lvl) = {
 
 print FunExtTac.
 
-theorem NotNotPath : (path [_] (-> bool bool) (Cmp Not Not) (lam [x] x))by {
+theorem NotNotPath : (path [_] (-> bool bool) (Cmp Not Not) (lam [x] x)) by {
   (FunExtTac #lvl{0});
   lam x => if x then abs _ => `tt else abs _ => `ff
 }.
@@ -214,11 +214,11 @@ print NotNotPath.
 print FunExtTac.
 print NotNotPath.
 
-theorem Singleton : (* [x : bool] (path [_] bool x tt))by {
+theorem Singleton : (* [x : bool] (path [_] bool x tt)) by {
   {`tt, abs _ => `tt}
 }.
 
-theorem PathElimTest : (-> (path [_] bool tt tt) bool)by {
+theorem PathElimTest : (-> (path [_] bool tt tt) bool) by {
   lam x => use x [`(dim 0)]
 }.
 

--- a/example/README.prl
+++ b/example/README.prl
@@ -1,4 +1,4 @@
-theorem BoolTest : 
+theorem BoolTest :
   (-> bool bool)
 by {
   // A term/witness can be supplied to the refiner at any point in a tactic script
@@ -7,13 +7,13 @@ by {
 }.
 
 
-theorem PathTest : 
+theorem PathTest :
   (path [_] S1 base base)
 by {
   abs x => `(loop x)
 }.
 
-theorem LowLevel : 
+theorem LowLevel :
   (->
     (-> bool bool)
     bool)
@@ -28,7 +28,7 @@ by {
 
 print LowLevel.
 
-theorem LowLevel2 : 
+theorem LowLevel2 :
   (->
     (-> bool bool)
     bool
@@ -36,7 +36,7 @@ theorem LowLevel2 :
 by {
   repeat {refine fun/intro; [id, auto]};
   with x f =>
-    elim f; 
+    elim f;
     [ use x
     , with y/eq y => use y
     ]
@@ -45,7 +45,7 @@ by {
 
 print LowLevel2.
 
-theorem FunElimTest : 
+theorem FunElimTest :
   (->
    (-> bool bool)
    bool)
@@ -75,7 +75,7 @@ tactic TryStep = {
 
 // 'if' is the recursor for booleans.  It takes the motive of induction as an argument
 // in order to facilitate type synthesizing.
-define BoolEta(#M) = 
+define BoolEta(#M) =
   (if [a] bool #M tt ff)
 .
 
@@ -84,7 +84,7 @@ print BoolEta.
 // If we define such a function in the refiner using tactics, we can use the
 // built-in 'if x then t1 else t2' tactical, and the extracted witness will be
 // an 'if' form with the motive already filled in.
-theorem BoolEtaFunction : 
+theorem BoolEtaFunction :
   (-> bool bool)
 by {
   lam b => if b then `tt else `ff
@@ -101,7 +101,7 @@ print BoolEtaFunction.
 // proof is that we can leave holes, and interactively figure out what
 // we need to do.
 //
-theorem PathTest2 : 
+theorem PathTest2 :
   (path
     [_] (-> bool bool)
     (lam [b] b)
@@ -133,7 +133,7 @@ by {
 // time the entirety of the program, and cannot take advantage of
 // types in order to guide its construction, or even synthesize part
 // of it.
-theorem PathTest3 : 
+theorem PathTest3 :
   (path
     [_] (-> bool bool)
     (lam [b] b)
@@ -154,16 +154,16 @@ theorem PairTest :  (* [a : S1] (path [_] S1 a base)) by {
 }.
 
 
-define Cmp(#f, #g) = 
+define Cmp(#f, #g) =
   (lam [x] ($ #f ($ #g x)))
 .
 
 
-define MyLoop(#x:dim, #m) = 
+define MyLoop(#x:dim, #m) =
   (tuple [proj1 #m] [proj2 (loop #x)])
 .
 
-define Test = 
+define Test =
   (MyLoop (dim 0) (loop 1))
 .
 
@@ -181,7 +181,7 @@ theorem Not : (-> [_ : bool] bool)by {
   lam x => if x then `ff else `tt
 }.
 
-theorem FunExt(#l:lvl) : 
+theorem FunExt(#l:lvl) :
   (->
    [a b : (U #l)]
    [f g : (-> a b)]
@@ -222,7 +222,7 @@ theorem PathElimTest : (-> (path [_] bool tt tt) bool)by {
   lam x => use x [`(dim 0)]
 }.
 
-theorem PathEta(#l:lvl) : 
+theorem PathEta(#l:lvl) :
   (->
    [a : (U #l)]
    [m n : a]

--- a/example/README.prl
+++ b/example/README.prl
@@ -114,9 +114,9 @@ by {
     lam b =>
       // for our b:bool, we will construct a path between b and
       // (BoolEta b).
-      claim p : [(path [_] bool b (BoolEta b))] by [
+      claim p : (path [_] bool b (BoolEta b)) by {
         if b then abs y => `tt else abs y => `ff
-      ];
+      };
 
       // Now, we will project the 'x'-side of our path. In the
       // interactive tactic environment, dimension expressions are

--- a/example/category.prl
+++ b/example/category.prl
@@ -1,4 +1,4 @@
-theorem Category(#i:lvl) : (U (++ #i))  by
+theorem Category(#i:lvl) :  (U (++ #i)) by {
    `(record
      [ob : (U #i)]
      [hom : (-> ob ob (U #i))]
@@ -28,9 +28,9 @@ theorem Category(#i:lvl) : (U (++ #i))  by
           ($ cmp a c d h ($ cmp a b c g f))
           ($ cmp a b d ($ cmp b c d h g) f)
           ))])
-.
+}.
 
-theorem Test(#l:lvl) : (Category (++#l)) by
+theorem Test(#l:lvl) : (Category (++#l))by {
   { ob = `(U #l)
   , hom = lam ty/a ty/b => `(-> ty/a ty/b)
   , idn = lam ty/a x => `x
@@ -39,11 +39,11 @@ theorem Test(#l:lvl) : (Category (++#l)) by
   , idn/r = lam _ _ _ => auto
   , assoc = lam _ _ _ _ _ _ _ => auto
   }
-.
+}.
 
-// theorem Op(#l:lvl) :
+// theorem Op(#l:lvl) : 
 //   (-> (Category #l) (Category #l))
-// by
+// by {
 //   lam {ob = ob, hom = hom, idn = idn, cmp = cmp, idn/l = idn/l, idn/r = idn/r, assoc = assoc} => 
 //     { ob = `ob
 //     , hom = lam c d => use hom [`d, `c]
@@ -53,4 +53,4 @@ theorem Test(#l:lvl) : (Category (++#l)) by
 //     , idn/r = lam a b f => use idn/l [`b, `a, `f]; auto; assumption
 //     , assoc = ?
 //     }
-// .
+// }.

--- a/example/category.prl
+++ b/example/category.prl
@@ -18,8 +18,8 @@ theorem Category(#i:lvl) :  (U (++ #i)) by {
        (= ($ hom a b)
           ($ cmp a a b f ($ idn a))
           f))]
-     [assoc : 
-      (-> 
+     [assoc :
+      (->
        [a b c d : ob]
        [f : ($ hom a b)]
        [g : ($ hom b c)]
@@ -41,10 +41,10 @@ theorem Test(#l:lvl) : (Category (++#l))by {
   }
 }.
 
-// theorem Op(#l:lvl) : 
+// theorem Op(#l:lvl) :
 //   (-> (Category #l) (Category #l))
 // by {
-//   lam {ob = ob, hom = hom, idn = idn, cmp = cmp, idn/l = idn/l, idn/r = idn/r, assoc = assoc} => 
+//   lam {ob = ob, hom = hom, idn = idn, cmp = cmp, idn/l = idn/l, idn/r = idn/r, assoc = assoc} =>
 //     { ob = `ob
 //     , hom = lam c d => use hom [`d, `c]
 //     , idn = `idn

--- a/example/category.prl
+++ b/example/category.prl
@@ -1,4 +1,4 @@
-Thm Category(#i:lvl) : [ (U (++ #i)) ] by [
+theorem Category(#i:lvl) : (U (++ #i))  by
    `(record
      [ob : (U #i)]
      [hom : (-> ob ob (U #i))]
@@ -28,9 +28,9 @@ Thm Category(#i:lvl) : [ (U (++ #i)) ] by [
           ($ cmp a c d h ($ cmp a b c g f))
           ($ cmp a b d ($ cmp b c d h g) f)
           ))])
-].
+.
 
-Thm Test(#l:lvl) : [(Category (++#l))] by [
+theorem Test(#l:lvl) : (Category (++#l)) by
   { ob = `(U #l)
   , hom = lam ty/a ty/b => `(-> ty/a ty/b)
   , idn = lam ty/a x => `x
@@ -39,11 +39,11 @@ Thm Test(#l:lvl) : [(Category (++#l))] by [
   , idn/r = lam _ _ _ => auto
   , assoc = lam _ _ _ _ _ _ _ => auto
   }
-].
+.
 
-// Thm Op(#l:lvl) : [
+// theorem Op(#l:lvl) :
 //   (-> (Category #l) (Category #l))
-// ] by [
+// by
 //   lam {ob = ob, hom = hom, idn = idn, cmp = cmp, idn/l = idn/l, idn/r = idn/r, assoc = assoc} => 
 //     { ob = `ob
 //     , hom = lam c d => use hom [`d, `c]
@@ -53,4 +53,4 @@ Thm Test(#l:lvl) : [(Category (++#l))] by [
 //     , idn/r = lam a b f => use idn/l [`b, `a, `f]; auto; assumption
 //     , assoc = ?
 //     }
-// ].
+// .

--- a/example/category.prl
+++ b/example/category.prl
@@ -30,7 +30,7 @@ theorem Category(#i:lvl) :  (U (++ #i)) by {
           ))])
 }.
 
-theorem Test(#l:lvl) : (Category (++#l))by {
+theorem Test(#l:lvl) : (Category (++#l)) by {
   { ob = `(U #l)
   , hom = lam ty/a ty/b => `(-> ty/a ty/b)
   , idn = lam ty/a x => `x

--- a/example/connection.prl
+++ b/example/connection.prl
@@ -1,10 +1,10 @@
-Thm Connection/And(#l:lvl) : [
+theorem Connection/And(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [i] (path [_] ty a (@ p i)) (abs [_] a) p))
-] by [
+by
   lam ty a b p =>
     abs i j =>
       `(hcom 0~>1 ty a
@@ -13,25 +13,27 @@ Thm Connection/And(#l:lvl) : [
         [j=0 [k] (hcom 1~>0 ty (@ p k) [k=0 [_] a] [k=1 [l] (@ p l)])]
         [j=1 [k] (hcom 1~>i ty (@ p k) [k=0 [_] a] [k=1 [l] (@ p l)])]
         [i=j [k] (hcom 1~>i ty (@ p k) [k=0 [_] a] [k=1 [l] (@ p l)])])
-].
+.
 
-Thm Connection/And/Diagonal (#l:lvl) : [
+theorem Connection/And/Diagonal (#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (= (path [_] ty a b) (abs [i] (@ ($ (Connection/And #l) ty a b p) i i)) p))
-] by [
+by
   lam ty a b p => unfold Connection/And; auto
-].
+.
 
-Thm Connection/Or(#l:lvl) : [
+do let val M = extract Connection/And/Diagonal; print M.
+
+theorem Connection/Or(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [i] (path [_] ty (@ p i) b) p (abs [_] b)))
-] by [
+by
   lam ty a b p =>
    abs i j =>
      `(hcom 1~>0 ty b
@@ -40,14 +42,14 @@ Thm Connection/Or(#l:lvl) : [
        [j=0 [k] (hcom 0~>i ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
        [j=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
        [i=j [k] (hcom 0~>i ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])])
-].
+.
 
-Thm Connection/Or/Diagonal (#l:lvl) : [
+theorem Connection/Or/Diagonal (#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (= (path [_] ty a b) (abs [i] (@ ($ (Connection/Or #l) ty a b p) i i)) p))
-] by [
+by
   lam ty a b p => unfold Connection/Or; auto
-].
+.

--- a/example/connection.prl
+++ b/example/connection.prl
@@ -1,10 +1,10 @@
-theorem Connection/And(#l:lvl) :
+theorem Connection/And(#l:lvl) : 
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [i] (path [_] ty a (@ p i)) (abs [_] a) p))
-by
+by {
   lam ty a b p =>
     abs i j =>
       `(hcom 0~>1 ty a
@@ -13,27 +13,25 @@ by
         [j=0 [k] (hcom 1~>0 ty (@ p k) [k=0 [_] a] [k=1 [l] (@ p l)])]
         [j=1 [k] (hcom 1~>i ty (@ p k) [k=0 [_] a] [k=1 [l] (@ p l)])]
         [i=j [k] (hcom 1~>i ty (@ p k) [k=0 [_] a] [k=1 [l] (@ p l)])])
-.
+}.
 
-theorem Connection/And/Diagonal (#l:lvl) :
+theorem Connection/And/Diagonal (#l:lvl) : 
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (= (path [_] ty a b) (abs [i] (@ ($ (Connection/And #l) ty a b p) i i)) p))
-by
+by {
   lam ty a b p => unfold Connection/And; auto
-.
+}.
 
-do let val M = extract Connection/And/Diagonal; print M.
-
-theorem Connection/Or(#l:lvl) :
+theorem Connection/Or(#l:lvl) : 
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [i] (path [_] ty (@ p i) b) p (abs [_] b)))
-by
+by {
   lam ty a b p =>
    abs i j =>
      `(hcom 1~>0 ty b
@@ -42,14 +40,14 @@ by
        [j=0 [k] (hcom 0~>i ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
        [j=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
        [i=j [k] (hcom 0~>i ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])])
-.
+}.
 
-theorem Connection/Or/Diagonal (#l:lvl) :
+theorem Connection/Or/Diagonal (#l:lvl) : 
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (= (path [_] ty a b) (abs [i] (@ ($ (Connection/Or #l) ty a b p) i i)) p))
-by
+by {
   lam ty a b p => unfold Connection/Or; auto
-.
+}.

--- a/example/connection.prl
+++ b/example/connection.prl
@@ -1,4 +1,4 @@
-theorem Connection/And(#l:lvl) : 
+theorem Connection/And(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b : ty]
@@ -15,7 +15,7 @@ by {
         [i=j [k] (hcom 1~>i ty (@ p k) [k=0 [_] a] [k=1 [l] (@ p l)])])
 }.
 
-theorem Connection/And/Diagonal (#l:lvl) : 
+theorem Connection/And/Diagonal (#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b : ty]
@@ -25,7 +25,7 @@ by {
   lam ty a b p => unfold Connection/And; auto
 }.
 
-theorem Connection/Or(#l:lvl) : 
+theorem Connection/Or(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b : ty]
@@ -42,7 +42,7 @@ by {
        [i=j [k] (hcom 0~>i ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])])
 }.
 
-theorem Connection/Or/Diagonal (#l:lvl) : 
+theorem Connection/Or/Diagonal (#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b : ty]

--- a/example/groupoid.prl
+++ b/example/groupoid.prl
@@ -1,42 +1,42 @@
 // Homogeneous groupoid operations
 
-theorem Refl(#l:lvl) :
+theorem Refl(#l:lvl) : 
   (->
    [ty : (U #l kan)]
    [a : ty]
    (path [_] ty a a))
-by
+by {
   lam ty a => abs _ => `a
-.
+}.
 
-theorem Symm(#l:lvl) :
+theorem Symm(#l:lvl) : 
   (->
    [ty : (U #l kan)]
    [p : (line [_] ty)]
    (path [_] ty (@ p 1) (@ p 0)))
-by
+by {
   lam ty p => abs x =>
   `(hcom 0~>1 ty (@ p 0)
     [x=0 [y] (@ p y)]
     [x=1 [_] (@ p 0)])
-.
+}.
 
-theorem Trans(#l:lvl) :
+theorem Trans(#l:lvl) : 
   (->
    [ty : (U #l kan)]
    [p : (line [_] ty)]
    [q : (line [_] ty)]
    [eq : (= ty (@ p 1) (@ q 0))]
    (path [_] ty (@ p 0) (@ q 1)))
-by
+by {
   lam ty p q eq => (abs x =>
     `(hcom 0~>1 ty (@ p x)
       [x=0 [_] (@ p 0)]
       [x=1 [z] (@ q z)]));
     auto; assumption
-.
+}.
 
-theorem Symm/Unit(#l:lvl) :
+theorem Symm/Unit(#l:lvl) : 
   (->
    [ty : (U #l kan)]
    [a : ty]
@@ -44,13 +44,13 @@ theorem Symm/Unit(#l:lvl) :
      (path [_] ty a a)
      (abs [_] a)
      ($ (Symm #l) ty (abs [_] a))))
-by
+by {
   lam ty a =>
   abs y x =>
   `(hcom 0~>y ty a [x=0 [_] a] [x=1 [_] a])
-.
+}.
 
-theorem Trans/Unit/R(#l:lvl) :
+theorem Trans/Unit/R(#l:lvl) : 
   (->
    [ty : (U #l kan)]
    [p : (line [_] ty)]
@@ -58,16 +58,16 @@ theorem Trans/Unit/R(#l:lvl) :
      (path [_] ty (@ p 0) (@ p 1))
      p
      ($ (Trans #l) ty p (abs [_] (@ p 1)) ax)))
-by
+by {
   lam ty p =>
   (abs y x => 
     `(hcom 0~>y ty (@ p x) [x=0 [_] (@ p 0)] [x=1 [_] (@ p 1)]));
   
   refine path/eq/from-line; auto
-.
+}.
 
 // Thanks to Bruno Bentzen for already doing this and drawing a picture! -Carlo
-theorem Trans/Sym/R(#l:lvl) :
+theorem Trans/Sym/R(#l:lvl) : 
   (->
    [ty : (U #l kan)]
    [p : (line [_] ty)]
@@ -75,7 +75,7 @@ theorem Trans/Sym/R(#l:lvl) :
      (path [_] ty (@ p 0) (@ p 0))
      (abs [_] (@ p 0))
      ($ (Trans #l) ty p ($ (Symm #l) ty p) ax)))
-by
+by {
   lam ty p =>
   (abs z x =>
     `(hcom 0~>1 ty (@ p x)
@@ -87,11 +87,11 @@ by
           [x=0 [_] (@ p 0)]
           [x=1 [y] (@ ($ (Symm #l) ty p) y)])]));
   unfold Symm; auto
-.
+}.
 
 // Heterogeneous groupoid operations
 
-theorem DSymm(#l:lvl) :
+theorem DSymm(#l:lvl) : 
   (->
    [ty : (line [_] (U #l kan))]
    [p : (line [x] (@ ty x))]
@@ -99,7 +99,7 @@ theorem DSymm(#l:lvl) :
      (@ ($ (Symm (++ #l)) (U #l kan) ty) x)
      (@ p 1)
      (@ p 0)))
-by
+by {
   lam ty p =>
   (abs x =>
   `(com 0~>1
@@ -108,4 +108,4 @@ by
     [x=0 [y] (@ p y)]
     [x=1 [_] (@ p 0)]));
   unfold Symm; auto
-.
+}.

--- a/example/groupoid.prl
+++ b/example/groupoid.prl
@@ -1,42 +1,42 @@
 // Homogeneous groupoid operations
 
-Thm Refl(#l:lvl) : [
+theorem Refl(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [a : ty]
    (path [_] ty a a))
-] by [
+by
   lam ty a => abs _ => `a
-].
+.
 
-Thm Symm(#l:lvl) : [
+theorem Symm(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [p : (line [_] ty)]
    (path [_] ty (@ p 1) (@ p 0)))
-] by [
+by
   lam ty p => abs x =>
   `(hcom 0~>1 ty (@ p 0)
     [x=0 [y] (@ p y)]
     [x=1 [_] (@ p 0)])
-].
+.
 
-Thm Trans(#l:lvl) : [
+theorem Trans(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [p : (line [_] ty)]
    [q : (line [_] ty)]
    [eq : (= ty (@ p 1) (@ q 0))]
    (path [_] ty (@ p 0) (@ q 1)))
-] by [
+by
   lam ty p q eq => (abs x =>
     `(hcom 0~>1 ty (@ p x)
       [x=0 [_] (@ p 0)]
       [x=1 [z] (@ q z)]));
     auto; assumption
-].
+.
 
-Thm Symm/Unit(#l:lvl) : [
+theorem Symm/Unit(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [a : ty]
@@ -44,13 +44,13 @@ Thm Symm/Unit(#l:lvl) : [
      (path [_] ty a a)
      (abs [_] a)
      ($ (Symm #l) ty (abs [_] a))))
-] by [
+by
   lam ty a =>
   abs y x =>
   `(hcom 0~>y ty a [x=0 [_] a] [x=1 [_] a])
-].
+.
 
-Thm Trans/Unit/R(#l:lvl) : [
+theorem Trans/Unit/R(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [p : (line [_] ty)]
@@ -58,16 +58,16 @@ Thm Trans/Unit/R(#l:lvl) : [
      (path [_] ty (@ p 0) (@ p 1))
      p
      ($ (Trans #l) ty p (abs [_] (@ p 1)) ax)))
-] by [
+by
   lam ty p =>
   (abs y x => 
     `(hcom 0~>y ty (@ p x) [x=0 [_] (@ p 0)] [x=1 [_] (@ p 1)]));
   
   refine path/eq/from-line; auto
-].
+.
 
 // Thanks to Bruno Bentzen for already doing this and drawing a picture! -Carlo
-Thm Trans/Sym/R(#l:lvl) : [
+theorem Trans/Sym/R(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [p : (line [_] ty)]
@@ -75,7 +75,7 @@ Thm Trans/Sym/R(#l:lvl) : [
      (path [_] ty (@ p 0) (@ p 0))
      (abs [_] (@ p 0))
      ($ (Trans #l) ty p ($ (Symm #l) ty p) ax)))
-] by [
+by
   lam ty p =>
   (abs z x =>
     `(hcom 0~>1 ty (@ p x)
@@ -87,11 +87,11 @@ Thm Trans/Sym/R(#l:lvl) : [
           [x=0 [_] (@ p 0)]
           [x=1 [y] (@ ($ (Symm #l) ty p) y)])]));
   unfold Symm; auto
-].
+.
 
 // Heterogeneous groupoid operations
 
-Thm DSymm(#l:lvl) : [
+theorem DSymm(#l:lvl) :
   (->
    [ty : (line [_] (U #l kan))]
    [p : (line [x] (@ ty x))]
@@ -99,7 +99,7 @@ Thm DSymm(#l:lvl) : [
      (@ ($ (Symm (++ #l)) (U #l kan) ty) x)
      (@ p 1)
      (@ p 0)))
-] by [
+by
   lam ty p =>
   (abs x =>
   `(com 0~>1
@@ -108,4 +108,4 @@ Thm DSymm(#l:lvl) : [
     [x=0 [y] (@ p y)]
     [x=1 [_] (@ p 0)]));
   unfold Symm; auto
-].
+.

--- a/example/groupoid.prl
+++ b/example/groupoid.prl
@@ -1,6 +1,6 @@
 // Homogeneous groupoid operations
 
-theorem Refl(#l:lvl) : 
+theorem Refl(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [a : ty]
@@ -9,7 +9,7 @@ by {
   lam ty a => abs _ => `a
 }.
 
-theorem Symm(#l:lvl) : 
+theorem Symm(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [p : (line [_] ty)]
@@ -21,7 +21,7 @@ by {
     [x=1 [_] (@ p 0)])
 }.
 
-theorem Trans(#l:lvl) : 
+theorem Trans(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [p : (line [_] ty)]
@@ -36,7 +36,7 @@ by {
     auto; assumption
 }.
 
-theorem Symm/Unit(#l:lvl) : 
+theorem Symm/Unit(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [a : ty]
@@ -50,7 +50,7 @@ by {
   `(hcom 0~>y ty a [x=0 [_] a] [x=1 [_] a])
 }.
 
-theorem Trans/Unit/R(#l:lvl) : 
+theorem Trans/Unit/R(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [p : (line [_] ty)]
@@ -60,14 +60,14 @@ theorem Trans/Unit/R(#l:lvl) :
      ($ (Trans #l) ty p (abs [_] (@ p 1)) ax)))
 by {
   lam ty p =>
-  (abs y x => 
+  (abs y x =>
     `(hcom 0~>y ty (@ p x) [x=0 [_] (@ p 0)] [x=1 [_] (@ p 1)]));
-  
+
   refine path/eq/from-line; auto
 }.
 
 // Thanks to Bruno Bentzen for already doing this and drawing a picture! -Carlo
-theorem Trans/Sym/R(#l:lvl) : 
+theorem Trans/Sym/R(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [p : (line [_] ty)]
@@ -91,7 +91,7 @@ by {
 
 // Heterogeneous groupoid operations
 
-theorem DSymm(#l:lvl) : 
+theorem DSymm(#l:lvl) :
   (->
    [ty : (line [_] (U #l kan))]
    [p : (line [x] (@ ty x))]

--- a/example/hlevels.prl
+++ b/example/hlevels.prl
@@ -1,34 +1,34 @@
-Def HasAllPathsTo (#C,#c) = [(-> [c' : #C] (path [_] #C c' #c))].
-Def IsContr (#C) = [(* [c : #C] (HasAllPathsTo #C c))].
-Def IsProp (#A) = [(-> [a b : #A] (path [_] #A a b))].
-Def IsSet (#A) = [(-> [a b : #A] (IsProp (path [_] #A a b)))].
+define HasAllPathsTo (#C,#c) = (-> [c' : #C] (path [_] #C c' #c)).
+define IsContr (#C) = (* [c : #C] (HasAllPathsTo #C c)).
+define IsProp (#A) = (-> [a b : #A] (path [_] #A a b)).
+define IsSet (#A) = (-> [a b : #A] (IsProp (path [_] #A a b))).
 
-Thm InhPropIsContr(#l:lvl) : [
+theorem InhPropIsContr(#l:lvl) :
  (->
   [ty : (U #l kan)] // can I use pre here?
   [h : (IsProp ty)]
   [a : ty]
   (IsContr ty))
-] by [
+by
   lam ty h a => {use a, lam x => `($ h x a)}
-].
+.
 
-Thm PropPi(#l:lvl) : [
+theorem PropPi(#l:lvl) :
  (->
   [tyA : (U #l kan)]
   [tyB : (-> tyA (U #l kan))]
   [h : (-> [x : tyA] (IsProp ($ tyB x)))]
   (IsProp (-> [x : tyA] ($ tyB x))))
-] by [
+by
   lam tyA tyB h f g => abs i => lam x => `(@ ($ h x ($ f x) ($ g x)) i)
-].
+.
 
-Thm PropSet(#l:lvl) : [
+theorem PropSet(#l:lvl) :
   (->
    [tyA : (U #l kan)]
    [h : (IsProp tyA)]
    (IsSet tyA))
-] by [
+by
   lam tyA h a b p q =>
   abs j i =>
     `(hcom 0~>1 tyA a
@@ -36,38 +36,38 @@ Thm PropSet(#l:lvl) : [
       [i=1 [k] (@ ($ h a b) k)]
       [j=0 [k] (@ ($ h a (@ p i)) k)]
       [j=1 [k] (@ ($ h a (@ q i)) k)])
-].
+.
 
 // This proof should be easy, but it is not...
-Thm IsPropIsProp(#l:lvl) : [
+theorem IsPropIsProp(#l:lvl) :
   (->
    [tyA : (U #l kan)]
    (IsProp (IsProp tyA))
   )
-] by [
+by
   lam tyA h1 h2 =>
   abs i => lam a b =>
     let foo = (PropSet #l) [`tyA, `h1];
     unfold IsSet IsProp;
     use foo [`a, `b, use h1 [`a, `b], use h2 [`a, `b], `i]
-].
+.
 
-Thm IsPropIsProp'(#l:lvl) : [
+theorem IsPropIsProp'(#l:lvl) :
   (->
    [tyA : (U #l kan)]
    (IsProp (IsProp tyA))
   )
-] by [
+by
   lam tyA h1 h2 => abs i => lam a b =>
     `(@ ($ (PropSet #l) tyA h1 a b ($ h1 a b) ($ h2 a b)) i)
-].
+.
 
 // // This should be exactly like the one above:
-// Thm IsPropIsSet(#l:lvl) : [
+// theorem IsPropIsSet(#l:lvl) :
 //   (->
 //    [tyA : (U #l kan)]
 //    (IsProp (IsSet tyA))
 //   )
-//  ] by [
+//  by
 //   ?hole
-// ].
+// .

--- a/example/hlevels.prl
+++ b/example/hlevels.prl
@@ -3,7 +3,7 @@ define IsContr (#C) = (* [c : #C] (HasAllPathsTo #C c)).
 define IsProp (#A) = (-> [a b : #A] (path [_] #A a b)).
 define IsSet (#A) = (-> [a b : #A] (IsProp (path [_] #A a b))).
 
-theorem InhPropIsContr(#l:lvl) : 
+theorem InhPropIsContr(#l:lvl) :
  (->
   [ty : (U #l kan)] // can I use pre here?
   [h : (IsProp ty)]
@@ -13,7 +13,7 @@ by {
   lam ty h a => {use a, lam x => `($ h x a)}
 }.
 
-theorem PropPi(#l:lvl) : 
+theorem PropPi(#l:lvl) :
  (->
   [tyA : (U #l kan)]
   [tyB : (-> tyA (U #l kan))]
@@ -23,7 +23,7 @@ by {
   lam tyA tyB h f g => abs i => lam x => `(@ ($ h x ($ f x) ($ g x)) i)
 }.
 
-theorem PropSet(#l:lvl) : 
+theorem PropSet(#l:lvl) :
   (->
    [tyA : (U #l kan)]
    [h : (IsProp tyA)]
@@ -39,7 +39,7 @@ by {
 }.
 
 // This proof should be easy, but it is not...
-theorem IsPropIsProp(#l:lvl) : 
+theorem IsPropIsProp(#l:lvl) :
   (->
    [tyA : (U #l kan)]
    (IsProp (IsProp tyA))
@@ -52,7 +52,7 @@ by {
     use foo [`a, `b, use h1 [`a, `b], use h2 [`a, `b], `i]
 }.
 
-theorem IsPropIsProp'(#l:lvl) : 
+theorem IsPropIsProp'(#l:lvl) :
   (->
    [tyA : (U #l kan)]
    (IsProp (IsProp tyA))
@@ -63,7 +63,7 @@ by {
 }.
 
 // // This should be exactly like the one above:
-// theorem IsPropIsSet(#l:lvl) : 
+// theorem IsPropIsSet(#l:lvl) :
 //   (->
 //    [tyA : (U #l kan)]
 //    (IsProp (IsSet tyA))

--- a/example/hlevels.prl
+++ b/example/hlevels.prl
@@ -3,32 +3,32 @@ define IsContr (#C) = (* [c : #C] (HasAllPathsTo #C c)).
 define IsProp (#A) = (-> [a b : #A] (path [_] #A a b)).
 define IsSet (#A) = (-> [a b : #A] (IsProp (path [_] #A a b))).
 
-theorem InhPropIsContr(#l:lvl) :
+theorem InhPropIsContr(#l:lvl) : 
  (->
   [ty : (U #l kan)] // can I use pre here?
   [h : (IsProp ty)]
   [a : ty]
   (IsContr ty))
-by
+by {
   lam ty h a => {use a, lam x => `($ h x a)}
-.
+}.
 
-theorem PropPi(#l:lvl) :
+theorem PropPi(#l:lvl) : 
  (->
   [tyA : (U #l kan)]
   [tyB : (-> tyA (U #l kan))]
   [h : (-> [x : tyA] (IsProp ($ tyB x)))]
   (IsProp (-> [x : tyA] ($ tyB x))))
-by
+by {
   lam tyA tyB h f g => abs i => lam x => `(@ ($ h x ($ f x) ($ g x)) i)
-.
+}.
 
-theorem PropSet(#l:lvl) :
+theorem PropSet(#l:lvl) : 
   (->
    [tyA : (U #l kan)]
    [h : (IsProp tyA)]
    (IsSet tyA))
-by
+by {
   lam tyA h a b p q =>
   abs j i =>
     `(hcom 0~>1 tyA a
@@ -36,38 +36,38 @@ by
       [i=1 [k] (@ ($ h a b) k)]
       [j=0 [k] (@ ($ h a (@ p i)) k)]
       [j=1 [k] (@ ($ h a (@ q i)) k)])
-.
+}.
 
 // This proof should be easy, but it is not...
-theorem IsPropIsProp(#l:lvl) :
+theorem IsPropIsProp(#l:lvl) : 
   (->
    [tyA : (U #l kan)]
    (IsProp (IsProp tyA))
   )
-by
+by {
   lam tyA h1 h2 =>
   abs i => lam a b =>
     let foo = (PropSet #l) [`tyA, `h1];
     unfold IsSet IsProp;
     use foo [`a, `b, use h1 [`a, `b], use h2 [`a, `b], `i]
-.
+}.
 
-theorem IsPropIsProp'(#l:lvl) :
+theorem IsPropIsProp'(#l:lvl) : 
   (->
    [tyA : (U #l kan)]
    (IsProp (IsProp tyA))
   )
-by
+by {
   lam tyA h1 h2 => abs i => lam a b =>
     `(@ ($ (PropSet #l) tyA h1 a b ($ h1 a b) ($ h2 a b)) i)
-.
+}.
 
 // // This should be exactly like the one above:
-// theorem IsPropIsSet(#l:lvl) :
+// theorem IsPropIsSet(#l:lvl) : 
 //   (->
 //    [tyA : (U #l kan)]
 //    (IsProp (IsSet tyA))
 //   )
-//  by
+//  by {
 //   ?hole
-// .
+// }.

--- a/example/metalanguage.prl
+++ b/example/metalanguage.prl
@@ -1,0 +1,22 @@
+// RedPRL's metalanguage is called RedML. RedPRL documents are really sequences of RedML declarations!
+// RedML is like "CBPV with nominal characteristics"; later it will develop to a full ML.
+
+define Op = (lam [x] x).
+
+// we can suspend a command to execute later. "{ cmd }" turns a command into a value (thunk),
+// and "^ val" is the command that returns a value.
+val MyCmd = ^ { print Op }.
+
+let
+  theorem Bar(#l:lvl) : (-> [ty : (U #l kan)] ty ty) by {
+    lam ty x => use x
+  };
+  let val M = extract Bar;
+  print M.
+
+// Bar no longer in scope
+
+
+// now let's go ahead and run our command
+!MyCmd.
+

--- a/example/omega1s1.prl
+++ b/example/omega1s1.prl
@@ -1,6 +1,6 @@
-theorem IntPred :
+theorem IntPred : 
   (-> int int)
-by
+by {
   lam a => elim a;
   [ with n => elim n;
     [ `(int -1)
@@ -8,11 +8,11 @@ by
     ]
   , with n => `(negsucc (succ n))
   ];
-.
+}.
 
-theorem IntSucc :
+theorem IntSucc : 
   (-> int int)
-by
+by {
   lam a => elim a;
   [ with n => `(pos (succ n))
   , with n => elim n;
@@ -20,25 +20,25 @@ by
     , with _ n' => `(negsucc n')
     ]
   ]
-.
+}.
 
-theorem IntSuccIntPred :
+theorem IntSuccIntPred : 
   (-> [i : int] (= int ($ IntSucc ($ IntPred i)) i))
-by
+by {
   lam i => elim i;
   [ with n => elim n; auto
   , auto
   ]
-.
+}.
 
-theorem IntPredIntSucc :
+theorem IntPredIntSucc : 
   (-> [i : int] (= int ($ IntPred ($ IntSucc i)) i))
-by
+by {
   lam i => elim i;
   [ auto
   , with n => elim n; auto
   ]
-.
+}.
 
 define HasAllPathsTo (#C,#c) = (-> [c' : #C] (path [_] #C c' #c)).
 
@@ -50,9 +50,9 @@ define IsEquiv (#A,#B,#f) = (-> [b : #B] (IsContr (Fiber #A #B #f b))).
 
 define Equiv (#A,#B) = (* [f : (-> #A #B)] (IsEquiv #A #B f)).
 
-theorem IntSuccIsEquiv :
+theorem IntSuccIsEquiv : 
   (IsEquiv int int IntSucc)
-by
+by {
   lam i =>
     claim eq : [(= int ($ IntSucc ($ IntPred i)) i)] by [use IntSuccIntPred [`i]];
     unfold IntSucc IntPred in eq; reduce at left in eq;
@@ -71,63 +71,63 @@ by
 
         auto; unfold IntPred in eq1; reduce at left in eq1; auto; assumption
     }
-.
+}.
 
-theorem IntSuccEquiv :
+theorem IntSuccEquiv : 
   (Equiv int int)
-by
+by {
   {`IntSucc, `IntSuccIsEquiv}
-.
+}.
 
-theorem IntSuccPath :
+theorem IntSuccPath : 
   (path [_] (U 0 kan) int int)
-by
+by {
   abs x => `(V x int int IntSuccEquiv)
-.
+}.
 
-theorem S1UnivCover :
+theorem S1UnivCover : 
   (-> S1 (U 0 kan))
-by
+by {
   lam x => `(S1-rec [_] (U 0 kan) x int [x] (@ IntSuccPath x)); 
-.
+}.
 
-theorem Loop :
+theorem Loop : 
   (path [_] S1 base base)
-by
+by {
   abs i => `(loop i)
-.
+}.
 
-theorem S1LoopToInt :
+theorem S1LoopToInt : 
   (-> (path [_] S1 base base) int)
-by
+by {
   lam l => `(coe 0~>1 [x] ($ S1UnivCover (@ l x)) (int 0));
     claim eq : [(= S1 (@ l 1) base)] by [auto];
     auto;
     [ rewrite eq at type; [with x => `($ S1UnivCover x)]; auto
     , rewrite eq at left; [with x => `($ S1UnivCover x)]; auto
     ]
-.
+}.
 
-theorem S1LoopConcat :
+theorem S1LoopConcat : 
   (->
    (path [_] S1 base base)
    (path [_] S1 base base)
    (path [_] S1 base base))
-by
+by {
   lam p q => abs x => `(hcom 0~>1 S1 (@ p x) [x=0 [_] base] [x=1 [y] (@ q y)])
-.
+}.
 
-theorem S1LoopInv :
+theorem S1LoopInv : 
   (->
    (path [_] S1 base base)
    (path [_] S1 base base))
-by
+by {
   lam p => abs x => `(hcom 0~>1 S1 base [x=0 [y] (@ p y)] [x=1 [_] base])
-.
+}.
 
-theorem IntToS1Loop :
+theorem IntToS1Loop : 
   (-> int (path [_] S1 base base))
-by
+by {
   lam i => elim i;
   [ with n => elim n;
     [ abs _ => `base
@@ -138,16 +138,16 @@ by
     , with ih => `($ S1LoopConcat ($ S1LoopInv Loop) ih)
     ]
   ]
-.
+}.
 
-theorem Test0 :
+theorem Test0 : 
   (= int ($ S1LoopToInt ($ IntToS1Loop (int 3))) (int 3))
-by
+by {
   unfold IntToS1Loop Loop; auto
-.
+}.
 
-theorem Test1 :
+theorem Test1 : 
   (= int ($ S1LoopToInt ($ IntToS1Loop (int -3))) (int -3))
-by
+by {
   unfold IntToS1Loop S1LoopInv Loop; auto
-.
+}.

--- a/example/omega1s1.prl
+++ b/example/omega1s1.prl
@@ -1,4 +1,4 @@
-theorem IntPred : 
+theorem IntPred :
   (-> int int)
 by {
   lam a => elim a;
@@ -10,7 +10,7 @@ by {
   ];
 }.
 
-theorem IntSucc : 
+theorem IntSucc :
   (-> int int)
 by {
   lam a => elim a;
@@ -22,7 +22,7 @@ by {
   ]
 }.
 
-theorem IntSuccIntPred : 
+theorem IntSuccIntPred :
   (-> [i : int] (= int ($ IntSucc ($ IntPred i)) i))
 by {
   lam i => elim i;
@@ -31,7 +31,7 @@ by {
   ]
 }.
 
-theorem IntPredIntSucc : 
+theorem IntPredIntSucc :
   (-> [i : int] (= int ($ IntPred ($ IntSucc i)) i))
 by {
   lam i => elim i;
@@ -50,7 +50,7 @@ define IsEquiv (#A,#B,#f) = (-> [b : #B] (IsContr (Fiber #A #B #f b))).
 
 define Equiv (#A,#B) = (* [f : (-> #A #B)] (IsEquiv #A #B f)).
 
-theorem IntSuccIsEquiv : 
+theorem IntSuccIsEquiv :
   (IsEquiv int int IntSucc)
 by {
   lam i =>
@@ -73,31 +73,31 @@ by {
     }
 }.
 
-theorem IntSuccEquiv : 
+theorem IntSuccEquiv :
   (Equiv int int)
 by {
   {`IntSucc, `IntSuccIsEquiv}
 }.
 
-theorem IntSuccPath : 
+theorem IntSuccPath :
   (path [_] (U 0 kan) int int)
 by {
   abs x => `(V x int int IntSuccEquiv)
 }.
 
-theorem S1UnivCover : 
+theorem S1UnivCover :
   (-> S1 (U 0 kan))
 by {
-  lam x => `(S1-rec [_] (U 0 kan) x int [x] (@ IntSuccPath x)); 
+  lam x => `(S1-rec [_] (U 0 kan) x int [x] (@ IntSuccPath x));
 }.
 
-theorem Loop : 
+theorem Loop :
   (path [_] S1 base base)
 by {
   abs i => `(loop i)
 }.
 
-theorem S1LoopToInt : 
+theorem S1LoopToInt :
   (-> (path [_] S1 base base) int)
 by {
   lam l => `(coe 0~>1 [x] ($ S1UnivCover (@ l x)) (int 0));
@@ -108,7 +108,7 @@ by {
     ]
 }.
 
-theorem S1LoopConcat : 
+theorem S1LoopConcat :
   (->
    (path [_] S1 base base)
    (path [_] S1 base base)
@@ -117,7 +117,7 @@ by {
   lam p q => abs x => `(hcom 0~>1 S1 (@ p x) [x=0 [_] base] [x=1 [y] (@ q y)])
 }.
 
-theorem S1LoopInv : 
+theorem S1LoopInv :
   (->
    (path [_] S1 base base)
    (path [_] S1 base base))
@@ -125,7 +125,7 @@ by {
   lam p => abs x => `(hcom 0~>1 S1 base [x=0 [y] (@ p y)] [x=1 [_] base])
 }.
 
-theorem IntToS1Loop : 
+theorem IntToS1Loop :
   (-> int (path [_] S1 base base))
 by {
   lam i => elim i;
@@ -140,13 +140,13 @@ by {
   ]
 }.
 
-theorem Test0 : 
+theorem Test0 :
   (= int ($ S1LoopToInt ($ IntToS1Loop (int 3))) (int 3))
 by {
   unfold IntToS1Loop Loop; auto
 }.
 
-theorem Test1 : 
+theorem Test1 :
   (= int ($ S1LoopToInt ($ IntToS1Loop (int -3))) (int -3))
 by {
   unfold IntToS1Loop S1LoopInv Loop; auto

--- a/example/omega1s1.prl
+++ b/example/omega1s1.prl
@@ -1,6 +1,6 @@
-Thm IntPred : [
+theorem IntPred :
   (-> int int)
-] by [
+by
   lam a => elim a;
   [ with n => elim n;
     [ `(int -1)
@@ -8,11 +8,11 @@ Thm IntPred : [
     ]
   , with n => `(negsucc (succ n))
   ];
-].
+.
 
-Thm IntSucc : [
+theorem IntSucc :
   (-> int int)
-] by [
+by
   lam a => elim a;
   [ with n => `(pos (succ n))
   , with n => elim n;
@@ -20,39 +20,39 @@ Thm IntSucc : [
     , with _ n' => `(negsucc n')
     ]
   ]
-].
+.
 
-Thm IntSuccIntPred : [
+theorem IntSuccIntPred :
   (-> [i : int] (= int ($ IntSucc ($ IntPred i)) i))
-] by [
+by
   lam i => elim i;
   [ with n => elim n; auto
   , auto
   ]
-].
+.
 
-Thm IntPredIntSucc : [
+theorem IntPredIntSucc :
   (-> [i : int] (= int ($ IntPred ($ IntSucc i)) i))
-] by [
+by
   lam i => elim i;
   [ auto
   , with n => elim n; auto
   ]
-].
+.
 
-Def HasAllPathsTo (#C,#c) = [(-> [c' : #C] (path [_] #C c' #c))].
+define HasAllPathsTo (#C,#c) = (-> [c' : #C] (path [_] #C c' #c)).
 
-Def IsContr (#C) = [(* [c : #C] (HasAllPathsTo #C c))].
+define IsContr (#C) = (* [c : #C] (HasAllPathsTo #C c)).
 
-Def Fiber (#A,#B,#f,#b) = [(* [a : #A] (path [_] #B ($ #f a) #b))].
+define Fiber (#A,#B,#f,#b) = (* [a : #A] (path [_] #B ($ #f a) #b)).
 
-Def IsEquiv (#A,#B,#f) = [(-> [b : #B] (IsContr (Fiber #A #B #f b)))].
+define IsEquiv (#A,#B,#f) = (-> [b : #B] (IsContr (Fiber #A #B #f b))).
 
-Def Equiv (#A,#B) = [(* [f : (-> #A #B)] (IsEquiv #A #B f))].
+define Equiv (#A,#B) = (* [f : (-> #A #B)] (IsEquiv #A #B f)).
 
-Thm IntSuccIsEquiv : [
+theorem IntSuccIsEquiv :
   (IsEquiv int int IntSucc)
-] by [
+by
   lam i =>
     claim eq : [(= int ($ IntSucc ($ IntPred i)) i)] by [use IntSuccIntPred [`i]];
     unfold IntSucc IntPred in eq; reduce at left in eq;
@@ -71,63 +71,63 @@ Thm IntSuccIsEquiv : [
 
         auto; unfold IntPred in eq1; reduce at left in eq1; auto; assumption
     }
-].
+.
 
-Thm IntSuccEquiv : [
+theorem IntSuccEquiv :
   (Equiv int int)
-] by [
+by
   {`IntSucc, `IntSuccIsEquiv}
-].
+.
 
-Thm IntSuccPath : [
+theorem IntSuccPath :
   (path [_] (U 0 kan) int int)
-] by [
+by
   abs x => `(V x int int IntSuccEquiv)
-].
+.
 
-Thm S1UnivCover : [
+theorem S1UnivCover :
   (-> S1 (U 0 kan))
-] by [
+by
   lam x => `(S1-rec [_] (U 0 kan) x int [x] (@ IntSuccPath x)); 
-].
+.
 
-Thm Loop : [
+theorem Loop :
   (path [_] S1 base base)
-] by [
+by
   abs i => `(loop i)
-].
+.
 
-Thm S1LoopToInt : [
+theorem S1LoopToInt :
   (-> (path [_] S1 base base) int)
-] by [
+by
   lam l => `(coe 0~>1 [x] ($ S1UnivCover (@ l x)) (int 0));
     claim eq : [(= S1 (@ l 1) base)] by [auto];
     auto;
     [ rewrite eq at type; [with x => `($ S1UnivCover x)]; auto
     , rewrite eq at left; [with x => `($ S1UnivCover x)]; auto
     ]
-].
+.
 
-Thm S1LoopConcat : [
+theorem S1LoopConcat :
   (->
    (path [_] S1 base base)
    (path [_] S1 base base)
    (path [_] S1 base base))
-] by [
+by
   lam p q => abs x => `(hcom 0~>1 S1 (@ p x) [x=0 [_] base] [x=1 [y] (@ q y)])
-].
+.
 
-Thm S1LoopInv : [
+theorem S1LoopInv :
   (->
    (path [_] S1 base base)
    (path [_] S1 base base))
-] by [
+by
   lam p => abs x => `(hcom 0~>1 S1 base [x=0 [y] (@ p y)] [x=1 [_] base])
-].
+.
 
-Thm IntToS1Loop : [
+theorem IntToS1Loop :
   (-> int (path [_] S1 base base))
-] by [
+by
   lam i => elim i;
   [ with n => elim n;
     [ abs _ => `base
@@ -138,16 +138,16 @@ Thm IntToS1Loop : [
     , with ih => `($ S1LoopConcat ($ S1LoopInv Loop) ih)
     ]
   ]
-].
+.
 
-Thm Test0 : [
+theorem Test0 :
   (= int ($ S1LoopToInt ($ IntToS1Loop (int 3))) (int 3))
-] by [
+by
   unfold IntToS1Loop Loop; auto
-].
+.
 
-Thm Test1 : [
+theorem Test1 :
   (= int ($ S1LoopToInt ($ IntToS1Loop (int -3))) (int -3))
-] by [
+by
   unfold IntToS1Loop S1LoopInv Loop; auto
-].
+.

--- a/example/omega1s1.prl
+++ b/example/omega1s1.prl
@@ -54,17 +54,17 @@ theorem IntSuccIsEquiv :
   (IsEquiv int int IntSucc)
 by {
   lam i =>
-    claim eq : [(= int ($ IntSucc ($ IntPred i)) i)] by [use IntSuccIntPred [`i]];
+    claim eq : (= int ($ IntSucc ($ IntPred i)) i) by {use IntSuccIntPred [`i]};
     unfold IntSucc IntPred in eq; reduce at left in eq;
     { {use IntPred [`i], abs _ => `i};
       auto; assumption
     , lam {i',p'} =>
-        claim eq0 : [(= int i ($ IntSucc i'))] by [`(coe 1~>0 [x] (= int i (@ p' x)) ax)];
-        claim eq1 : [(= int ($ IntPred i) i')] by [
+        claim eq0 : (= int i ($ IntSucc i')) by {`(coe 1~>0 [x] (= int i (@ p' x)) ax)};
+        claim eq1 : (= int ($ IntPred i) i') by {
           rewrite eq0 at left;
           [ with i'' => `($ IntPred i''), `($ IntPredIntSucc i') ];
           auto
-        ];
+        };
 
         (abs x =>
           {`($ IntPred i), abs y => `(hcom 1~>y int i [x=0 [y] (@ p' y)] [x=1 [_] i])});
@@ -101,7 +101,7 @@ theorem S1LoopToInt :
   (-> (path [_] S1 base base) int)
 by {
   lam l => `(coe 0~>1 [x] ($ S1UnivCover (@ l x)) (int 0));
-    claim eq : [(= S1 (@ l 1) base)] by [auto];
+    claim eq : (= S1 (@ l 1) base) by {auto};
     auto;
     [ rewrite eq at type; [with x => `($ S1UnivCover x)]; auto
     , rewrite eq at left; [with x => `($ S1UnivCover x)]; auto

--- a/example/semi-simplicial.prl
+++ b/example/semi-simplicial.prl
@@ -10,11 +10,11 @@
   and (2) the reformulation based on it to avoid additions.
 */
 
-Thm Choice : [
+theorem Choice :
   // a choice of #(first argument) elements from #(second argument) elemnts.
   // `tt` means "take", and `ff` means "drop".
   (-> nat nat (U 0))
-] by [
+by
   lam n => elim n;
   [ lam n => `record ]; // n = 0
   with n'/ih n' =>  lam m => elim m;
@@ -23,15 +23,15 @@ Thm Choice : [
     `(record
       [head : bool]
       [tail : (if [_] (U 0) head ($ n'/ih m') m'/ih)])
-].
+.
 
-Thm Choice/compose : [
+theorem Choice/compose :
   (->
    [a b c : nat]
    ($ Choice b c)
    ($ Choice a b)
    ($ Choice a c))
-] by [
+by
   lam a => elim a;
   [ lam b c p0 p1 => `tuple ]; // a = 0
   with a'/ih a' => lam b => elim b;
@@ -53,9 +53,9 @@ Thm Choice/compose : [
     , tail = `($ c'/ih p0/t p1)
     }
   ]
-].
+.
 
-Thm Choice/compose/tt/tt : [
+theorem Choice/compose/tt/tt :
   (->
    [a b c : nat]
    [p0/t : ($ Choice b c)]
@@ -65,13 +65,13 @@ Thm Choice/compose/tt/tt : [
     ($ Choice/compose (succ a) (succ b) (succ c)
        (tuple [head tt] [tail p0/t]) (tuple [head tt] [tail p1/t]))
     (tuple [head tt] [tail ($ Choice/compose a b c p0/t p1/t)])))
-] by [
+by
   lam a b c p0/t p1/t =>
     auto;
     unfold Choice; reduce; assumption
-].
+.
 
-Thm Choice/compose/tt/ff : [
+theorem Choice/compose/tt/ff :
   (->
    [a b c : nat]
    [p0/t : ($ Choice b c)]
@@ -81,13 +81,13 @@ Thm Choice/compose/tt/ff : [
     ($ Choice/compose (succ a) (succ b) (succ c)
        (tuple [head tt] [tail p0/t]) (tuple [head ff] [tail p1/t]))
     (tuple [head ff] [tail ($ Choice/compose (succ a) b c p0/t p1/t)])))
-] by [
+by
   lam a b c p0/t p1/t =>
     auto;
     unfold Choice; reduce; assumption
-].
+.
 
-Thm Choice/compose/ff : [
+theorem Choice/compose/ff :
   (->
    [a b c : nat]
    [p0/t : ($ Choice (succ b) c)]
@@ -97,20 +97,20 @@ Thm Choice/compose/ff : [
     ($ Choice/compose (succ a) (succ b) (succ c)
        (tuple [head ff] [tail p0/t]) p1)
     (tuple [head ff] [tail ($ Choice/compose (succ a) (succ b) c p0/t p1)])))
-] by [
+by
   lam a b c p0/t p1 =>
     auto; 
     unfold Choice; reduce; assumption
-].
+.
 
-Thm Eq/inv : [
+theorem Eq/inv :
   (-> [a : (U 0)] [x y : a]
     (= a x y) (= a y x))
-] by [
+by
   lam a x y eq => assumption
-].
+.
 
-Thm Choice/compose/assoc : [
+theorem Choice/compose/assoc :
   (->
    [a b c d : nat]
    [p0 : ($ Choice c d)]
@@ -120,7 +120,7 @@ Thm Choice/compose/assoc : [
     ($ Choice a d)
     ($ Choice/compose a b d ($ Choice/compose b c d p0 p1) p2)
     ($ Choice/compose a c d p0 ($ Choice/compose a b c p1 p2))))
-] by [
+by
   lam a => elim a;
   [ lam b c d p0 p1 p2 => unfold Choice/compose; auto ]; // a = 0
   with a'/ind a' => lam b => elim b;
@@ -194,7 +194,7 @@ Thm Choice/compose/assoc : [
     ]
   ];
   auto
-].
+.
 
 /*
 
@@ -225,7 +225,7 @@ pick-coh : (-> [p : nat] [X : sst p] {n m o : nat}
       ($ pick p X ($ Choice/compose c1 c2) f)))
 */
 
-Thm MegaMutualDefs : [
+theorem MegaMutualDefs :
   (-> nat
     (record
       [sst : (U 1)]
@@ -241,7 +241,7 @@ Thm MegaMutualDefs : [
         (= ($ folder x o)
           ($ pick x m o c1 ($ pick x n m c2 f))
           ($ pick x n o ($ Choice/compose n m o c1 c2) f)))]))
-] by [
+by
   lam p => elim p;
   [
     { sst = `record
@@ -289,10 +289,10 @@ Thm MegaMutualDefs : [
     }
   ];
   auto
-].
+.
 
-Thm SemiSimplicial : [
+theorem SemiSimplicial :
   (-> nat (U 1))
-] by [
+by
   lam n => `(! sst ($ MegaMutualDefs n))
-].
+.

--- a/example/semi-simplicial.prl
+++ b/example/semi-simplicial.prl
@@ -10,11 +10,11 @@
   and (2) the reformulation based on it to avoid additions.
 */
 
-theorem Choice :
+theorem Choice : 
   // a choice of #(first argument) elements from #(second argument) elemnts.
   // `tt` means "take", and `ff` means "drop".
   (-> nat nat (U 0))
-by
+by {
   lam n => elim n;
   [ lam n => `record ]; // n = 0
   with n'/ih n' =>  lam m => elim m;
@@ -23,15 +23,15 @@ by
     `(record
       [head : bool]
       [tail : (if [_] (U 0) head ($ n'/ih m') m'/ih)])
-.
+}.
 
-theorem Choice/compose :
+theorem Choice/compose : 
   (->
    [a b c : nat]
    ($ Choice b c)
    ($ Choice a b)
    ($ Choice a c))
-by
+by {
   lam a => elim a;
   [ lam b c p0 p1 => `tuple ]; // a = 0
   with a'/ih a' => lam b => elim b;
@@ -53,9 +53,9 @@ by
     , tail = `($ c'/ih p0/t p1)
     }
   ]
-.
+}.
 
-theorem Choice/compose/tt/tt :
+theorem Choice/compose/tt/tt : 
   (->
    [a b c : nat]
    [p0/t : ($ Choice b c)]
@@ -65,13 +65,13 @@ theorem Choice/compose/tt/tt :
     ($ Choice/compose (succ a) (succ b) (succ c)
        (tuple [head tt] [tail p0/t]) (tuple [head tt] [tail p1/t]))
     (tuple [head tt] [tail ($ Choice/compose a b c p0/t p1/t)])))
-by
+by {
   lam a b c p0/t p1/t =>
     auto;
     unfold Choice; reduce; assumption
-.
+}.
 
-theorem Choice/compose/tt/ff :
+theorem Choice/compose/tt/ff : 
   (->
    [a b c : nat]
    [p0/t : ($ Choice b c)]
@@ -81,13 +81,13 @@ theorem Choice/compose/tt/ff :
     ($ Choice/compose (succ a) (succ b) (succ c)
        (tuple [head tt] [tail p0/t]) (tuple [head ff] [tail p1/t]))
     (tuple [head ff] [tail ($ Choice/compose (succ a) b c p0/t p1/t)])))
-by
+by {
   lam a b c p0/t p1/t =>
     auto;
     unfold Choice; reduce; assumption
-.
+}.
 
-theorem Choice/compose/ff :
+theorem Choice/compose/ff : 
   (->
    [a b c : nat]
    [p0/t : ($ Choice (succ b) c)]
@@ -97,20 +97,20 @@ theorem Choice/compose/ff :
     ($ Choice/compose (succ a) (succ b) (succ c)
        (tuple [head ff] [tail p0/t]) p1)
     (tuple [head ff] [tail ($ Choice/compose (succ a) (succ b) c p0/t p1)])))
-by
+by {
   lam a b c p0/t p1 =>
     auto; 
     unfold Choice; reduce; assumption
-.
+}.
 
-theorem Eq/inv :
+theorem Eq/inv : 
   (-> [a : (U 0)] [x y : a]
     (= a x y) (= a y x))
-by
+by {
   lam a x y eq => assumption
-.
+}.
 
-theorem Choice/compose/assoc :
+theorem Choice/compose/assoc : 
   (->
    [a b c d : nat]
    [p0 : ($ Choice c d)]
@@ -120,7 +120,7 @@ theorem Choice/compose/assoc :
     ($ Choice a d)
     ($ Choice/compose a b d ($ Choice/compose b c d p0 p1) p2)
     ($ Choice/compose a c d p0 ($ Choice/compose a b c p1 p2))))
-by
+by {
   lam a => elim a;
   [ lam b c d p0 p1 p2 => unfold Choice/compose; auto ]; // a = 0
   with a'/ind a' => lam b => elim b;
@@ -194,7 +194,7 @@ by
     ]
   ];
   auto
-.
+}.
 
 /*
 
@@ -225,7 +225,7 @@ pick-coh : (-> [p : nat] [X : sst p] {n m o : nat}
       ($ pick p X ($ Choice/compose c1 c2) f)))
 */
 
-theorem MegaMutualDefs :
+theorem MegaMutualDefs : 
   (-> nat
     (record
       [sst : (U 1)]
@@ -241,7 +241,7 @@ theorem MegaMutualDefs :
         (= ($ folder x o)
           ($ pick x m o c1 ($ pick x n m c2 f))
           ($ pick x n o ($ Choice/compose n m o c1 c2) f)))]))
-by
+by {
   lam p => elim p;
   [
     { sst = `record
@@ -289,10 +289,10 @@ by
     }
   ];
   auto
-.
+}.
 
-theorem SemiSimplicial :
+theorem SemiSimplicial : 
   (-> nat (U 1))
-by
+by {
   lam n => `(! sst ($ MegaMutualDefs n))
-.
+}.

--- a/example/semi-simplicial.prl
+++ b/example/semi-simplicial.prl
@@ -10,7 +10,7 @@
   and (2) the reformulation based on it to avoid additions.
 */
 
-theorem Choice : 
+theorem Choice :
   // a choice of #(first argument) elements from #(second argument) elemnts.
   // `tt` means "take", and `ff` means "drop".
   (-> nat nat (U 0))
@@ -25,7 +25,7 @@ by {
       [tail : (if [_] (U 0) head ($ n'/ih m') m'/ih)])
 }.
 
-theorem Choice/compose : 
+theorem Choice/compose :
   (->
    [a b c : nat]
    ($ Choice b c)
@@ -55,7 +55,7 @@ by {
   ]
 }.
 
-theorem Choice/compose/tt/tt : 
+theorem Choice/compose/tt/tt :
   (->
    [a b c : nat]
    [p0/t : ($ Choice b c)]
@@ -71,7 +71,7 @@ by {
     unfold Choice; reduce; assumption
 }.
 
-theorem Choice/compose/tt/ff : 
+theorem Choice/compose/tt/ff :
   (->
    [a b c : nat]
    [p0/t : ($ Choice b c)]
@@ -87,7 +87,7 @@ by {
     unfold Choice; reduce; assumption
 }.
 
-theorem Choice/compose/ff : 
+theorem Choice/compose/ff :
   (->
    [a b c : nat]
    [p0/t : ($ Choice (succ b) c)]
@@ -99,18 +99,18 @@ theorem Choice/compose/ff :
     (tuple [head ff] [tail ($ Choice/compose (succ a) (succ b) c p0/t p1)])))
 by {
   lam a b c p0/t p1 =>
-    auto; 
+    auto;
     unfold Choice; reduce; assumption
 }.
 
-theorem Eq/inv : 
+theorem Eq/inv :
   (-> [a : (U 0)] [x y : a]
     (= a x y) (= a y x))
 by {
   lam a x y eq => assumption
 }.
 
-theorem Choice/compose/assoc : 
+theorem Choice/compose/assoc :
   (->
    [a b c d : nat]
    [p0 : ($ Choice c d)]
@@ -225,7 +225,7 @@ pick-coh : (-> [p : nat] [X : sst p] {n m o : nat}
       ($ pick p X ($ Choice/compose c1 c2) f)))
 */
 
-theorem MegaMutualDefs : 
+theorem MegaMutualDefs :
   (-> nat
     (record
       [sst : (U 1)]
@@ -291,7 +291,7 @@ by {
   auto
 }.
 
-theorem SemiSimplicial : 
+theorem SemiSimplicial :
   (-> nat (U 1))
 by {
   lam n => `(! sst ($ MegaMutualDefs n))

--- a/example/theorem-of-choice.prl
+++ b/example/theorem-of-choice.prl
@@ -1,4 +1,4 @@
-theorem Choice(#i:lvl) :
+theorem Choice(#i:lvl) : 
   (->
    [a b : (U #i)]
    [r : (-> a b (U #i))]
@@ -6,12 +6,12 @@ theorem Choice(#i:lvl) :
    (*
     [f : (-> a b)]
     (-> [x : a] ($ r x ($ f x)))))
-by
+by {
   lam a b r f =>
     {lam x => let {y,_} = f [`x]; `y,
      lam x => let {_,z} = f [`x]; `z};
   
   inversion; with _ aux0 => reduce at left in aux0; auto; assumption
-.
+}.
 
 // print Choice.

--- a/example/theorem-of-choice.prl
+++ b/example/theorem-of-choice.prl
@@ -1,4 +1,4 @@
-Thm Choice(#i:lvl) : [
+theorem Choice(#i:lvl) :
   (->
    [a b : (U #i)]
    [r : (-> a b (U #i))]
@@ -6,12 +6,12 @@ Thm Choice(#i:lvl) : [
    (*
     [f : (-> a b)]
     (-> [x : a] ($ r x ($ f x)))))
-] by [
+by
   lam a b r f =>
     {lam x => let {y,_} = f [`x]; `y,
      lam x => let {_,z} = f [`x]; `z};
   
   inversion; with _ aux0 => reduce at left in aux0; auto; assumption
-].
+.
 
-// Print Choice.
+// print Choice.

--- a/example/theorem-of-choice.prl
+++ b/example/theorem-of-choice.prl
@@ -1,4 +1,4 @@
-theorem Choice(#i:lvl) : 
+theorem Choice(#i:lvl) :
   (->
    [a b : (U #i)]
    [r : (-> a b (U #i))]
@@ -10,7 +10,7 @@ by {
   lam a b r f =>
     {lam x => let {y,_} = f [`x]; `y,
      lam x => let {_,z} = f [`x]; `z};
-  
+
   inversion; with _ aux0 => reduce at left in aux0; auto; assumption
 }.
 

--- a/example/tutorial.prl
+++ b/example/tutorial.prl
@@ -99,8 +99,8 @@ tactic GetEndpoints(#p, #t:[exp,exp].tac) = {
   query pty <- #p;
   match pty  {
     [ty l r | #jdg{(path [_] %ty %l %r)} =>
-      claim p/0 : [(@ #p 0) = %l in %ty] by [auto];
-      claim p/1 : [(@ #p 1) = %r in %ty] by [auto];
+      claim p/0 : (@ #p 0) = %l in %ty by {auto};
+      claim p/1 : (@ #p 1) = %r in %ty by {auto};
       (#t p/0 p/1)
     ]
   }

--- a/example/tutorial.prl
+++ b/example/tutorial.prl
@@ -1,91 +1,91 @@
 // POPL 2018 tutorial
 // January 8, 2018
 
-Thm Not : [
+theorem Not :
   (-> bool bool)
-] by [
+by
   lam b =>
   if b then `ff else `tt
-].
+.
 
-Print Not.
+print Not.
 
 // (not(not(b)) == b) because it holds for every closed boolean.
-Thm NotNot : [
+theorem NotNot :
   (->
    [b : bool]
    (= bool ($ Not ($ Not b)) b))
-] by [
+by
   lam b =>
   // The next four lines can be replaced by auto.
   unfold Not;
   if b
   then (reduce at left; refine bool/eq/tt)
   else (reduce at left; refine bool/eq/ff)
-].
+.
 
-Print NotNot.
+print NotNot.
 
 // Type families respect equality proofs.
-Thm RespectEquality : [
+theorem RespectEquality :
   (->
    [family : (-> [b : bool] (U 0))]
    [b : bool]
    ($ family b)
    ($ family ($ Not ($ Not b))))
-] by [
+by
   lam family b pf =>
   rewrite ($ NotNot b);
   [ with b' => `($ family b')
   , use pf
   ];
   auto
-].
+.
 
 
 // Extract does not mention the equality proof!
 // (No need to ``transport'' at runtime.)
-Print RespectEquality.
+print RespectEquality.
 
 // In fact, all proofs of (not(not(b)) == b) are equal.
-Thm EqualityIrrelevant : [
+theorem EqualityIrrelevant :
   (=
     (-> [b : bool] (= bool ($ Not ($ Not b)) b))
     NotNot
     (lam [b] ax))
-] by [
+by
   auto
-].
+.
 
-Print EqualityIrrelevant.
+print EqualityIrrelevant.
 
 // Paths (cf equalities), like those arising from
 // equivalences via univalence, do induce computation.
-Thm FunToPair : [
+theorem FunToPair :
   (->
    [ty : (U 0 kan)]
    (-> bool ty)
    (* ty ty))
-] by [
+by
   lam ty fun =>
   {`($ fun tt), `($ fun ff)}
-].
+.
 
 // {{{ Univalence
 
-Def HasAllPathsTo (#C,#c) = [(-> [c' : #C] (path [_] #C c' #c))].
-Def IsContr (#C) = [(* [c : #C] (HasAllPathsTo #C c))].
-Def Fiber (#A,#B,#f,#b) = [(* [a : #A] (path [_] #B ($ #f a) #b))].
-Def IsEquiv (#A,#B,#f) = [(-> [b : #B] (IsContr (Fiber #A #B #f b)))].
-Def Equiv (#A,#B) = [(* [f : (-> #A #B)] (IsEquiv #A #B f))].
+define HasAllPathsTo (#C,#c) = (-> [c' : #C] (path [_] #C c' #c)).
+define IsContr (#C) = (* [c : #C] (HasAllPathsTo #C c)).
+define Fiber (#A,#B,#f,#b) = (* [a : #A] (path [_] #B ($ #f a) #b)).
+define IsEquiv (#A,#B,#f) = (-> [b : #B] (IsContr (Fiber #A #B #f b))).
+define Equiv (#A,#B) = (* [f : (-> #A #B)] (IsEquiv #A #B f)).
 
-Thm WeakConnection(#l:lvl) : [
+theorem WeakConnection(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [i] (path [_] ty (@ p i) b) p (abs [_] b)))
-] by [
+by
   (lam ty a b p =>
     abs i j =>
       `(hcom 1~>0 ty b
@@ -93,9 +93,9 @@ Thm WeakConnection(#l:lvl) : [
         [i=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
         [j=0 [k] (hcom 0~>i ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
         [j=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]))
-].
+.
 
-Tac GetEndpoints(#p, #t:[exp,exp].tac) = [
+tactic GetEndpoints(#p, #t:[exp,exp].tac) = 
   query pty <- #p;
   match pty  {
     [ty l r | #jdg{(path [_] %ty %l %r)} =>
@@ -104,16 +104,16 @@ Tac GetEndpoints(#p, #t:[exp,exp].tac) = [
       (#t p/0 p/1)
     ]
   }
-].
+.
 
 
-Print WeakConnection.
+print WeakConnection.
 
-Thm FunToPairIsEquiv : [
+theorem FunToPairIsEquiv :
   (->
    [ty : (U 0 kan)]
    (IsEquiv (-> bool ty) (* ty ty) ($ FunToPair ty)))
-] by [
+by
   lam ty pair =>
   { { lam b => if b then `(!proj1 pair) else `(!proj2 pair)
     , abs _ => `pair }
@@ -138,44 +138,44 @@ Thm FunToPairIsEquiv : [
       ]
      })
   }
-].
+.
 
-Thm PathFunToPair : [
+theorem PathFunToPair :
   (->
    [ty : (U 0 kan)]
    (path [_] (U 0 kan) (-> bool ty) (* ty ty)))
-] by [
+by
   lam ty => abs x =>
   `(V x (-> bool ty) (* ty ty)
     (tuple [proj1 ($ FunToPair ty)] [proj2 ($ FunToPairIsEquiv ty)]))
-].
+.
 
 // }}}
 
-Print PathFunToPair.
+print PathFunToPair.
 
 // We can coerce elements of (bool -> ty) to (ty * ty).
-Thm RespectPaths : [
+theorem RespectPaths :
   (->
    [ty : (U 0 kan)]
    (-> bool ty)
    (* ty ty))
-] by [
+by
   lam ty fun =>
   `(coe 0~>1 [x] (@ ($ PathFunToPair ty) x) fun)
-].
+.
 
-Print RespectPaths.
+print RespectPaths.
 
 // When coercing, the choice of PathFunToPair matters!
-Thm ComputeCoercion : [
+theorem ComputeCoercion :
   (=
    (* bool bool)
    ($ RespectPaths bool (lam [b] b))
    (tuple [proj1 tt] [proj2 ff]))
-] by [
+by
   auto
-].
+.
 
 
 // ---------------------------------------------------------
@@ -183,41 +183,41 @@ Thm ComputeCoercion : [
 // ---------------------------------------------------------
 
 // A constant path does not depend on its dimension.
-Thm Refl : [
+theorem Refl :
   (->
    [ty : (U 0)]
    [a : ty]
    (path [_] ty a a))
-] by [
+by
   lam ty a =>
   abs _ => `a
-].
+.
 
 // The path structure of each type is defined in terms of
 // its constituent types.
-Thm FunPath : [
+theorem FunPath :
   (->
    [a b : (U 0)]
    [f g : (-> a b)]
    (path [_] (-> a b) f g)
    [arg : a]
    (path [_] b ($ f arg) ($ g arg)))
-] by [
+by
   lam a b f g p =>
   lam arg => abs x =>
     `($ (@ p x) arg)
-].
+.
 
 
-Print FunPath.
+print FunPath.
 
-Thm PathInv : [
+theorem PathInv :
   (->
    [ty : (U 0 kan)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [_] ty b a))
-] by [
+by
 //        a          -- x
 //     -------      |
 //    |      |      y
@@ -228,16 +228,16 @@ Thm PathInv : [
   lam ty a b p =>
   abs x =>
   `(hcom 0~>1 ty a [x=0 [y] (@ p y)] [x=1 [_] a])
-].
+.
 
-Thm PathConcat : [
+theorem PathConcat :
   (->
    [ty : (U 0 kan)]
    [a b c : ty]
    [p : (path [_] ty a b)]
    [q : (path [_] ty b c)]
    (path [_] ty a c))
-] by [
+by
 //        p          -- x
 //     -------      |
 //    |      |      y
@@ -248,9 +248,9 @@ Thm PathConcat : [
   lam ty a b c p q =>
   abs x =>
   `(hcom 0~>1 ty (@ p x) [x=0 [_] a] [x=1 [y] (@ q y)])
-].
+.
 
-Thm InvRefl : [
+theorem InvRefl :
   (->
    [ty : (U 0 kan)]
    [a : ty]
@@ -258,7 +258,7 @@ Thm InvRefl : [
      [_] (path [_] ty a a)
      ($ PathInv ty a a (abs [_] a))
      (abs [_] a)))
-] by [
+by
   // See diagram!
   lam ty a =>
   abs x y =>
@@ -267,12 +267,12 @@ Thm InvRefl : [
     [x=1 [_] a]
     [y=0 [_] a]
     [y=1 [_] a])
-].
+.
 
 // Although the path type is not defined by refl and J
 // (as in HoTT), we can still define J using hcom + coe.
 // The #l is an example of a parametrized definition.
-Thm J(#l:lvl) : [
+theorem J(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [a : ty]
@@ -281,21 +281,21 @@ Thm J(#l:lvl) : [
    [x : ty]
    [p : (path [_] ty a x)]
    ($ fam x p))
-] by [
+by
   lam ty a fam d x p =>
   `(coe 0~>1
     [i] ($ fam
            (hcom 0~>1 ty a [i=0 [_] a] [i=1 [j] (@ p j)])
            (abs [j] (hcom 0~>j ty a [i=0 [_] a] [i=1 [j] (@ p j)]))) d)
-].
+.
 
-Thm JInv : [
+theorem JInv :
   (->
    [ty : (U 0 kan)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [_] ty b a))
-] by [
+by
   lam ty a b p =>
   exact
     ($ (J #lvl{0})
@@ -307,21 +307,21 @@ Thm JInv : [
        p)
   ; auto
   //; unfold J; reduce at left right; ?
-].
+.
 
-Print JInv.
+print JInv.
 
 // Computing winding numbers in the circle.
 
 // Bonus material:
 
-Thm Shannon : [
+theorem Shannon :
   (->
    [ty  : (-> bool (U 0))]
    [elt : (-> [b : bool] ($ ty b))]
    [b : bool]
    (= ($ ty b) ($ elt b) (if [b] ($ ty b) b ($ elt tt) ($ elt ff))))
-] by [
+by
   lam ty elt b =>
   elim b; auto
-].
+.

--- a/example/tutorial.prl
+++ b/example/tutorial.prl
@@ -3,10 +3,10 @@
 
 theorem Not :
   (-> bool bool)
-by
+by {
   lam b =>
   if b then `ff else `tt
-.
+}.
 
 print Not.
 
@@ -15,14 +15,14 @@ theorem NotNot :
   (->
    [b : bool]
    (= bool ($ Not ($ Not b)) b))
-by
+by {
   lam b =>
   // The next four lines can be replaced by auto.
   unfold Not;
   if b
   then (reduce at left; refine bool/eq/tt)
   else (reduce at left; refine bool/eq/ff)
-.
+}.
 
 print NotNot.
 
@@ -33,17 +33,17 @@ theorem RespectEquality :
    [b : bool]
    ($ family b)
    ($ family ($ Not ($ Not b))))
-by
+by {
   lam family b pf =>
   rewrite ($ NotNot b);
   [ with b' => `($ family b')
   , use pf
   ];
   auto
-.
+}.
 
 
-// Extract does not mention the equality proof!
+// print does not mention the equality proof!
 // (No need to ``transport'' at runtime.)
 print RespectEquality.
 
@@ -53,9 +53,9 @@ theorem EqualityIrrelevant :
     (-> [b : bool] (= bool ($ Not ($ Not b)) b))
     NotNot
     (lam [b] ax))
-by
+by {
   auto
-.
+}.
 
 print EqualityIrrelevant.
 
@@ -66,10 +66,10 @@ theorem FunToPair :
    [ty : (U 0 kan)]
    (-> bool ty)
    (* ty ty))
-by
+by {
   lam ty fun =>
   {`($ fun tt), `($ fun ff)}
-.
+}.
 
 // {{{ Univalence
 
@@ -85,7 +85,7 @@ theorem WeakConnection(#l:lvl) :
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [i] (path [_] ty (@ p i) b) p (abs [_] b)))
-by
+by {
   (lam ty a b p =>
     abs i j =>
       `(hcom 1~>0 ty b
@@ -93,9 +93,9 @@ by
         [i=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
         [j=0 [k] (hcom 0~>i ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
         [j=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]))
-.
+}.
 
-tactic GetEndpoints(#p, #t:[exp,exp].tac) = 
+tactic GetEndpoints(#p, #t:[exp,exp].tac) = {
   query pty <- #p;
   match pty  {
     [ty l r | #jdg{(path [_] %ty %l %r)} =>
@@ -104,7 +104,7 @@ tactic GetEndpoints(#p, #t:[exp,exp].tac) =
       (#t p/0 p/1)
     ]
   }
-.
+}.
 
 
 print WeakConnection.
@@ -113,42 +113,42 @@ theorem FunToPairIsEquiv :
   (->
    [ty : (U 0 kan)]
    (IsEquiv (-> bool ty) (* ty ty) ($ FunToPair ty)))
-by
+by {
   lam ty pair =>
   { { lam b => if b then `(!proj1 pair) else `(!proj2 pair)
     , abs _ => `pair }
   , unfold Fiber;
     lam {fun,p} =>
      (GetEndpoints p [p/0 p/1] #tac{
-      (abs x => 
+      (abs x =>
         {lam b => if b then `(!proj1 (@ p x)) else `(!proj2 (@ p x)),
          abs y =>
            `(@ ($ (WeakConnection #lvl{0}) (* ty ty) ($ FunToPair ty fun) pair p) x y)
-        }); 
+        });
       [ unfold FunToPair in p/0; reduce in p/0 at right;
-        inversion; with q3 q2 q1 q0 => 
+        inversion; with q3 q2 q1 q0 =>
           reduce at right in q2;
           reduce at right in q3;
           auto; with b =>
             elim b; reduce at right; symmetry; assumption
       , unfold FunToPair in p/1; reduce in p/1 at right;
-        inversion; with q3 q2 q1 q0 => elim pair; 
-        reduce at right in q0; reduce at right in q1; 
+        inversion; with q3 q2 q1 q0 => elim pair;
+        reduce at right in q0; reduce at right in q1;
         auto; assumption
       ]
      })
   }
-.
+}.
 
 theorem PathFunToPair :
   (->
    [ty : (U 0 kan)]
    (path [_] (U 0 kan) (-> bool ty) (* ty ty)))
-by
+by {
   lam ty => abs x =>
   `(V x (-> bool ty) (* ty ty)
     (tuple [proj1 ($ FunToPair ty)] [proj2 ($ FunToPairIsEquiv ty)]))
-.
+}.
 
 // }}}
 
@@ -160,10 +160,10 @@ theorem RespectPaths :
    [ty : (U 0 kan)]
    (-> bool ty)
    (* ty ty))
-by
+by {
   lam ty fun =>
   `(coe 0~>1 [x] (@ ($ PathFunToPair ty) x) fun)
-.
+}.
 
 print RespectPaths.
 
@@ -173,9 +173,9 @@ theorem ComputeCoercion :
    (* bool bool)
    ($ RespectPaths bool (lam [b] b))
    (tuple [proj1 tt] [proj2 ff]))
-by
+by {
   auto
-.
+}.
 
 
 // ---------------------------------------------------------
@@ -188,10 +188,10 @@ theorem Refl :
    [ty : (U 0)]
    [a : ty]
    (path [_] ty a a))
-by
+by {
   lam ty a =>
   abs _ => `a
-.
+}.
 
 // The path structure of each type is defined in terms of
 // its constituent types.
@@ -202,11 +202,11 @@ theorem FunPath :
    (path [_] (-> a b) f g)
    [arg : a]
    (path [_] b ($ f arg) ($ g arg)))
-by
+by {
   lam a b f g p =>
   lam arg => abs x =>
     `($ (@ p x) arg)
-.
+}.
 
 
 print FunPath.
@@ -217,7 +217,7 @@ theorem PathInv :
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [_] ty b a))
-by
+by {
 //        a          -- x
 //     -------      |
 //    |      |      y
@@ -228,7 +228,7 @@ by
   lam ty a b p =>
   abs x =>
   `(hcom 0~>1 ty a [x=0 [y] (@ p y)] [x=1 [_] a])
-.
+}.
 
 theorem PathConcat :
   (->
@@ -237,7 +237,7 @@ theorem PathConcat :
    [p : (path [_] ty a b)]
    [q : (path [_] ty b c)]
    (path [_] ty a c))
-by
+by {
 //        p          -- x
 //     -------      |
 //    |      |      y
@@ -248,7 +248,7 @@ by
   lam ty a b c p q =>
   abs x =>
   `(hcom 0~>1 ty (@ p x) [x=0 [_] a] [x=1 [y] (@ q y)])
-.
+}.
 
 theorem InvRefl :
   (->
@@ -258,7 +258,7 @@ theorem InvRefl :
      [_] (path [_] ty a a)
      ($ PathInv ty a a (abs [_] a))
      (abs [_] a)))
-by
+by {
   // See diagram!
   lam ty a =>
   abs x y =>
@@ -267,7 +267,7 @@ by
     [x=1 [_] a]
     [y=0 [_] a]
     [y=1 [_] a])
-.
+}.
 
 // Although the path type is not defined by refl and J
 // (as in HoTT), we can still define J using hcom + coe.
@@ -281,13 +281,13 @@ theorem J(#l:lvl) :
    [x : ty]
    [p : (path [_] ty a x)]
    ($ fam x p))
-by
+by {
   lam ty a fam d x p =>
   `(coe 0~>1
     [i] ($ fam
            (hcom 0~>1 ty a [i=0 [_] a] [i=1 [j] (@ p j)])
            (abs [j] (hcom 0~>j ty a [i=0 [_] a] [i=1 [j] (@ p j)]))) d)
-.
+}.
 
 theorem JInv :
   (->
@@ -295,7 +295,7 @@ theorem JInv :
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [_] ty b a))
-by
+by {
   lam ty a b p =>
   exact
     ($ (J #lvl{0})
@@ -307,7 +307,7 @@ by
        p)
   ; auto
   //; unfold J; reduce at left right; ?
-.
+}.
 
 print JInv.
 
@@ -321,7 +321,7 @@ theorem Shannon :
    [elt : (-> [b : bool] ($ ty b))]
    [b : bool]
    (= ($ ty b) ($ elt b) (if [b] ($ ty b) b ($ elt tt) ($ elt ff))))
-by
+by {
   lam ty elt b =>
   elim b; auto
-.
+}.

--- a/example/tutorial1.prl
+++ b/example/tutorial1.prl
@@ -177,7 +177,7 @@ by {
 
       [ symmetry; refine record/eq/tuple;
         [ refine fun/eq/eta; #1{auto}; auto; symmetry;
-          claim p/0 : [(@ p 0) = ($ FunToPair ty fun) in (* ty ty)] by [ auto ];
+          claim p/0 : (@ p 0) = ($ FunToPair ty fun) in (* ty ty) by { auto };
           auto;
           [ fresh h -> rewrite p/0; [`(= ty (! proj1 h) ($ fun tt))]
           , fresh h -> rewrite p/0; [`(= ty (! proj2 h) ($ fun ff))]

--- a/example/tutorial1.prl
+++ b/example/tutorial1.prl
@@ -3,11 +3,11 @@
 
 quit.
 
-theorem Not :
+theorem Not : 
   (-> bool bool)
-by
+by {
   ?
-.
+}.
 
 quit.
 
@@ -31,13 +31,13 @@ print Not.
 
 
 
-theorem NotNot :
+theorem NotNot : 
   (->
    [b : bool]
    (= bool ($ Not ($ Not b)) b))
-by
+by {
   ?
-.
+}.
 
 quit.
 
@@ -61,15 +61,15 @@ print NotNot.
 
 
 
-theorem RespectEquality :
+theorem RespectEquality : 
   (->
    [family : (-> [b : bool] (U 0))]
    [b : bool]
    ($ family b)
    ($ family ($ Not ($ Not b))))
-by
+by {
   ?
-.
+}.
 
 quit.
 
@@ -93,14 +93,14 @@ print RespectEquality.
 
 
 
-theorem EqualityIrrelevant :
+theorem EqualityIrrelevant : 
   (=
     (-> [b : bool] (= bool ($ Not ($ Not b)) b))
     NotNot
     (lam [b] ax))
-by
+by {
   ?
-.
+}.
 
 quit.
 
@@ -124,15 +124,15 @@ print EqualityIrrelevant.
 
 
 
-theorem FunToPair :
+theorem FunToPair : 
   (->
    [ty : (U 0 kan)]
    (-> bool ty)
    (* ty ty))
-by
+by {
   lam ty fun =>
   {`($ fun tt), `($ fun ff)}
-.
+}.
 
 // {{{ Univalence
 
@@ -142,13 +142,13 @@ define Fiber (#A,#B,#f,#b) = (* [a : #A] (path [_] #B ($ #f a) #b)).
 define IsEquiv (#A,#B,#f) = (-> [b : #B] (IsContr (Fiber #A #B #f b))).
 define Equiv (#A,#B) = (* [f : (-> #A #B)] (IsEquiv #A #B f)).
 
-theorem WeakConnection(#l:lvl) :
+theorem WeakConnection(#l:lvl) : 
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [i] (path [_] ty (@ p i) b) p (abs [_] b)))
-by
+by {
   (lam ty a b p =>
     abs i j =>
       `(hcom 1~>0 ty b
@@ -156,13 +156,13 @@ by
         [i=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
         [j=0 [k] (hcom 0~>i ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
         [j=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]))
-.
+}.
 
-theorem FunToPairIsEquiv :
+theorem FunToPairIsEquiv : 
   (->
    [ty : (U 0 kan)]
    (IsEquiv (-> bool ty) (* ty ty) ($ FunToPair ty)))
-by
+by {
   lam ty pair =>
   { { lam b => if b then `(!proj1 pair) else `(!proj2 pair)
     , abs _ => `pair }
@@ -199,17 +199,17 @@ by
          auto
       ]
   }
-.
+}.
 
-theorem PathFunToPair :
+theorem PathFunToPair : 
   (->
    [ty : (U 0 kan)]
    (path [_] (U 0 kan) (-> bool ty) (* ty ty)))
-by
+by {
   lam ty => abs x =>
   `(V x (-> bool ty) (* ty ty)
     (tuple [proj1 ($ FunToPair ty)] [proj2 ($ FunToPairIsEquiv ty)]))
-.
+}.
 
 // }}}
 
@@ -235,15 +235,15 @@ print PathFunToPair.
 
 
 
-theorem RespectPaths :
+theorem RespectPaths : 
   (->
    [ty : (U 0 kan)]
    (-> bool ty)
    (* ty ty))
-by
+by {
   lam ty fun =>
   `(coe 0~>1 [x] (@ ($ PathFunToPair ty) x) fun)
-.
+}.
 
 quit.
 
@@ -267,11 +267,11 @@ print RespectPaths.
 
 
 
-theorem ComputeCoercion :
+theorem ComputeCoercion : 
   (=
    (* bool bool)
    ($ RespectPaths bool (lam [b] b))
    (tuple [proj1 tt] [proj2 ff]))
-by
+by {
   auto
-.
+}.

--- a/example/tutorial1.prl
+++ b/example/tutorial1.prl
@@ -3,7 +3,7 @@
 
 quit.
 
-theorem Not : 
+theorem Not :
   (-> bool bool)
 by {
   ?
@@ -31,7 +31,7 @@ print Not.
 
 
 
-theorem NotNot : 
+theorem NotNot :
   (->
    [b : bool]
    (= bool ($ Not ($ Not b)) b))
@@ -61,7 +61,7 @@ print NotNot.
 
 
 
-theorem RespectEquality : 
+theorem RespectEquality :
   (->
    [family : (-> [b : bool] (U 0))]
    [b : bool]
@@ -93,7 +93,7 @@ print RespectEquality.
 
 
 
-theorem EqualityIrrelevant : 
+theorem EqualityIrrelevant :
   (=
     (-> [b : bool] (= bool ($ Not ($ Not b)) b))
     NotNot
@@ -124,7 +124,7 @@ print EqualityIrrelevant.
 
 
 
-theorem FunToPair : 
+theorem FunToPair :
   (->
    [ty : (U 0 kan)]
    (-> bool ty)
@@ -142,7 +142,7 @@ define Fiber (#A,#B,#f,#b) = (* [a : #A] (path [_] #B ($ #f a) #b)).
 define IsEquiv (#A,#B,#f) = (-> [b : #B] (IsContr (Fiber #A #B #f b))).
 define Equiv (#A,#B) = (* [f : (-> #A #B)] (IsEquiv #A #B f)).
 
-theorem WeakConnection(#l:lvl) : 
+theorem WeakConnection(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b : ty]
@@ -158,7 +158,7 @@ by {
         [j=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]))
 }.
 
-theorem FunToPairIsEquiv : 
+theorem FunToPairIsEquiv :
   (->
    [ty : (U 0 kan)]
    (IsEquiv (-> bool ty) (* ty ty) ($ FunToPair ty)))
@@ -201,7 +201,7 @@ by {
   }
 }.
 
-theorem PathFunToPair : 
+theorem PathFunToPair :
   (->
    [ty : (U 0 kan)]
    (path [_] (U 0 kan) (-> bool ty) (* ty ty)))
@@ -235,7 +235,7 @@ print PathFunToPair.
 
 
 
-theorem RespectPaths : 
+theorem RespectPaths :
   (->
    [ty : (U 0 kan)]
    (-> bool ty)
@@ -267,7 +267,7 @@ print RespectPaths.
 
 
 
-theorem ComputeCoercion : 
+theorem ComputeCoercion :
   (=
    (* bool bool)
    ($ RespectPaths bool (lam [b] b))

--- a/example/tutorial1.prl
+++ b/example/tutorial1.prl
@@ -1,19 +1,17 @@
 // POPL 2018 tutorial, part one
 // January 8, 2018
 
-Quit.
+quit.
 
-Thm Not : [
+theorem Not :
   (-> bool bool)
-] by [
+by
   ?
-].
+.
 
-Quit.
+quit.
 
-Print Not.
-
-
+print Not.
 
 
 
@@ -31,19 +29,19 @@ Print Not.
 
 
 
-Thm NotNot : [
+
+
+theorem NotNot :
   (->
    [b : bool]
    (= bool ($ Not ($ Not b)) b))
-] by [
+by
   ?
-].
+.
 
-Quit.
+quit.
 
-Print NotNot.
-
-
+print NotNot.
 
 
 
@@ -61,21 +59,21 @@ Print NotNot.
 
 
 
-Thm RespectEquality : [
+
+
+theorem RespectEquality :
   (->
    [family : (-> [b : bool] (U 0))]
    [b : bool]
    ($ family b)
    ($ family ($ Not ($ Not b))))
-] by [
+by
   ?
-].
+.
 
-Quit.
+quit.
 
-Print RespectEquality.
-
-
+print RespectEquality.
 
 
 
@@ -93,20 +91,20 @@ Print RespectEquality.
 
 
 
-Thm EqualityIrrelevant : [
+
+
+theorem EqualityIrrelevant :
   (=
     (-> [b : bool] (= bool ($ Not ($ Not b)) b))
     NotNot
     (lam [b] ax))
-] by [
+by
   ?
-].
+.
 
-Quit.
+quit.
 
-Print EqualityIrrelevant.
-
-
+print EqualityIrrelevant.
 
 
 
@@ -124,31 +122,33 @@ Print EqualityIrrelevant.
 
 
 
-Thm FunToPair : [
+
+
+theorem FunToPair :
   (->
    [ty : (U 0 kan)]
    (-> bool ty)
    (* ty ty))
-] by [
+by
   lam ty fun =>
   {`($ fun tt), `($ fun ff)}
-].
+.
 
 // {{{ Univalence
 
-Def HasAllPathsTo (#C,#c) = [(-> [c' : #C] (path [_] #C c' #c))].
-Def IsContr (#C) = [(* [c : #C] (HasAllPathsTo #C c))].
-Def Fiber (#A,#B,#f,#b) = [(* [a : #A] (path [_] #B ($ #f a) #b))].
-Def IsEquiv (#A,#B,#f) = [(-> [b : #B] (IsContr (Fiber #A #B #f b)))].
-Def Equiv (#A,#B) = [(* [f : (-> #A #B)] (IsEquiv #A #B f))].
+define HasAllPathsTo (#C,#c) = (-> [c' : #C] (path [_] #C c' #c)).
+define IsContr (#C) = (* [c : #C] (HasAllPathsTo #C c)).
+define Fiber (#A,#B,#f,#b) = (* [a : #A] (path [_] #B ($ #f a) #b)).
+define IsEquiv (#A,#B,#f) = (-> [b : #B] (IsContr (Fiber #A #B #f b))).
+define Equiv (#A,#B) = (* [f : (-> #A #B)] (IsEquiv #A #B f)).
 
-Thm WeakConnection(#l:lvl) : [
+theorem WeakConnection(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [i] (path [_] ty (@ p i) b) p (abs [_] b)))
-] by [
+by
   (lam ty a b p =>
     abs i j =>
       `(hcom 1~>0 ty b
@@ -156,13 +156,13 @@ Thm WeakConnection(#l:lvl) : [
         [i=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
         [j=0 [k] (hcom 0~>i ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]
         [j=1 [k] (hcom 0~>1 ty (@ p k) [k=0 [w] (@ p w)] [k=1 [_] b])]))
-].
+.
 
-Thm FunToPairIsEquiv : [
+theorem FunToPairIsEquiv :
   (->
    [ty : (U 0 kan)]
    (IsEquiv (-> bool ty) (* ty ty) ($ FunToPair ty)))
-] by [
+by
   lam ty pair =>
   { { lam b => if b then `(!proj1 pair) else `(!proj2 pair)
     , abs _ => `pair }
@@ -199,25 +199,23 @@ Thm FunToPairIsEquiv : [
          auto
       ]
   }
-].
+.
 
-Thm PathFunToPair : [
+theorem PathFunToPair :
   (->
    [ty : (U 0 kan)]
    (path [_] (U 0 kan) (-> bool ty) (* ty ty)))
-] by [
+by
   lam ty => abs x =>
   `(V x (-> bool ty) (* ty ty)
     (tuple [proj1 ($ FunToPair ty)] [proj2 ($ FunToPairIsEquiv ty)]))
-].
+.
 
 // }}}
 
-Quit.
+quit.
 
-Print PathFunToPair.
-
-
+print PathFunToPair.
 
 
 
@@ -235,21 +233,21 @@ Print PathFunToPair.
 
 
 
-Thm RespectPaths : [
+
+
+theorem RespectPaths :
   (->
    [ty : (U 0 kan)]
    (-> bool ty)
    (* ty ty))
-] by [
+by
   lam ty fun =>
   `(coe 0~>1 [x] (@ ($ PathFunToPair ty) x) fun)
-].
+.
 
-Quit.
+quit.
 
-Print RespectPaths.
-
-
+print RespectPaths.
 
 
 
@@ -267,11 +265,13 @@ Print RespectPaths.
 
 
 
-Thm ComputeCoercion : [
+
+
+theorem ComputeCoercion :
   (=
    (* bool bool)
    ($ RespectPaths bool (lam [b] b))
    (tuple [proj1 tt] [proj2 ff]))
-] by [
+by
   auto
-].
+.

--- a/example/tutorial2.prl
+++ b/example/tutorial2.prl
@@ -3,7 +3,7 @@
 
 quit.
 
-theorem Refl : 
+theorem Refl :
   (->
    [ty : (U 0)]
    [a : ty]
@@ -34,7 +34,7 @@ print Refl.
 
 
 
-theorem FunPath : 
+theorem FunPath :
   (->
    [a b : (U 0)]
    [f g : (-> a b)]
@@ -67,7 +67,7 @@ print FunPath.
 
 
 
-theorem PathInv : 
+theorem PathInv :
   (->
    [ty : (U 0 kan)]
    [a b : ty]
@@ -106,7 +106,7 @@ print PathInv.
 
 
 
-theorem PathConcat : 
+theorem PathConcat :
   (->
    [ty : (U 0 kan)]
    [a b c : ty]
@@ -144,7 +144,7 @@ quit.
 
 
 
-theorem InvRefl : 
+theorem InvRefl :
   (->
    [ty : (U 0 kan)]
    [a : ty]
@@ -186,7 +186,7 @@ quit.
 // Although the path type is not defined by refl and J
 // (as in HoTT), we can still define J using hcom + coe.
 // The #l is an example of a parametrized definition.
-theorem J(#l:lvl) : 
+theorem J(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [a : ty]
@@ -223,7 +223,7 @@ by {
 
 
 
-theorem JInv : 
+theorem JInv :
   (->
    [ty : (U 0 kan)]
    [a b : ty]

--- a/example/tutorial2.prl
+++ b/example/tutorial2.prl
@@ -1,22 +1,20 @@
 // POPL 2018 tutorial, part two
 // January 8, 2018
 
-Quit.
+quit.
 
-Thm Refl : [
+theorem Refl :
   (->
    [ty : (U 0)]
    [a : ty]
    (path [_] ty a a))
-] by [
+by
   ?
-].
+.
 
-Quit.
+quit.
 
-Print Refl.
-
-
+print Refl.
 
 
 
@@ -34,22 +32,22 @@ Print Refl.
 
 
 
-Thm FunPath : [
+
+
+theorem FunPath :
   (->
    [a b : (U 0)]
    [f g : (-> a b)]
    (path [_] (-> a b) f g)
    [arg : a]
    (path [_] b ($ f arg) ($ g arg)))
-] by [
+by
   ?
-].
+.
 
-Quit.
+quit.
 
-Print FunPath.
-
-
+print FunPath.
 
 
 
@@ -67,13 +65,15 @@ Print FunPath.
 
 
 
-Thm PathInv : [
+
+
+theorem PathInv :
   (->
    [ty : (U 0 kan)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [_] ty b a))
-] by [
+by
 //        a          -- x
 //     -------      |
 //    |      |      y
@@ -82,13 +82,11 @@ Thm PathInv : [
 //    b .... a
 
   ?
-].
+.
 
-Quit.
+quit.
 
-Print PathInv.
-
-
+print PathInv.
 
 
 
@@ -106,14 +104,16 @@ Print PathInv.
 
 
 
-Thm PathConcat : [
+
+
+theorem PathConcat :
   (->
    [ty : (U 0 kan)]
    [a b c : ty]
    [p : (path [_] ty a b)]
    [q : (path [_] ty b c)]
    (path [_] ty a c))
-] by [
+by
 //        p          -- x
 //     -------      |
 //    |      |      y
@@ -122,11 +122,9 @@ Thm PathConcat : [
 //    a .... c
 
   ?
-].
+.
 
-Quit.
-
-
+quit.
 
 
 
@@ -144,7 +142,9 @@ Quit.
 
 
 
-Thm InvRefl : [
+
+
+theorem InvRefl :
   (->
    [ty : (U 0 kan)]
    [a : ty]
@@ -152,7 +152,7 @@ Thm InvRefl : [
      [_] (path [_] ty a a)
      ($ PathInv ty a a (abs [_] a))
      (abs [_] a)))
-] by [
+by
   // See diagram!
   lam ty a =>
   abs x y =>
@@ -161,9 +161,9 @@ Thm InvRefl : [
     [x=1 [_] a]
     [y=0 [_] a]
     [y=1 [_] a])
-].
+.
 
-Quit.
+quit.
 
 
 
@@ -186,7 +186,7 @@ Quit.
 // Although the path type is not defined by refl and J
 // (as in HoTT), we can still define J using hcom + coe.
 // The #l is an example of a parametrized definition.
-Thm J(#l:lvl) : [
+theorem J(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [a : ty]
@@ -195,13 +195,13 @@ Thm J(#l:lvl) : [
    [x : ty]
    [p : (path [_] ty a x)]
    ($ fam x p))
-] by [
+by
   lam ty a fam d x p =>
   `(coe 0~>1
     [i] ($ fam
            (hcom 0~>1 ty a [i=0 [_] a] [i=1 [j] (@ p j)])
            (abs [j] (hcom 0~>j ty a [i=0 [_] a] [i=1 [j] (@ p j)]))) d)
-].
+.
 
 
 
@@ -223,13 +223,13 @@ Thm J(#l:lvl) : [
 
 
 
-Thm JInv : [
+theorem JInv :
   (->
    [ty : (U 0 kan)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [_] ty b a))
-] by [
+by
   lam ty a b p =>
   exact
     ($ (J #lvl{0})
@@ -240,4 +240,4 @@ Thm JInv : [
        b
        p);
   ?
-].
+.

--- a/example/tutorial2.prl
+++ b/example/tutorial2.prl
@@ -3,14 +3,14 @@
 
 quit.
 
-theorem Refl :
+theorem Refl : 
   (->
    [ty : (U 0)]
    [a : ty]
    (path [_] ty a a))
-by
+by {
   ?
-.
+}.
 
 quit.
 
@@ -34,16 +34,16 @@ print Refl.
 
 
 
-theorem FunPath :
+theorem FunPath : 
   (->
    [a b : (U 0)]
    [f g : (-> a b)]
    (path [_] (-> a b) f g)
    [arg : a]
    (path [_] b ($ f arg) ($ g arg)))
-by
+by {
   ?
-.
+}.
 
 quit.
 
@@ -67,13 +67,13 @@ print FunPath.
 
 
 
-theorem PathInv :
+theorem PathInv : 
   (->
    [ty : (U 0 kan)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [_] ty b a))
-by
+by {
 //        a          -- x
 //     -------      |
 //    |      |      y
@@ -82,7 +82,7 @@ by
 //    b .... a
 
   ?
-.
+}.
 
 quit.
 
@@ -106,14 +106,14 @@ print PathInv.
 
 
 
-theorem PathConcat :
+theorem PathConcat : 
   (->
    [ty : (U 0 kan)]
    [a b c : ty]
    [p : (path [_] ty a b)]
    [q : (path [_] ty b c)]
    (path [_] ty a c))
-by
+by {
 //        p          -- x
 //     -------      |
 //    |      |      y
@@ -122,7 +122,7 @@ by
 //    a .... c
 
   ?
-.
+}.
 
 quit.
 
@@ -144,7 +144,7 @@ quit.
 
 
 
-theorem InvRefl :
+theorem InvRefl : 
   (->
    [ty : (U 0 kan)]
    [a : ty]
@@ -152,7 +152,7 @@ theorem InvRefl :
      [_] (path [_] ty a a)
      ($ PathInv ty a a (abs [_] a))
      (abs [_] a)))
-by
+by {
   // See diagram!
   lam ty a =>
   abs x y =>
@@ -161,7 +161,7 @@ by
     [x=1 [_] a]
     [y=0 [_] a]
     [y=1 [_] a])
-.
+}.
 
 quit.
 
@@ -186,7 +186,7 @@ quit.
 // Although the path type is not defined by refl and J
 // (as in HoTT), we can still define J using hcom + coe.
 // The #l is an example of a parametrized definition.
-theorem J(#l:lvl) :
+theorem J(#l:lvl) : 
   (->
    [ty : (U #l kan)]
    [a : ty]
@@ -195,13 +195,13 @@ theorem J(#l:lvl) :
    [x : ty]
    [p : (path [_] ty a x)]
    ($ fam x p))
-by
+by {
   lam ty a fam d x p =>
   `(coe 0~>1
     [i] ($ fam
            (hcom 0~>1 ty a [i=0 [_] a] [i=1 [j] (@ p j)])
            (abs [j] (hcom 0~>j ty a [i=0 [_] a] [i=1 [j] (@ p j)]))) d)
-.
+}.
 
 
 
@@ -223,13 +223,13 @@ by
 
 
 
-theorem JInv :
+theorem JInv : 
   (->
    [ty : (U 0 kan)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (path [_] ty b a))
-by
+by {
   lam ty a b p =>
   exact
     ($ (J #lvl{0})
@@ -240,4 +240,4 @@ by
        b
        p);
   ?
-.
+}.

--- a/example/univalence.prl
+++ b/example/univalence.prl
@@ -12,9 +12,9 @@ define IsSet (#C) = (-> [c c' : #C] (IsProp (path [_] #C c c'))).
 
 define Retract (#A,#f,#g) = (-> [a : #A] (path [_] #A ($ #g ($ #f a)) a)).
 
-theorem IdEquiv(#l:lvl) :
+theorem IdEquiv(#l:lvl) : 
   (-> [ty : (U #l hcom)] (Equiv ty ty))
-by
+by {
   lam ty =>
   { lam a => use a
   , lam a =>
@@ -24,21 +24,21 @@ by
          abs j => `(hcom 1~>j ty a [i=0 [j] (@ c' j)] [i=1 [j] a])}
      }
   }
-.
+}.
 
 // per Dan Licata, UA and UABeta suffice for full univalence:
 // https://groups.google.com/forum/#!topic/homotopytypetheory/j2KBIvDw53s
 
-theorem UA(#l:lvl) :
+theorem UA(#l:lvl) : 
   (-> [ty/a ty/b : (U #l kan)]
       [e : (Equiv ty/a ty/b)]
       (path [_] (U #l kan) ty/a ty/b))
-by
+by {
   lam ty/a ty/b e =>
     abs x => `(V x ty/a ty/b e)
-.
+}.
 
-theorem UABeta(#l:lvl) :
+theorem UABeta(#l:lvl) : 
   (->
    [ty/a ty/b : (U #l kan)]
    [e : (Equiv ty/a ty/b)]
@@ -46,26 +46,26 @@ theorem UABeta(#l:lvl) :
    (path [_] ty/b
     (coe 0~>1 [x] (@ ($ (UA #l) ty/a ty/b e) x) a)
     ($ (!proj1 e) a)))
-by
+by {
   unfold UA;
   lam ty/a ty/b {f,_} a =>
     abs x => `(coe x~>1 [_] ty/b ($ f a))
-.
+}.
 
 // To prove univalence from UA and UABeta, we need some basic results.
 // (What follows is adapted from the cubicaltt prelude.)
 
-theorem PathToEquiv(#l:lvl) :
+theorem PathToEquiv(#l:lvl) : 
   (->
    [ty/a ty/b : (U #l kan)]
    [p : (path [_] (U #l kan) ty/a ty/b)]
    (Equiv ty/a ty/b))
-by
+by {
   lam ty/a ty/b p =>
   `(coe 0~>1 [x] (Equiv ty/a (@ p x)) ($ (IdEquiv #l) ty/a))
-.
+}.
 
-theorem LemPropF(#l:lvl) :
+theorem LemPropF(#l:lvl) : 
   (->
    [ty/a : (U #l kan)]
    [ty/b : (-> ty/a (U #l kan))]
@@ -75,7 +75,7 @@ theorem LemPropF(#l:lvl) :
    [b0 : ($ ty/b a0)]
    [b1 : ($ ty/b a1)]
    (path [x] ($ ty/b (@ p x)) b0 b1))
-by
+by {
   lam ty/a ty/b prop/b a0 a1 p b0 b1 => abs x =>
     use prop/b
       [ use p [`x]
@@ -83,9 +83,9 @@ by
       , `(coe 1~>x [i] ($ ty/b (@ p i)) b1)
       , `x
       ]
-.
+}.
 
-theorem LemSig(#l:lvl) :
+theorem LemSig(#l:lvl) : 
   (->
    [ty/a : (U #l kan)]
    [ty/b : (-> ty/a (U #l kan))]
@@ -93,14 +93,14 @@ theorem LemSig(#l:lvl) :
    [u v : (* [a : ty/a] ($ ty/b a))]
    [p : (path [_] ty/a (!proj1 u) (!proj1 v))]
    (path [_] (* [a : ty/a] ($ ty/b a)) u v))
-by
+by {
   lam ty/a ty/b prop/b {u1, u2} {v1, v2} p => abs x =>
     { use p [`x]
     , use (LemPropF #l) [`ty/a, `ty/b, `prop/b, `u1, `v1, `p, `u2, `v2, `x]
     }
-.
+}.
 
-theorem PropSig(#l:lvl) :
+theorem PropSig(#l:lvl) : 
   (->
    [ty/a : (U #l kan)]
    [ty/b : (-> ty/a (U #l kan))]
@@ -108,7 +108,7 @@ theorem PropSig(#l:lvl) :
    [prop/b : (-> [a : ty/a] (IsProp ($ ty/b a)))]
    [u v : (* [a : ty/a] ($ ty/b a))]
    (path [_] (* [a : ty/a] ($ ty/b a)) u v))
-by
+by {
   lam ty/a ty/b prop/a prop/b u v =>
     use (LemSig #l)
       [ `ty/a
@@ -118,39 +118,39 @@ by
       , `v
       , use prop/a [let {u1, _} = u; `u1, let {v1, _} = v; `v1]
       ]
-.
+}.
 
-theorem PropPi(#l:lvl) :
+theorem PropPi(#l:lvl) : 
   (->
    [ty/a : (U #l kan)]
    [ty/b : (-> ty/a (U #l kan))]
    [prop/b : (-> [a : ty/a] (IsProp ($ ty/b a)))]
    [f g : (-> [a : ty/a] ($ ty/b a))]
    (path [_] (-> [a : ty/a] ($ ty/b a)) f g))
-by
+by {
   lam ty/a ty/b prop/b f g =>
   abs x => lam a => 
     use prop/b [`a, use f [`a], use g [`a], `x];
-.
+}.
 
 
-theorem LemProp(#l:lvl) :
+theorem LemProp(#l:lvl) : 
  (->
   [ty/a : (U #l kan)]
   [prop/a : (IsProp ty/a)]
   [a : ty/a]
   (IsContr ty/a))
-by
+by {
   lam ty/a prop/a a =>
   {`a , lam a' => use prop/a [`a', `a]}
-.
+}.
 
-theorem PropSet(#l:lvl) :
+theorem PropSet(#l:lvl) : 
   (->
    [ty : (U #l kan)]
    [prop : (IsProp ty)]
    (IsSet ty))
-by
+by {
   unfold IsProp IsSet;
   lam ty prop a b p q => abs x y =>
     `(hcom 0~>1 ty a
@@ -158,13 +158,13 @@ by
       [y=1 [z] (@ ($ prop a b) z)]
       [x=0 [z] (@ ($ prop a (@ p y)) z)]
       [x=1 [z] (@ ($ prop a (@ q y)) z)])
-.
+}.
 
-theorem PropIsContr(#l:lvl) :
+theorem PropIsContr(#l:lvl) : 
   (->
    [ty/a : (U #l kan)]
    (IsProp (IsContr ty/a)))
-by
+by {
   lam ty/a isContr =>
     claim contr/a/prop : [(IsProp (IsContr ty/a))] by [
       let {_,contr} = isContr;
@@ -189,14 +189,14 @@ by
     ];
 
     use contr/a/prop [`isContr]
-.
+}.
 
-theorem PropIsEquiv(#l:lvl) :
+theorem PropIsEquiv(#l:lvl) : 
   (->
    [ty/a ty/b : (U #l kan)]
    [f : (-> ty/a ty/b)]
    (IsProp (IsEquiv ty/a ty/b f)))
-by
+by {
   lam ty/a ty/b f e0 e1 =>
   abs x => lam b =>
     use (PropIsContr #l)
@@ -205,31 +205,31 @@ by
       , use e1 [`b]
       , `x
       ]
-.
+}.
 
-theorem EquivLemma(#l:lvl) :
+theorem EquivLemma(#l:lvl) : 
   (->
    [ty/a ty/b : (U #l kan)]
    [e1 e2 : (Equiv ty/a ty/b)]
    (path [_] (-> ty/a ty/b) (!proj1 e1) (!proj1 e2))
    (path [_] (Equiv ty/a ty/b) e1 e2))
-by
+by {
   lam ty/a ty/b =>
     use (LemSig #l)
       [ `(-> ty/a ty/b)
       , lam f => `(IsEquiv ty/a ty/b f)
       , use (PropIsEquiv #l) [`ty/a, `ty/b]
       ]
-.
+}.
 
-theorem UARet(#l:lvl) :
+theorem UARet(#l:lvl) : 
   (->
    [ty/a ty/b : (U #l kan)]
    (Retract
     (Equiv ty/a ty/b)
     ($ (UA #l) ty/a ty/b)
     ($ (PathToEquiv #l) ty/a ty/b)))
-by
+by {
   lam ty/a ty/b e =>
     use (EquivLemma #l)
       [ `ty/a
@@ -241,13 +241,13 @@ by
       ];
 
       unfold PathToEquiv at right in concl; auto
-.
+}.
 
-theorem IsContrPath(#l:lvl) :
+theorem IsContrPath(#l:lvl) : 
   (->
    [ty/a : (U #l kan)]
    (IsContr (* [ty/b : (U #l kan)] (path [_] (U #l kan) ty/a ty/b))))
-by
+by {
   lam ty/a =>
   { {use ty/a, abs _ => use ty/a},
 
@@ -256,9 +256,9 @@ by
       , abs y => `(hcom 0~>y (U #l kan) ty/a [x=0 [y] (@ p y)] [x=1 [_] ty/a])
       }
   }
-.
+}.
 
-theorem RetIsContr(#l:lvl) :
+theorem RetIsContr(#l:lvl) : 
   (->
    [ty/a ty/b : (U #l kan)]
    [f : (-> ty/a ty/b)]
@@ -266,54 +266,54 @@ theorem RetIsContr(#l:lvl) :
    [h : (-> [a : ty/a] (path [_] ty/a ($ g ($ f a)) a))]
    [contr/b : (IsContr ty/b)]
    (IsContr ty/a))
-by
+by {
   lam ty/a ty/b f g h {b,p} =>
   {`($ g b),
    lam a => abs x =>
      `(hcom 0~>1 ty/a ($ g (@ ($ p ($ f a)) x))
         [x=0 [y] (@ ($ h a) y)]
         [x=1 [_] ($ g b)])}
-.
+}.
 
-theorem SigEquivToPath(#l:lvl) :
+theorem SigEquivToPath(#l:lvl) : 
   (->
    [ty/a : (U #l kan)]
    (* [ty/b : (U #l kan)] (Equiv ty/a ty/b))
    (* [ty/b : (U #l kan)] (path [_] (U #l kan) ty/a ty/b)))
-by
+by {
   lam ty/a {ty/b,equiv} =>
   { use ty/b
   , abs x => `(V x ty/a ty/b equiv)
   }
-.
+}.
 
-theorem SigPathToEquiv(#l:lvl) :
+theorem SigPathToEquiv(#l:lvl) : 
   (->
    [ty/a : (U #l kan)]
    (* [ty/b : (U #l kan)] (path [_] (U #l kan) ty/a ty/b))
    (* [ty/b : (U #l kan)] (Equiv ty/a ty/b)))
-by
+by {
   lam ty/a {ty/b,p} =>
   { use ty/b
   , use (PathToEquiv #l) [`ty/a, `ty/b, `p]
   }
-.
+}.
 
-theorem UARetSig(#l:lvl) :
+theorem UARetSig(#l:lvl) : 
   (->
    [ty/a : (U #l kan)]
    (Retract
     (* [ty/b : (U #l kan)] (Equiv ty/a ty/b))
     ($ (SigEquivToPath #l) ty/a)
     ($ (SigPathToEquiv #l) ty/a)))
-by
+by {
   lam ty/a {ty/b,equiv} =>
   unfold SigPathToEquiv SigEquivToPath;
   abs x =>
     { use ty/b
     , use (UARet #l) [`ty/a, `ty/b, `equiv, `x]
     }
-.
+}.
 
 
 
@@ -321,11 +321,11 @@ by
 // https://groups.google.com/forum/#!msg/homotopytypetheory/HfCB_b-PNEU/Ibb48LvUMeUJ
 // See also Theorem 5.8.4 of the HoTT Book.
 
-theorem Univalence(#l:lvl) :
+theorem Univalence(#l:lvl) : 
   (->
    [ty/a : (U #l kan)]
    (IsContr (* [ty/b : (U #l kan)] (Equiv ty/a ty/b))))
-by
+by {
   lam ty/a =>
   use (RetIsContr (++ #l))
    [ `(* [ty/b : (U #l kan)] (Equiv ty/a ty/b))
@@ -335,4 +335,4 @@ by
    , use (UARetSig #l) [`ty/a]
    , use (IsContrPath #l) [`ty/a]
    ]
-.
+}.

--- a/example/univalence.prl
+++ b/example/univalence.prl
@@ -1,20 +1,20 @@
-Def IsContr (#C) = [(* [c : #C] (-> [c' : #C] (path [_] #C c' c)))].
+define IsContr (#C) = (* [c : #C] (-> [c' : #C] (path [_] #C c' c))).
 
-Def Fiber (#A,#B,#f,#b) = [(* [a : #A] (path [_] #B ($ #f a) #b))].
+define Fiber (#A,#B,#f,#b) = (* [a : #A] (path [_] #B ($ #f a) #b)).
 
-Def IsEquiv (#A,#B,#f) = [(-> [b : #B] (IsContr (Fiber #A #B #f b)))].
+define IsEquiv (#A,#B,#f) = (-> [b : #B] (IsContr (Fiber #A #B #f b))).
 
-Def Equiv (#A,#B) = [(* [f : (-> #A #B)] (IsEquiv #A #B f))].
+define Equiv (#A,#B) = (* [f : (-> #A #B)] (IsEquiv #A #B f)).
 
-Def IsProp (#C) = [(-> [c c' : #C] (path [_] #C c c'))].
+define IsProp (#C) = (-> [c c' : #C] (path [_] #C c c')).
 
-Def IsSet (#C) = [(-> [c c' : #C] (IsProp (path [_] #C c c')))].
+define IsSet (#C) = (-> [c c' : #C] (IsProp (path [_] #C c c'))).
 
-Def Retract (#A,#f,#g) = [(-> [a : #A] (path [_] #A ($ #g ($ #f a)) a))].
+define Retract (#A,#f,#g) = (-> [a : #A] (path [_] #A ($ #g ($ #f a)) a)).
 
-Thm IdEquiv(#l:lvl) : [
+theorem IdEquiv(#l:lvl) :
   (-> [ty : (U #l hcom)] (Equiv ty ty))
-] by [
+by
   lam ty =>
   { lam a => use a
   , lam a =>
@@ -24,21 +24,21 @@ Thm IdEquiv(#l:lvl) : [
          abs j => `(hcom 1~>j ty a [i=0 [j] (@ c' j)] [i=1 [j] a])}
      }
   }
-].
+.
 
 // per Dan Licata, UA and UABeta suffice for full univalence:
 // https://groups.google.com/forum/#!topic/homotopytypetheory/j2KBIvDw53s
 
-Thm UA(#l:lvl) : [
+theorem UA(#l:lvl) :
   (-> [ty/a ty/b : (U #l kan)]
       [e : (Equiv ty/a ty/b)]
       (path [_] (U #l kan) ty/a ty/b))
-] by [
+by
   lam ty/a ty/b e =>
     abs x => `(V x ty/a ty/b e)
-].
+.
 
-Thm UABeta(#l:lvl) : [
+theorem UABeta(#l:lvl) :
   (->
    [ty/a ty/b : (U #l kan)]
    [e : (Equiv ty/a ty/b)]
@@ -46,26 +46,26 @@ Thm UABeta(#l:lvl) : [
    (path [_] ty/b
     (coe 0~>1 [x] (@ ($ (UA #l) ty/a ty/b e) x) a)
     ($ (!proj1 e) a)))
-] by [
+by
   unfold UA;
   lam ty/a ty/b {f,_} a =>
     abs x => `(coe x~>1 [_] ty/b ($ f a))
-].
+.
 
 // To prove univalence from UA and UABeta, we need some basic results.
 // (What follows is adapted from the cubicaltt prelude.)
 
-Thm PathToEquiv(#l:lvl) : [
+theorem PathToEquiv(#l:lvl) :
   (->
    [ty/a ty/b : (U #l kan)]
    [p : (path [_] (U #l kan) ty/a ty/b)]
    (Equiv ty/a ty/b))
-] by [
+by
   lam ty/a ty/b p =>
   `(coe 0~>1 [x] (Equiv ty/a (@ p x)) ($ (IdEquiv #l) ty/a))
-].
+.
 
-Thm LemPropF(#l:lvl) : [
+theorem LemPropF(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    [ty/b : (-> ty/a (U #l kan))]
@@ -75,7 +75,7 @@ Thm LemPropF(#l:lvl) : [
    [b0 : ($ ty/b a0)]
    [b1 : ($ ty/b a1)]
    (path [x] ($ ty/b (@ p x)) b0 b1))
-] by [
+by
   lam ty/a ty/b prop/b a0 a1 p b0 b1 => abs x =>
     use prop/b
       [ use p [`x]
@@ -83,9 +83,9 @@ Thm LemPropF(#l:lvl) : [
       , `(coe 1~>x [i] ($ ty/b (@ p i)) b1)
       , `x
       ]
-].
+.
 
-Thm LemSig(#l:lvl) : [
+theorem LemSig(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    [ty/b : (-> ty/a (U #l kan))]
@@ -93,14 +93,14 @@ Thm LemSig(#l:lvl) : [
    [u v : (* [a : ty/a] ($ ty/b a))]
    [p : (path [_] ty/a (!proj1 u) (!proj1 v))]
    (path [_] (* [a : ty/a] ($ ty/b a)) u v))
-] by [
+by
   lam ty/a ty/b prop/b {u1, u2} {v1, v2} p => abs x =>
     { use p [`x]
     , use (LemPropF #l) [`ty/a, `ty/b, `prop/b, `u1, `v1, `p, `u2, `v2, `x]
     }
-].
+.
 
-Thm PropSig(#l:lvl) : [
+theorem PropSig(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    [ty/b : (-> ty/a (U #l kan))]
@@ -108,7 +108,7 @@ Thm PropSig(#l:lvl) : [
    [prop/b : (-> [a : ty/a] (IsProp ($ ty/b a)))]
    [u v : (* [a : ty/a] ($ ty/b a))]
    (path [_] (* [a : ty/a] ($ ty/b a)) u v))
-] by [
+by
   lam ty/a ty/b prop/a prop/b u v =>
     use (LemSig #l)
       [ `ty/a
@@ -118,39 +118,39 @@ Thm PropSig(#l:lvl) : [
       , `v
       , use prop/a [let {u1, _} = u; `u1, let {v1, _} = v; `v1]
       ]
-].
+.
 
-Thm PropPi(#l:lvl) : [
+theorem PropPi(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    [ty/b : (-> ty/a (U #l kan))]
    [prop/b : (-> [a : ty/a] (IsProp ($ ty/b a)))]
    [f g : (-> [a : ty/a] ($ ty/b a))]
    (path [_] (-> [a : ty/a] ($ ty/b a)) f g))
-] by [
+by
   lam ty/a ty/b prop/b f g =>
   abs x => lam a => 
     use prop/b [`a, use f [`a], use g [`a], `x];
-].
+.
 
 
-Thm LemProp(#l:lvl) : [
+theorem LemProp(#l:lvl) :
  (->
   [ty/a : (U #l kan)]
   [prop/a : (IsProp ty/a)]
   [a : ty/a]
   (IsContr ty/a))
-] by [
+by
   lam ty/a prop/a a =>
   {`a , lam a' => use prop/a [`a', `a]}
-].
+.
 
-Thm PropSet(#l:lvl) : [
+theorem PropSet(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [prop : (IsProp ty)]
    (IsSet ty))
-] by [
+by
   unfold IsProp IsSet;
   lam ty prop a b p q => abs x y =>
     `(hcom 0~>1 ty a
@@ -158,13 +158,13 @@ Thm PropSet(#l:lvl) : [
       [y=1 [z] (@ ($ prop a b) z)]
       [x=0 [z] (@ ($ prop a (@ p y)) z)]
       [x=1 [z] (@ ($ prop a (@ q y)) z)])
-].
+.
 
-Thm PropIsContr(#l:lvl) : [
+theorem PropIsContr(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    (IsProp (IsContr ty/a)))
-] by [
+by
   lam ty/a isContr =>
     claim contr/a/prop : [(IsProp (IsContr ty/a))] by [
       let {_,contr} = isContr;
@@ -189,14 +189,14 @@ Thm PropIsContr(#l:lvl) : [
     ];
 
     use contr/a/prop [`isContr]
-].
+.
 
-Thm PropIsEquiv(#l:lvl) : [
+theorem PropIsEquiv(#l:lvl) :
   (->
    [ty/a ty/b : (U #l kan)]
    [f : (-> ty/a ty/b)]
    (IsProp (IsEquiv ty/a ty/b f)))
-] by [
+by
   lam ty/a ty/b f e0 e1 =>
   abs x => lam b =>
     use (PropIsContr #l)
@@ -205,31 +205,31 @@ Thm PropIsEquiv(#l:lvl) : [
       , use e1 [`b]
       , `x
       ]
-].
+.
 
-Thm EquivLemma(#l:lvl) : [
+theorem EquivLemma(#l:lvl) :
   (->
    [ty/a ty/b : (U #l kan)]
    [e1 e2 : (Equiv ty/a ty/b)]
    (path [_] (-> ty/a ty/b) (!proj1 e1) (!proj1 e2))
    (path [_] (Equiv ty/a ty/b) e1 e2))
-] by [
+by
   lam ty/a ty/b =>
     use (LemSig #l)
       [ `(-> ty/a ty/b)
       , lam f => `(IsEquiv ty/a ty/b f)
       , use (PropIsEquiv #l) [`ty/a, `ty/b]
       ]
-].
+.
 
-Thm UARet(#l:lvl) : [
+theorem UARet(#l:lvl) :
   (->
    [ty/a ty/b : (U #l kan)]
    (Retract
     (Equiv ty/a ty/b)
     ($ (UA #l) ty/a ty/b)
     ($ (PathToEquiv #l) ty/a ty/b)))
-] by [
+by
   lam ty/a ty/b e =>
     use (EquivLemma #l)
       [ `ty/a
@@ -241,13 +241,13 @@ Thm UARet(#l:lvl) : [
       ];
 
       unfold PathToEquiv at right in concl; auto
-].
+.
 
-Thm IsContrPath(#l:lvl) : [
+theorem IsContrPath(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    (IsContr (* [ty/b : (U #l kan)] (path [_] (U #l kan) ty/a ty/b))))
-] by [
+by
   lam ty/a =>
   { {use ty/a, abs _ => use ty/a},
 
@@ -256,9 +256,9 @@ Thm IsContrPath(#l:lvl) : [
       , abs y => `(hcom 0~>y (U #l kan) ty/a [x=0 [y] (@ p y)] [x=1 [_] ty/a])
       }
   }
-].
+.
 
-Thm RetIsContr(#l:lvl) : [
+theorem RetIsContr(#l:lvl) :
   (->
    [ty/a ty/b : (U #l kan)]
    [f : (-> ty/a ty/b)]
@@ -266,54 +266,54 @@ Thm RetIsContr(#l:lvl) : [
    [h : (-> [a : ty/a] (path [_] ty/a ($ g ($ f a)) a))]
    [contr/b : (IsContr ty/b)]
    (IsContr ty/a))
-] by [
+by
   lam ty/a ty/b f g h {b,p} =>
   {`($ g b),
    lam a => abs x =>
      `(hcom 0~>1 ty/a ($ g (@ ($ p ($ f a)) x))
         [x=0 [y] (@ ($ h a) y)]
         [x=1 [_] ($ g b)])}
-].
+.
 
-Thm SigEquivToPath(#l:lvl) : [
+theorem SigEquivToPath(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    (* [ty/b : (U #l kan)] (Equiv ty/a ty/b))
    (* [ty/b : (U #l kan)] (path [_] (U #l kan) ty/a ty/b)))
-] by [
+by
   lam ty/a {ty/b,equiv} =>
   { use ty/b
   , abs x => `(V x ty/a ty/b equiv)
   }
-].
+.
 
-Thm SigPathToEquiv(#l:lvl) : [
+theorem SigPathToEquiv(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    (* [ty/b : (U #l kan)] (path [_] (U #l kan) ty/a ty/b))
    (* [ty/b : (U #l kan)] (Equiv ty/a ty/b)))
-] by [
+by
   lam ty/a {ty/b,p} =>
   { use ty/b
   , use (PathToEquiv #l) [`ty/a, `ty/b, `p]
   }
-].
+.
 
-Thm UARetSig(#l:lvl) : [
+theorem UARetSig(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    (Retract
     (* [ty/b : (U #l kan)] (Equiv ty/a ty/b))
     ($ (SigEquivToPath #l) ty/a)
     ($ (SigPathToEquiv #l) ty/a)))
-] by [
+by
   lam ty/a {ty/b,equiv} =>
   unfold SigPathToEquiv SigEquivToPath;
   abs x =>
     { use ty/b
     , use (UARet #l) [`ty/a, `ty/b, `equiv, `x]
     }
-].
+.
 
 
 
@@ -321,11 +321,11 @@ Thm UARetSig(#l:lvl) : [
 // https://groups.google.com/forum/#!msg/homotopytypetheory/HfCB_b-PNEU/Ibb48LvUMeUJ
 // See also Theorem 5.8.4 of the HoTT Book.
 
-Thm Univalence(#l:lvl) : [
+theorem Univalence(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    (IsContr (* [ty/b : (U #l kan)] (Equiv ty/a ty/b))))
-] by [
+by
   lam ty/a =>
   use (RetIsContr (++ #l))
    [ `(* [ty/b : (U #l kan)] (Equiv ty/a ty/b))
@@ -335,4 +335,4 @@ Thm Univalence(#l:lvl) : [
    , use (UARetSig #l) [`ty/a]
    , use (IsContrPath #l) [`ty/a]
    ]
-].
+.

--- a/example/univalence.prl
+++ b/example/univalence.prl
@@ -166,14 +166,14 @@ theorem PropIsContr(#l:lvl) :
    (IsProp (IsContr ty/a)))
 by {
   lam ty/a isContr =>
-    claim contr/a/prop : [(IsProp (IsContr ty/a))] by [
+    claim contr/a/prop : (IsProp (IsContr ty/a)) by {
       let {_,contr} = isContr;
-      claim prop/a : [(IsProp ty/a)] by [
+      claim prop/a : (IsProp ty/a) by {
         lam a a' => abs x =>
           `(hcom 1~>0 ty/a (@ ($ contr a) x)
             [x=0 [_] a]
             [x=1 [y] (@ ($ contr a') y)])
-      ];
+      };
 
       use (PropSig #l)
         [ `ty/a
@@ -186,7 +186,7 @@ by {
               , lam a' => use (PropSet #l) [`ty/a, `prop/a, `a', `a]
               ]
         ]
-    ];
+    };
 
     use contr/a/prop [`isContr]
 }.

--- a/example/univalence.prl
+++ b/example/univalence.prl
@@ -12,7 +12,7 @@ define IsSet (#C) = (-> [c c' : #C] (IsProp (path [_] #C c c'))).
 
 define Retract (#A,#f,#g) = (-> [a : #A] (path [_] #A ($ #g ($ #f a)) a)).
 
-theorem IdEquiv(#l:lvl) : 
+theorem IdEquiv(#l:lvl) :
   (-> [ty : (U #l hcom)] (Equiv ty ty))
 by {
   lam ty =>
@@ -29,7 +29,7 @@ by {
 // per Dan Licata, UA and UABeta suffice for full univalence:
 // https://groups.google.com/forum/#!topic/homotopytypetheory/j2KBIvDw53s
 
-theorem UA(#l:lvl) : 
+theorem UA(#l:lvl) :
   (-> [ty/a ty/b : (U #l kan)]
       [e : (Equiv ty/a ty/b)]
       (path [_] (U #l kan) ty/a ty/b))
@@ -38,7 +38,7 @@ by {
     abs x => `(V x ty/a ty/b e)
 }.
 
-theorem UABeta(#l:lvl) : 
+theorem UABeta(#l:lvl) :
   (->
    [ty/a ty/b : (U #l kan)]
    [e : (Equiv ty/a ty/b)]
@@ -55,7 +55,7 @@ by {
 // To prove univalence from UA and UABeta, we need some basic results.
 // (What follows is adapted from the cubicaltt prelude.)
 
-theorem PathToEquiv(#l:lvl) : 
+theorem PathToEquiv(#l:lvl) :
   (->
    [ty/a ty/b : (U #l kan)]
    [p : (path [_] (U #l kan) ty/a ty/b)]
@@ -65,7 +65,7 @@ by {
   `(coe 0~>1 [x] (Equiv ty/a (@ p x)) ($ (IdEquiv #l) ty/a))
 }.
 
-theorem LemPropF(#l:lvl) : 
+theorem LemPropF(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    [ty/b : (-> ty/a (U #l kan))]
@@ -85,7 +85,7 @@ by {
       ]
 }.
 
-theorem LemSig(#l:lvl) : 
+theorem LemSig(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    [ty/b : (-> ty/a (U #l kan))]
@@ -100,7 +100,7 @@ by {
     }
 }.
 
-theorem PropSig(#l:lvl) : 
+theorem PropSig(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    [ty/b : (-> ty/a (U #l kan))]
@@ -120,7 +120,7 @@ by {
       ]
 }.
 
-theorem PropPi(#l:lvl) : 
+theorem PropPi(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    [ty/b : (-> ty/a (U #l kan))]
@@ -129,12 +129,12 @@ theorem PropPi(#l:lvl) :
    (path [_] (-> [a : ty/a] ($ ty/b a)) f g))
 by {
   lam ty/a ty/b prop/b f g =>
-  abs x => lam a => 
+  abs x => lam a =>
     use prop/b [`a, use f [`a], use g [`a], `x];
 }.
 
 
-theorem LemProp(#l:lvl) : 
+theorem LemProp(#l:lvl) :
  (->
   [ty/a : (U #l kan)]
   [prop/a : (IsProp ty/a)]
@@ -145,7 +145,7 @@ by {
   {`a , lam a' => use prop/a [`a', `a]}
 }.
 
-theorem PropSet(#l:lvl) : 
+theorem PropSet(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [prop : (IsProp ty)]
@@ -160,7 +160,7 @@ by {
       [x=1 [z] (@ ($ prop a (@ q y)) z)])
 }.
 
-theorem PropIsContr(#l:lvl) : 
+theorem PropIsContr(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    (IsProp (IsContr ty/a)))
@@ -179,7 +179,7 @@ by {
         [ `ty/a
         , lam a => `(-> [a' : ty/a] (path [_] ty/a a' a))
         , `prop/a
-        , lam a => 
+        , lam a =>
             use (PropPi #l)
               [ `ty/a
               , lam a' => `(path [_] ty/a a' a)
@@ -191,7 +191,7 @@ by {
     use contr/a/prop [`isContr]
 }.
 
-theorem PropIsEquiv(#l:lvl) : 
+theorem PropIsEquiv(#l:lvl) :
   (->
    [ty/a ty/b : (U #l kan)]
    [f : (-> ty/a ty/b)]
@@ -207,7 +207,7 @@ by {
       ]
 }.
 
-theorem EquivLemma(#l:lvl) : 
+theorem EquivLemma(#l:lvl) :
   (->
    [ty/a ty/b : (U #l kan)]
    [e1 e2 : (Equiv ty/a ty/b)]
@@ -222,7 +222,7 @@ by {
       ]
 }.
 
-theorem UARet(#l:lvl) : 
+theorem UARet(#l:lvl) :
   (->
    [ty/a ty/b : (U #l kan)]
    (Retract
@@ -243,7 +243,7 @@ by {
       unfold PathToEquiv at right in concl; auto
 }.
 
-theorem IsContrPath(#l:lvl) : 
+theorem IsContrPath(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    (IsContr (* [ty/b : (U #l kan)] (path [_] (U #l kan) ty/a ty/b))))
@@ -258,7 +258,7 @@ by {
   }
 }.
 
-theorem RetIsContr(#l:lvl) : 
+theorem RetIsContr(#l:lvl) :
   (->
    [ty/a ty/b : (U #l kan)]
    [f : (-> ty/a ty/b)]
@@ -275,7 +275,7 @@ by {
         [x=1 [_] ($ g b)])}
 }.
 
-theorem SigEquivToPath(#l:lvl) : 
+theorem SigEquivToPath(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    (* [ty/b : (U #l kan)] (Equiv ty/a ty/b))
@@ -287,7 +287,7 @@ by {
   }
 }.
 
-theorem SigPathToEquiv(#l:lvl) : 
+theorem SigPathToEquiv(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    (* [ty/b : (U #l kan)] (path [_] (U #l kan) ty/a ty/b))
@@ -299,7 +299,7 @@ by {
   }
 }.
 
-theorem UARetSig(#l:lvl) : 
+theorem UARetSig(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    (Retract
@@ -321,7 +321,7 @@ by {
 // https://groups.google.com/forum/#!msg/homotopytypetheory/HfCB_b-PNEU/Ibb48LvUMeUJ
 // See also Theorem 5.8.4 of the HoTT Book.
 
-theorem Univalence(#l:lvl) : 
+theorem Univalence(#l:lvl) :
   (->
    [ty/a : (U #l kan)]
    (IsContr (* [ty/b : (U #l kan)] (Equiv ty/a ty/b))))

--- a/src/frontend/frontend.sml
+++ b/src/frontend/frontend.sml
@@ -39,12 +39,12 @@ struct
 
   local
     val EOF = RedPrlLrVals.Tokens.EOF (Coord.init, Coord.init)
-    val DEF = RedPrlLrVals.Tokens.DCL_DEF (Coord.init, Coord.init)
-    val THM = RedPrlLrVals.Tokens.DCL_THM (Coord.init, Coord.init)
-    val TAC = RedPrlLrVals.Tokens.DCL_TAC (Coord.init, Coord.init)
-    val PRINT = RedPrlLrVals.Tokens.CMD_PRINT (Coord.init, Coord.init)
-    val EXTRACT = RedPrlLrVals.Tokens.CMD_EXTRACT (Coord.init, Coord.init)
-    val QUIT = RedPrlLrVals.Tokens.CMD_QUIT (Coord.init, Coord.init)    
+    val DEF = RedPrlLrVals.Tokens.DEFINE (Coord.init, Coord.init)
+    val THM = RedPrlLrVals.Tokens.THEOREM (Coord.init, Coord.init)
+    val TAC = RedPrlLrVals.Tokens.TACTIC (Coord.init, Coord.init)
+    val PRINT = RedPrlLrVals.Tokens.PRINT (Coord.init, Coord.init)
+    val EXTRACT = RedPrlLrVals.Tokens.EXTRACT (Coord.init, Coord.init)
+    val QUIT = RedPrlLrVals.Tokens.QUIT (Coord.init, Coord.init)    
     val DOT = RedPrlLrVals.Tokens.DOT (Coord.init, Coord.init)
 
     fun isBeginElt tok =

--- a/src/redprl/metalanguage/elaborate.fun
+++ b/src/redprl/metalanguage/elaborate.fun
@@ -237,6 +237,89 @@ struct
     in
       elabNu (psi, resultAbs)
     end
+  
+  fun elabMatchThm (elabv : elab_val, xjdg, xtm, elabc : elab_cmd) : elab_cmd = fn env => 
+    let
+      val (v', ty) = elabv env
+      val tau =
+        case ty of
+          Ty.THM tau => tau
+        | _ => Err.raiseError @@ Err.GENERIC [Fpp.text "MATCH_THM applied to non-theorem"]
+
+      val env' = R.extendId env xjdg @@ Ty.TERM RedPrlSort.JDG
+      val env'' = R.extendId env' xtm @@ Ty.TERM tau
+      val (cmd', cty) = elabc env''
+    in
+      (ISyn.MATCH_THM (v', xjdg, xtm, cmd'), cty)
+    end
+
+  fun elabMatchAbs (elabv : elab_val, xpsi, xv, elabc : elab_cmd) : elab_cmd = fn env =>
+    let
+      val (v, Ty.ABS (vls, vty)) = elabv env
+      val env' = R.extendId env xpsi @@ Ty.METAS vls
+      val env'' = R.extendId env' xv vty
+      val (cmd, cty) = elabc env''
+    in
+      (ISyn.MATCH_ABS (v, xpsi, xv, cmd), cty)
+    end
+
+  fun elabPrint (pos, elabv : elab_val) : elab_cmd = fn env =>
+    (ISyn.PRINT (pos, #1 @@ elabv env), Ty.UP Ty.ONE)
+
+
+  fun elabExtract (elabv : elab_val) : elab_cmd = 
+    let
+      val xpsi = MlId.new ()
+      val xthm = MlId.new ()
+      val xjdg = MlId.new ()
+      val xtm = MlId.new ()
+    in
+      elabMatchAbs (elabv, xpsi, xthm, elabMatchThm (elabVar xthm, xjdg, xtm, elabRet @@ elabAbs (elabVar xpsi, elabVar xtm)))
+    end
+
+  fun elabPrintExtract (pos, elabv : elab_val) : elab_cmd =
+    let
+      val xtm = MlId.new ()
+    in
+      elabBind (elabExtract elabv, xtm, elabPrint (pos, elabVar xtm))
+    end
+
+  val elabAbort : elab_cmd = fn _ => 
+    (ISyn.ABORT, Ty.UP Ty.ONE)
+
+  fun elabForce (elabv : elab_val) : elab_cmd = fn env => 
+    let
+      val (v', vty) = elabv env
+    in
+      case vty of
+         Ty.DOWN cty => (ISyn.FORCE v', cty)
+       | _ => Err.raiseError @@ Err.GENERIC [Fpp.text "Expected down-shifted type"]
+    end
+
+  fun elabFn (x, vty, elabc : elab_cmd) : elab_cmd = fn env =>
+    let
+      val env' = R.extendId env x vty
+      val (cmd', cty) = elabc env'
+    in
+      (ISyn.FN (x, vty, cmd'), Ty.FUN (vty, cty))
+    end
+
+  fun elabAp (elabc : elab_cmd, elabv : elab_val) : elab_cmd = fn env => 
+    let
+      val (cmd', cty) = elabc env
+    in
+      case cty of
+         Ty.FUN (vty, cty') =>
+         let
+           val (v', vty') = elabv env
+         in
+           if vty = vty' then
+             (ISyn.AP (cmd', v'), cty')
+           else
+             Err.raiseError @@ Err.GENERIC [Fpp.text "Argument type mismatch"]
+         end
+       | _ => Err.raiseError @@ Err.GENERIC [Fpp.text "Expected function type"]
+    end
 
   fun elabValue value : elab_val =
     case value of
@@ -259,123 +342,63 @@ struct
        elabAbs (elabValue vpsi, elabValue v)
 
 
-  and elabCmd cmd env : ISyn.cmd * Ty.cty =
+  and elabCmd cmd : elab_cmd =
     case cmd of
        ESyn.NU (psi, cmd) =>
-       elabNu (psi, elabCmd cmd) env
+       elabNu (psi, elabCmd cmd)
 
      | ESyn.DEF {arguments, definiens} =>
-       elabDef (arguments, definiens) env
+       elabDef (arguments, definiens)
 
      | ESyn.TAC {arguments, script} =>
-       elabDef (arguments, (script, RedPrlSort.TAC)) env
+       elabDef (arguments, (script, RedPrlSort.TAC))
 
      | ESyn.THM {name, arguments, goal, script} =>
-       elabThm (name, arguments, goal, script) env
+       elabThm (name, arguments, goal, script)
 
      | ESyn.DATA_DECL {name, arguments, foo} =>
-       elabDataDecl (name, arguments, foo) env
+       elabDataDecl (name, arguments, foo)
 
      | ESyn.PRINT_EXTRACT (pos, v) =>
-       let
-         val xpsi = MlId.new ()
-         val xthm = MlId.new ()
-         val xjdg = MlId.new ()
-         val xtm = MlId.new ()
-         val ecmd' = ESyn.MATCH_ABS (v, xpsi, xthm, ESyn.MATCH_THM (ESyn.VAR xthm, xjdg, xtm, ESyn.PRINT (pos, ESyn.ABS (ESyn.VAR xpsi, ESyn.VAR xtm))))
-       in
-         elabCmd ecmd' env
-       end
+       elabPrintExtract (pos, elabValue v)
 
      | ESyn.EXTRACT v =>
-       let
-         val xjdg = MlId.new ()
-         val xtm = MlId.new ()
-         val ecmd' = ESyn.MATCH_THM (v, xjdg, xtm, ESyn.RET (ESyn.VAR xtm))
-       in
-         elabCmd ecmd' env
-       end
+       elabExtract (elabValue v)
 
      | ESyn.BIND (cmd1, nm, cmd2) =>
-       elabBind (elabCmd cmd1, nm, elabCmd cmd2) env
+       elabBind (elabCmd cmd1, nm, elabCmd cmd2)
 
      | ESyn.RET v =>
-       elabRet (elabValue v) env
+       elabRet (elabValue v)
 
      | ESyn.FORCE v =>
-       let
-         val (v', vty) = elabValue v env
-       in
-         case vty of
-            Ty.DOWN cty => (ISyn.FORCE v', cty)
-          | _ => Err.raiseError @@ Err.GENERIC [Fpp.text "Expected down-shifted type"]
-       end
+       elabForce (elabValue v)
 
      | ESyn.FN (x, vty, cmd) =>
-       let
-         val env' = R.extendId env x vty
-         val (cmd', cty) = elabCmd cmd env'
-       in
-         (ISyn.FN (x, vty, cmd'), Ty.FUN (vty, cty))
-       end
+       elabFn (x, vty, elabCmd cmd)
 
      | ESyn.AP (cmd, v) =>
-       let
-         val (cmd', cty) = elabCmd cmd env
-       in
-         case cty of
-            Ty.FUN (vty, cty') =>
-            let
-              val (v', vty') = elabValue v env
-            in
-              if vty = vty' then
-                (ISyn.AP (cmd', v'), cty')
-              else
-                Err.raiseError @@ Err.GENERIC [Fpp.text "Argument type mismatch"]
-            end
-          | _ => Err.raiseError @@ Err.GENERIC [Fpp.text "Expected function type"]
-       end
+       elabAp (elabCmd cmd, elabValue v)
 
      | ESyn.PRINT (pos, v) =>
-       (ISyn.PRINT (pos, #1 @@ elabValue v env), Ty.UP Ty.ONE)
-
+       elabPrint (pos, elabValue v)
 
      | ESyn.REFINE (name, ajdg, script) =>
-       elabRefine (name, ajdg, script) env
+       elabRefine (name, ajdg, script)
 
      | ESyn.FRESH vls =>
-       elabFresh vls env
+       elabFresh vls
 
      | ESyn.MATCH_METAS (v, Xs, cmd) =>
-       elabMatchMetas (elabValue v, Xs, elabCmd cmd) env
+       elabMatchMetas (elabValue v, Xs, elabCmd cmd)
 
      | ESyn.MATCH_THM (v, xjdg, xtm, cmd) =>
-       let
-         val (v', ty) = elabValue v env
-         val tau =
-           case ty of
-              Ty.THM tau => tau
-            | _ => Err.raiseError @@ Err.GENERIC [Fpp.text "MATCH_THM applied to non-theorem"]
-
-         val env' = R.extendId env xjdg @@ Ty.TERM RedPrlSort.JDG
-         val env'' = R.extendId env' xtm @@ Ty.TERM tau
-         val (cmd', cty) = elabCmd cmd env''
-       in
-         (ISyn.MATCH_THM (v', xjdg, xtm, cmd'), cty)
-       end
+       elabMatchThm (elabValue v, xjdg, xtm, elabCmd cmd)
 
      | ESyn.MATCH_ABS (v, xpsi, xv, cmd) =>
-       let
-         val (v', Ty.ABS (vls, vty)) = elabValue v env
-         val env' = R.extendId env xpsi @@ Ty.METAS vls
-         val env'' = R.extendId env' xv vty
-         val (cmd', cty) = elabCmd cmd env''
-       in
-         (ISyn.MATCH_ABS (v', xpsi, xv, cmd'), cty)
-       end
+       elabMatchAbs (elabValue v, xpsi, xv, elabCmd cmd)
 
      | ESyn.ABORT =>
-       (ISyn.ABORT, Ty.UP Ty.ONE)
-       (* ? *)
+       elabAbort
 
 end

--- a/src/redprl/metalanguage/syntax.sml
+++ b/src/redprl/metalanguage/syntax.sml
@@ -52,6 +52,7 @@ struct
   type jdg = Sequent.jdg
   type term = RedPrlAbt.abt
   type vty = MlType.vty
+  type proof_state = Sequent.jdg Lcf.state
 
   type metas = (metavariable * valence) list
 
@@ -72,6 +73,7 @@ struct
    | AP of cmd * value
    | PRINT of Pos.t option * value
    | REFINE of string option * jdg * term
+   | REFINE_MULTI of string option * proof_state * term
    | FRESH of (string option * valence) list
    | MATCH_METAS of value * metavariable list * cmd
    | MATCH_ABS of value * id * id * cmd

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -940,7 +940,7 @@ atomicRawTac
   | IF elimTarget THEN tactic ELSE tactic
       (Ast.$$ (O.DEV_BOOL_ELIM, [\ ([], elimTarget), \ ([], tactic1), \ ([], tactic2)]))
 
-  | CLAIM VARNAME COLON LSQUARE judgment RSQUARE BY LSQUARE tactic RSQUARE SEMI tactic
+  | CLAIM VARNAME COLON judgment BY LBRACKET tactic RBRACKET SEMI tactic
       (Ast.$$ (O.DEV_CLAIM NONE, [\ ([], judgment), \ ([], tactic1), \([VARNAME], tactic2)]))
 
   | LET devDecompPattern EQUALS elimTargetAnySort bracketedDevAppSpine SEMI tactic

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -374,10 +374,10 @@ end
 
  | DISCRETE | KAN | PRE
 
- (* commands and declarations *)
+ (* metalanguage *)
  | CMD_PRINT | CMD_EXTRACT | CMD_QUIT
  | DCL_DEF | DCL_TAC | DCL_THM
- | BY | IN | VAL
+ | BY | IN | VAL | DO | CAROT
 
 %right LEFT_ARROW RIGHT_ARROW DOUBLE_PIPE SEMI
 %right TIMES
@@ -495,6 +495,7 @@ end
 
  | mlValue of ML.value
  | mlCmd of ML.cmd
+ | mlAtomicCmd of ML.cmd
  | mlDecl of ML.cmd -> ML.cmd
 
 %verbose
@@ -1018,12 +1019,28 @@ declArgumentsParens
 mlValue
   : OPNAME
     (ML.VAR (MlId.const OPNAME))
+  | LBRACKET mlCmd RBRACKET
+    (ML.THUNK mlCmd)
+  | LPAREN RPAREN
+    (ML.NIL)
+
+mlAtomicCmd
+  : CMD_PRINT mlValue
+    (ML.PRINT (SOME (Pos.pos (mlValueleft fileName) (mlValueright fileName)), mlValue))
+  | CMD_QUIT
+    (ML.ABORT)
+  | CMD_EXTRACT mlValue
+    (ML.EXTRACT mlValue)
+  | CAROT mlValue
+    (ML.RET mlValue)
+  | BANG mlValue
+    (ML.FORCE mlValue)
 
 mlCmd
   : LET mlDecl SEMI mlCmd
     (mlDecl mlCmd)
-  | CMD_PRINT mlValue
-    (ML.PRINT (SOME (Pos.pos (mlValueleft fileName) (mlValueright fileName)), mlValue))
+  | mlAtomicCmd
+    (mlAtomicCmd)
 
 mlDecl
   : DCL_DEF OPNAME declArgumentsParens COLON sort EQUALS LSQUARE term RSQUARE
@@ -1040,19 +1057,13 @@ mlDecl
        ML.BIND (ML.THM {name = OPNAME, arguments = declArgumentsParens, goal = src_atjdg, script = tactic}, MlId.const OPNAME, kont))
 
   | VAL OPNAME EQUALS mlCmd
-   (fn kont => 
-      ML.BIND (mlCmd, MlId.const OPNAME, kont)) 
+   (fn kont =>
+      ML.BIND (mlCmd, MlId.const OPNAME, kont))
 
-  | CMD_PRINT OPNAME
+  | mlAtomicCmd
     (fn kont =>
-       ML.BIND (ML.PRINT (SOME (Pos.pos (OPNAMEleft fileName) (OPNAMEright fileName)), ML.VAR (MlId.const OPNAME)), MlId.fresh "_", kont))
-  | CMD_EXTRACT OPNAME
+       ML.BIND (mlAtomicCmd, MlId.fresh "_", kont))
+
+  | DO mlCmd
     (fn kont =>
-       ML.BIND (ML.PRINT_EXTRACT (SOME (Pos.pos (OPNAMEleft fileName) (OPNAMEright fileName)), ML.VAR (MlId.const OPNAME)), MlId.fresh "_", kont))
-  | CMD_QUIT
-    (fn kont =>
-       ML.BIND (ML.ABORT, MlId.fresh "_", kont))
-
-
-
-
+       ML.BIND (mlCmd, MlId.fresh "_", kont))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -377,7 +377,7 @@ end
  (* metalanguage *)
  | EXTRACT | QUIT
  | DEFINE | TACTIC | THEOREM
- | BY | IN | VAL | DO | CAROT | END
+ | BY | IN | VAL | DO | CARET | END
 
 %right LEFT_ARROW RIGHT_ARROW DOUBLE_PIPE SEMI
 %right TIMES
@@ -1031,7 +1031,7 @@ mlAtomicCmd
     (ML.ABORT)
   | EXTRACT mlValue
     (ML.EXTRACT mlValue)
-  | CAROT mlValue
+  | CARET mlValue
     (ML.RET mlValue)
   | BANG mlValue
     (ML.FORCE mlValue)

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -377,7 +377,7 @@ end
  (* metalanguage *)
  | EXTRACT | QUIT
  | DEFINE | TACTIC | THEOREM
- | BY | IN | VAL | DO | CAROT
+ | BY | IN | VAL | DO | CAROT | END
 
 %right LEFT_ARROW RIGHT_ARROW DOUBLE_PIPE SEMI
 %right TIMES
@@ -1051,11 +1051,11 @@ mlDecl
     (fn kont =>
        ML.BIND (ML.DEF {arguments = declArgumentsParens, definiens = (term, O.EXP)}, MlId.const OPNAME, kont))
 
-  | TACTIC OPNAME declArgumentsParens EQUALS tactic
+  | TACTIC OPNAME declArgumentsParens EQUALS LBRACKET tactic RBRACKET
     (fn kont =>
        ML.BIND (ML.TAC {arguments = declArgumentsParens, script = tactic}, MlId.const OPNAME, kont))
 
-  | THEOREM OPNAME declArgumentsParens COLON src_atjdg BY tactic
+  | THEOREM OPNAME declArgumentsParens COLON src_atjdg BY LBRACKET tactic RBRACKET
     (fn kont =>
        ML.BIND (ML.THM {name = OPNAME, arguments = declArgumentsParens, goal = src_atjdg, script = tactic}, MlId.const OPNAME, kont))
 

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -377,7 +377,7 @@ end
  (* commands and declarations *)
  | CMD_PRINT | CMD_EXTRACT | CMD_QUIT
  | DCL_DEF | DCL_TAC | DCL_THM
- | BY | IN
+ | BY | IN | VAL
 
 %right LEFT_ARROW RIGHT_ARROW DOUBLE_PIPE SEMI
 %right TIMES
@@ -388,7 +388,7 @@ end
 
 
 %nonterm
-   start of Signature.Src.elt
+   start of ML.cmd -> ML.cmd
 
  | ident of string
  | boundVar of string option
@@ -492,7 +492,10 @@ end
  | declArguments of Signature.Src.arguments
  | declArgumentsParens of Signature.Src.arguments
 
- | elt of Signature.Src.elt
+
+ | mlValue of ML.value
+ | mlCmd of ML.cmd
+ | mlDecl of ML.cmd -> ML.cmd
 
 %verbose
 %pos (string -> Coord.t)
@@ -503,7 +506,7 @@ end
 %arg (fileName) : string
 %%
 
-start : elt (elt)
+start : mlDecl (mlDecl)
 
 ident
   : OPNAME (OPNAME)
@@ -1012,8 +1015,17 @@ declArgumentsParens
   | ([])
 
 
+mlValue
+  : OPNAME
+    (ML.VAR (MlId.const OPNAME))
 
-elt
+mlCmd
+  : LET mlDecl SEMI mlCmd
+    (mlDecl mlCmd)
+  | CMD_PRINT mlValue
+    (ML.PRINT (SOME (Pos.pos (mlValueleft fileName) (mlValueright fileName)), mlValue))
+
+mlDecl
   : DCL_DEF OPNAME declArgumentsParens COLON sort EQUALS LSQUARE term RSQUARE
     (fn kont =>
        ML.BIND (ML.DEF {arguments = declArgumentsParens, definiens = (term, sort)}, MlId.const OPNAME, kont))
@@ -1026,6 +1038,10 @@ elt
   | DCL_THM OPNAME declArgumentsParens COLON LSQUARE src_atjdg RSQUARE BY LSQUARE tactic RSQUARE
     (fn kont =>
        ML.BIND (ML.THM {name = OPNAME, arguments = declArgumentsParens, goal = src_atjdg, script = tactic}, MlId.const OPNAME, kont))
+
+  | VAL OPNAME EQUALS mlCmd
+   (fn kont => 
+      ML.BIND (mlCmd, MlId.const OPNAME, kont)) 
 
   | CMD_PRINT OPNAME
     (fn kont =>

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -375,8 +375,8 @@ end
  | DISCRETE | KAN | PRE
 
  (* metalanguage *)
- | CMD_PRINT | CMD_EXTRACT | CMD_QUIT
- | DCL_DEF | DCL_TAC | DCL_THM
+ | EXTRACT | QUIT
+ | DEFINE | TACTIC | THEOREM
  | BY | IN | VAL | DO | CAROT
 
 %right LEFT_ARROW RIGHT_ARROW DOUBLE_PIPE SEMI
@@ -1025,11 +1025,11 @@ mlValue
     (ML.NIL)
 
 mlAtomicCmd
-  : CMD_PRINT mlValue
+  : PRINT mlValue
     (ML.PRINT (SOME (Pos.pos (mlValueleft fileName) (mlValueright fileName)), mlValue))
-  | CMD_QUIT
+  | QUIT
     (ML.ABORT)
-  | CMD_EXTRACT mlValue
+  | EXTRACT mlValue
     (ML.EXTRACT mlValue)
   | CAROT mlValue
     (ML.RET mlValue)
@@ -1043,16 +1043,19 @@ mlCmd
     (mlAtomicCmd)
 
 mlDecl
-  : DCL_DEF OPNAME declArgumentsParens COLON sort EQUALS LSQUARE term RSQUARE
+  : DEFINE OPNAME declArgumentsParens COLON sort EQUALS term
     (fn kont =>
        ML.BIND (ML.DEF {arguments = declArgumentsParens, definiens = (term, sort)}, MlId.const OPNAME, kont))
-  | DCL_DEF OPNAME declArgumentsParens EQUALS LSQUARE term RSQUARE
+
+  | DEFINE OPNAME declArgumentsParens EQUALS term
     (fn kont =>
        ML.BIND (ML.DEF {arguments = declArgumentsParens, definiens = (term, O.EXP)}, MlId.const OPNAME, kont))
-  | DCL_TAC OPNAME declArgumentsParens EQUALS LSQUARE tactic RSQUARE
+
+  | TACTIC OPNAME declArgumentsParens EQUALS tactic
     (fn kont =>
        ML.BIND (ML.TAC {arguments = declArgumentsParens, script = tactic}, MlId.const OPNAME, kont))
-  | DCL_THM OPNAME declArgumentsParens COLON LSQUARE src_atjdg RSQUARE BY LSQUARE tactic RSQUARE
+
+  | THEOREM OPNAME declArgumentsParens COLON src_atjdg BY tactic
     (fn kont =>
        ML.BIND (ML.THM {name = OPNAME, arguments = declArgumentsParens, goal = src_atjdg, script = tactic}, MlId.const OPNAME, kont))
 

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -1063,10 +1063,6 @@ mlDecl
    (fn kont =>
       ML.BIND (mlCmd, MlId.const OPNAME, kont))
 
-  | mlAtomicCmd
-    (fn kont =>
-       ML.BIND (mlAtomicCmd, MlId.fresh "_", kont))
-
-  | DO mlCmd
+  | mlCmd
     (fn kont =>
        ML.BIND (mlCmd, MlId.fresh "_", kont))

--- a/src/redprl/redprl.grm
+++ b/src/redprl/redprl.grm
@@ -377,7 +377,7 @@ end
  (* metalanguage *)
  | EXTRACT | QUIT
  | DEFINE | TACTIC | THEOREM
- | BY | IN | VAL | DO | CARET | END
+ | BY | IN | VAL | DO | CARET | END | FN
 
 %right LEFT_ARROW RIGHT_ARROW DOUBLE_PIPE SEMI
 %right TIMES
@@ -492,7 +492,8 @@ end
  | declArguments of Signature.Src.arguments
  | declArgumentsParens of Signature.Src.arguments
 
-
+ | mlVty of MlType.vty
+ | mlCty of MlType.cty
  | mlValue of ML.value
  | mlCmd of ML.cmd
  | mlAtomicCmd of ML.cmd
@@ -1016,6 +1017,18 @@ declArgumentsParens
   | ([])
 
 
+mlVty
+  : LPAREN RPAREN
+    (MlType.ONE)
+  | LBRACKET mlCty RBRACKET
+    (MlType.DOWN mlCty)
+  
+mlCty 
+  : CARET mlVty
+    (MlType.UP mlVty)
+  | mlVty RIGHT_ARROW mlCty
+    (MlType.FUN (mlVty, mlCty))
+
 mlValue
   : OPNAME
     (ML.VAR (MlId.const OPNAME))
@@ -1039,6 +1052,10 @@ mlAtomicCmd
 mlCmd
   : LET mlDecl SEMI mlCmd
     (mlDecl mlCmd)
+  | FN OPNAME COLON mlVty DOUBLE_RIGHT_ARROW mlCmd
+    (ML.FN (MlId.const OPNAME, mlVty, mlCmd))
+  | mlValue RANGLE mlCmd
+    (ML.AP (mlCmd, mlValue))
   | mlAtomicCmd
     (mlAtomicCmd)
 

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -172,7 +172,7 @@ whitespace = [\ \t];
 <INITIAL>"val"              => (Tokens.VAL (posTuple (size yytext)));
 <INITIAL>"do"               => (Tokens.DO (posTuple (size yytext)));
 <INITIAL>"end"              => (Tokens.END (posTuple (size yytext)));
-<INITIAL>"^"                => (Tokens.CAROT (posTuple (size yytext)));
+<INITIAL>"^"                => (Tokens.CARET (posTuple (size yytext)));
 
 
 <INITIAL>"repeat"           => (Tokens.MTAC_REPEAT (posTuple (size yytext)));

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -171,6 +171,7 @@ whitespace = [\ \t];
 <INITIAL>"in"               => (Tokens.IN (posTuple (size yytext)));
 <INITIAL>"val"              => (Tokens.VAL (posTuple (size yytext)));
 <INITIAL>"do"               => (Tokens.DO (posTuple (size yytext)));
+<INITIAL>"end"              => (Tokens.END (posTuple (size yytext)));
 <INITIAL>"^"                => (Tokens.CAROT (posTuple (size yytext)));
 
 

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -171,6 +171,9 @@ whitespace = [\ \t];
 <INITIAL>"by"               => (Tokens.BY (posTuple (size yytext)));
 <INITIAL>"in"               => (Tokens.IN (posTuple (size yytext)));
 <INITIAL>"val"              => (Tokens.VAL (posTuple (size yytext)));
+<INITIAL>"do"               => (Tokens.DO (posTuple (size yytext)));
+<INITIAL>"^"                => (Tokens.CAROT (posTuple (size yytext)));
+
 
 <INITIAL>"repeat"           => (Tokens.MTAC_REPEAT (posTuple (size yytext)));
 <INITIAL>"progress"         => (Tokens.MTAC_PROGRESS (posTuple (size yytext)));

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -172,6 +172,7 @@ whitespace = [\ \t];
 <INITIAL>"val"              => (Tokens.VAL (posTuple (size yytext)));
 <INITIAL>"do"               => (Tokens.DO (posTuple (size yytext)));
 <INITIAL>"end"              => (Tokens.END (posTuple (size yytext)));
+<INITIAL>"fn"               => (Tokens.FN (posTuple (size yytext)));
 <INITIAL>"^"                => (Tokens.CARET (posTuple (size yytext)));
 
 

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -170,6 +170,7 @@ whitespace = [\ \t];
 <INITIAL>"Thm"              => (Tokens.DCL_THM (posTuple (size yytext)));
 <INITIAL>"by"               => (Tokens.BY (posTuple (size yytext)));
 <INITIAL>"in"               => (Tokens.IN (posTuple (size yytext)));
+<INITIAL>"val"              => (Tokens.VAL (posTuple (size yytext)));
 
 <INITIAL>"repeat"           => (Tokens.MTAC_REPEAT (posTuple (size yytext)));
 <INITIAL>"progress"         => (Tokens.MTAC_PROGRESS (posTuple (size yytext)));

--- a/src/redprl/redprl.lex
+++ b/src/redprl/redprl.lex
@@ -162,12 +162,11 @@ whitespace = [\ \t];
 <INITIAL>"tac"              => (Tokens.TAC (posTuple (size yytext)));
 <INITIAL>"jdg"              => (Tokens.JDG (posTuple (size yytext)));
 
-<INITIAL>"Print"            => (Tokens.CMD_PRINT (posTuple (size yytext)));
-<INITIAL>"Extract"          => (Tokens.CMD_EXTRACT (posTuple (size yytext)));
-<INITIAL>"Quit"             => (Tokens.CMD_QUIT (posTuple (size yytext)));
-<INITIAL>"Def"              => (Tokens.DCL_DEF (posTuple (size yytext)));
-<INITIAL>"Tac"              => (Tokens.DCL_TAC (posTuple (size yytext)));
-<INITIAL>"Thm"              => (Tokens.DCL_THM (posTuple (size yytext)));
+<INITIAL>"extract"          => (Tokens.EXTRACT (posTuple (size yytext)));
+<INITIAL>"quit"             => (Tokens.QUIT (posTuple (size yytext)));
+<INITIAL>"define"           => (Tokens.DEFINE (posTuple (size yytext)));
+<INITIAL>"tactic"           => (Tokens.TACTIC (posTuple (size yytext)));
+<INITIAL>"theorem"          => (Tokens.THEOREM (posTuple (size yytext)));
 <INITIAL>"by"               => (Tokens.BY (posTuple (size yytext)));
 <INITIAL>"in"               => (Tokens.IN (posTuple (size yytext)));
 <INITIAL>"val"              => (Tokens.VAL (posTuple (size yytext)));

--- a/test/failure/bad-hcom-empty.prl
+++ b/test/failure/bad-hcom-empty.prl
@@ -1,4 +1,4 @@
-theorem MalformedTube : 
+theorem MalformedTube :
   wbool true
 by {
   `(hcom 0~>1 wbool tt)

--- a/test/failure/bad-hcom-empty.prl
+++ b/test/failure/bad-hcom-empty.prl
@@ -1,5 +1,5 @@
-Thm MalformedTube : [
+theorem MalformedTube :
   wbool true
-] by [
+by
   `(hcom 0~>1 wbool tt)
-].
+.

--- a/test/failure/bad-hcom-empty.prl
+++ b/test/failure/bad-hcom-empty.prl
@@ -1,5 +1,5 @@
-theorem MalformedTube :
+theorem MalformedTube : 
   wbool true
-by
+by {
   `(hcom 0~>1 wbool tt)
-.
+}.

--- a/test/failure/bad-hcom-stuck.prl
+++ b/test/failure/bad-hcom-stuck.prl
@@ -1,4 +1,4 @@
-theorem Bool : 
+theorem Bool :
   wbool true
 by {
   `(hcom 0~>1 wbool tt [0=1 [_] tt]);

--- a/test/failure/bad-hcom-stuck.prl
+++ b/test/failure/bad-hcom-stuck.prl
@@ -1,6 +1,6 @@
-theorem Bool :
+theorem Bool : 
   wbool true
-by
+by {
   `(hcom 0~>1 wbool tt [0=1 [_] tt]);
   auto
-.
+}.

--- a/test/failure/bad-hcom-stuck.prl
+++ b/test/failure/bad-hcom-stuck.prl
@@ -1,6 +1,6 @@
-Thm Bool : [
+theorem Bool :
   wbool true
-] by [
+by
   `(hcom 0~>1 wbool tt [0=1 [_] tt]);
   auto
-].
+.

--- a/test/failure/bad-op.prl
+++ b/test/failure/bad-op.prl
@@ -1,5 +1,5 @@
-Def Foo(#a : exp, #b : exp) : exp = [ (-> #a #b) ].
+define Foo(#a : exp, #b : exp) : exp =  (-> #a #b) .
 
-Thm Foo-bool-type : [(Foo bool) type] by [
+theorem Foo-bool-type : (Foo bool) type by
   auto
-].
+.

--- a/test/failure/bad-op.prl
+++ b/test/failure/bad-op.prl
@@ -1,5 +1,5 @@
 define Foo(#a : exp, #b : exp) : exp =  (-> #a #b) .
 
-theorem Foo-bool-type : (Foo bool) type by
+theorem Foo-bool-type : (Foo bool) typeby {
   auto
-.
+}.

--- a/test/failure/freemeta.prl
+++ b/test/failure/freemeta.prl
@@ -1,3 +1,3 @@
-define Cmp(#f : exp, #g : exp) : exp = 
+define Cmp(#f : exp, #g : exp) : exp =
   (lam [x] ($ #f ($ #h x)))
 .

--- a/test/failure/freemeta.prl
+++ b/test/failure/freemeta.prl
@@ -1,3 +1,3 @@
-Def Cmp(#f : exp, #g : exp) : exp = [
+define Cmp(#f : exp, #g : exp) : exp = 
   (lam [x] ($ #f ($ #h x)))
-].
+.

--- a/test/failure/freevar.prl
+++ b/test/failure/freevar.prl
@@ -1,3 +1,3 @@
-Thm FreeVar : [ x true ] by [
+theorem FreeVar : x true  by
   auto
-].
+.

--- a/test/failure/freevar.prl
+++ b/test/failure/freevar.prl
@@ -1,3 +1,3 @@
-theorem FreeVar : x true  by
+theorem FreeVar :  x true by {
   auto
-.
+}.

--- a/test/failure/incremental-parse.prl
+++ b/test/failure/incremental-parse.prl
@@ -3,16 +3,16 @@
 // last ones are just fine, and should be processed by RedPRL despite
 // the error in the middle.
 
-theorem Foo : tt = tt in bool  by
-  auto
-.
-
-theorem Bar : tt = tt in bool ] by {
+theorem Foo :  tt = tt in bool by {
   auto
 }.
 
-theorem Baz : tt = tt in bool  by
+theorem Bar :  tt = tt in bool ] by {
   auto
-.
+}.
+
+Thm Baz : [ tt = tt in bool by {
+  auto
+}.
 
 print Foo.

--- a/test/failure/incremental-parse.prl
+++ b/test/failure/incremental-parse.prl
@@ -3,16 +3,16 @@
 // last ones are just fine, and should be processed by RedPRL despite
 // the error in the middle.
 
-Thm Foo : [ tt = tt in bool ] by [
+theorem Foo : tt = tt in bool  by
   auto
-].
+.
 
-Thm Bar : [ tt = tt in bool ] by {
+theorem Bar : tt = tt in bool ] by {
   auto
 }.
 
-Thm Baz : [ tt = tt in bool ] by [
+theorem Baz : tt = tt in bool  by
   auto
-].
+.
 
-Print Foo.
+print Foo.

--- a/test/failure/kind-hcom.prl
+++ b/test/failure/kind-hcom.prl
@@ -1,4 +1,4 @@
-theorem Path/Symm(#l:lvl) : 
+theorem Path/Symm(#l:lvl) :
   ty : (U #l)
   >>
   ty type with hcom

--- a/test/failure/kind-hcom.prl
+++ b/test/failure/kind-hcom.prl
@@ -1,7 +1,7 @@
-theorem Path/Symm(#l:lvl) :
+theorem Path/Symm(#l:lvl) : 
   ty : (U #l)
   >>
   ty type with hcom
-by
+by {
   auto
-.
+}.

--- a/test/failure/kind-hcom.prl
+++ b/test/failure/kind-hcom.prl
@@ -1,7 +1,7 @@
-Thm Path/Symm(#l:lvl) : [
+theorem Path/Symm(#l:lvl) :
   ty : (U #l)
   >>
   ty type with hcom
-] by [
+by
   auto
-].
+.

--- a/test/failure/lexical-error.prl
+++ b/test/failure/lexical-error.prl
@@ -1,3 +1,3 @@
-Thm LexicalError : [ (-> bool bool) true ] by [
+theorem LexicalError : (-> bool bool) true  by
   (lam x => `_tt); auto
-].
+.

--- a/test/failure/lexical-error.prl
+++ b/test/failure/lexical-error.prl
@@ -1,3 +1,3 @@
-theorem LexicalError : (-> bool bool) true  by
+theorem LexicalError :  (-> bool bool) true by {
   (lam x => `_tt); auto
-.
+}.

--- a/test/failure/num.prl
+++ b/test/failure/num.prl
@@ -1,5 +1,5 @@
-theorem NegOne :
+theorem NegOne : 
   -1 in nat
-by
+by {
   auto
-.
+}.

--- a/test/failure/num.prl
+++ b/test/failure/num.prl
@@ -1,4 +1,4 @@
-theorem NegOne : 
+theorem NegOne :
   -1 in nat
 by {
   auto

--- a/test/failure/num.prl
+++ b/test/failure/num.prl
@@ -1,5 +1,5 @@
-Thm NegOne : [
+theorem NegOne :
   -1 in nat
-] by [
+by
   auto
-].
+.

--- a/test/failure/record0.prl
+++ b/test/failure/record0.prl
@@ -1,4 +1,4 @@
-theorem RecordTest : 
+theorem RecordTest :
   tuple in (record [a : bool])
 by {
   auto

--- a/test/failure/record0.prl
+++ b/test/failure/record0.prl
@@ -1,5 +1,5 @@
-Thm RecordTest : [
+theorem RecordTest :
   tuple in (record [a : bool])
-] by [
+by
   auto
-].
+.

--- a/test/failure/record0.prl
+++ b/test/failure/record0.prl
@@ -1,5 +1,5 @@
-theorem RecordTest :
+theorem RecordTest : 
   tuple in (record [a : bool])
-by
+by {
   auto
-.
+}.

--- a/test/failure/record1.prl
+++ b/test/failure/record1.prl
@@ -1,5 +1,5 @@
-theorem RecordTest :
+theorem RecordTest : 
   (! a tuple) in bool
-by
+by {
   auto
-.
+}.

--- a/test/failure/record1.prl
+++ b/test/failure/record1.prl
@@ -1,4 +1,4 @@
-theorem RecordTest : 
+theorem RecordTest :
   (! a tuple) in bool
 by {
   auto

--- a/test/failure/record1.prl
+++ b/test/failure/record1.prl
@@ -1,5 +1,5 @@
-Thm RecordTest : [
+theorem RecordTest :
   (! a tuple) in bool
-] by [
+by
   auto
-].
+.

--- a/test/failure/record2.prl
+++ b/test/failure/record2.prl
@@ -1,4 +1,4 @@
-theorem RecordTest : 
+theorem RecordTest :
   (! a (tuple [b tt])) in bool
 by {
   auto

--- a/test/failure/record2.prl
+++ b/test/failure/record2.prl
@@ -1,5 +1,5 @@
-theorem RecordTest :
+theorem RecordTest : 
   (! a (tuple [b tt])) in bool
-by
+by {
   auto
-.
+}.

--- a/test/failure/record2.prl
+++ b/test/failure/record2.prl
@@ -1,5 +1,5 @@
-Thm RecordTest : [
+theorem RecordTest :
   (! a (tuple [b tt])) in bool
-] by [
+by
   auto
-].
+.

--- a/test/failure/record3.prl
+++ b/test/failure/record3.prl
@@ -1,4 +1,4 @@
-theorem DuplicateLabel : 
+theorem DuplicateLabel :
   (tuple [a tt]) in (record [a a : bool])
 by {
   auto

--- a/test/failure/record3.prl
+++ b/test/failure/record3.prl
@@ -1,5 +1,5 @@
-Thm DuplicateLabel : [
+theorem DuplicateLabel :
   (tuple [a tt]) in (record [a a : bool])
-] by [
+by
   auto
-].
+.

--- a/test/failure/record3.prl
+++ b/test/failure/record3.prl
@@ -1,5 +1,5 @@
-theorem DuplicateLabel :
+theorem DuplicateLabel : 
   (tuple [a tt]) in (record [a a : bool])
-by
+by {
   auto
-.
+}.

--- a/test/failure/record4.prl
+++ b/test/failure/record4.prl
@@ -1,4 +1,4 @@
-theorem DuplicateLabel : 
+theorem DuplicateLabel :
   (tuple [a tt] [a tt]) in (record [a : bool])
 by {
   auto

--- a/test/failure/record4.prl
+++ b/test/failure/record4.prl
@@ -1,5 +1,5 @@
-Thm DuplicateLabel : [
+theorem DuplicateLabel :
   (tuple [a tt] [a tt]) in (record [a : bool])
-] by [
+by
   auto
-].
+.

--- a/test/failure/record4.prl
+++ b/test/failure/record4.prl
@@ -1,5 +1,5 @@
-theorem DuplicateLabel :
+theorem DuplicateLabel : 
   (tuple [a tt] [a tt]) in (record [a : bool])
-by
+by {
   auto
-.
+}.

--- a/test/failure/undef-custom.prl
+++ b/test/failure/undef-custom.prl
@@ -1,4 +1,4 @@
-define Not : exp = 
+define Not : exp =
   (lam [x] (if x ff tt))
 .
 

--- a/test/failure/undef-custom.prl
+++ b/test/failure/undef-custom.prl
@@ -7,6 +7,6 @@ print Not.
 // [Not] should still be printed, even though the
 // following theorem is malformed.
 
-theorem Foo : Bar = Bar in bool  by
+theorem Foo :  Bar = Bar in bool by {
   auto
-.
+}.

--- a/test/failure/undef-custom.prl
+++ b/test/failure/undef-custom.prl
@@ -1,12 +1,12 @@
-Def Not : exp = [
+define Not : exp = 
   (lam [x] (if x ff tt))
-].
+.
 
-Print Not.
+print Not.
 
 // [Not] should still be printed, even though the
 // following theorem is malformed.
 
-Thm Foo : [ Bar = Bar in bool ] by [
+theorem Foo : Bar = Bar in bool  by
   auto
-].
+.

--- a/test/success/S1-fcom.prl
+++ b/test/success/S1-fcom.prl
@@ -1,45 +1,45 @@
-theorem Fcom/trans3 :
+theorem Fcom/trans3 : 
   (-> [a b c d : S1]
    (path [_] S1 a b)
    (path [_] S1 a c)
    (path [_] S1 b d)
    (path [_] S1 c d))
-by
+by {
   lam a b c d pab pac pbd =>
     abs i => `(fcom 0~>1 (@ pab i) [i=0 [j] (@ pac j)] [i=1 [j] (@ pbd j)])
-.
+}.
 
 print Fcom/trans3.
 
-theorem Fcom/trans2 :
+theorem Fcom/trans2 : 
   (-> [a b c : S1]
    (path [_] S1 a b)
    (path [_] S1 b c)
    (path [_] S1 a c))
-by
+by {
   lam a b c pab pbc =>
     abs i => `(fcom 0~>1 (@ pab i) [i=0 [_] a] [i=1 [j] (@ pbc j)])
-.
+}.
 
-theorem Fcom/symm :
+theorem Fcom/symm : 
   (-> [a b : S1]
    (path [_] S1 a b)
    (path [_] S1 b a))
-by
+by {
   lam a b pab =>
     abs i => `(fcom 0~>1 a [i=0 [j] (@ pab j)] [i=1 [_] a])
-.
+}.
 
-theorem Tube :
+theorem Tube : 
   (->
    [x : S1]
    (= S1 (fcom 0~>1 x [1=1 [_] x] [0=0 [_] x]) x))
-by
+by {
   lam x => auto
-.
+}.
 
-theorem TrueByEvaluation :
+theorem TrueByEvaluation : 
   (fcom 0~>0 base) in S1
-by
+by {
   auto
-.
+}.

--- a/test/success/S1-fcom.prl
+++ b/test/success/S1-fcom.prl
@@ -1,4 +1,4 @@
-theorem Fcom/trans3 : 
+theorem Fcom/trans3 :
   (-> [a b c d : S1]
    (path [_] S1 a b)
    (path [_] S1 a c)
@@ -11,7 +11,7 @@ by {
 
 print Fcom/trans3.
 
-theorem Fcom/trans2 : 
+theorem Fcom/trans2 :
   (-> [a b c : S1]
    (path [_] S1 a b)
    (path [_] S1 b c)
@@ -21,7 +21,7 @@ by {
     abs i => `(fcom 0~>1 (@ pab i) [i=0 [_] a] [i=1 [j] (@ pbc j)])
 }.
 
-theorem Fcom/symm : 
+theorem Fcom/symm :
   (-> [a b : S1]
    (path [_] S1 a b)
    (path [_] S1 b a))
@@ -30,7 +30,7 @@ by {
     abs i => `(fcom 0~>1 a [i=0 [j] (@ pab j)] [i=1 [_] a])
 }.
 
-theorem Tube : 
+theorem Tube :
   (->
    [x : S1]
    (= S1 (fcom 0~>1 x [1=1 [_] x] [0=0 [_] x]) x))
@@ -38,7 +38,7 @@ by {
   lam x => auto
 }.
 
-theorem TrueByEvaluation : 
+theorem TrueByEvaluation :
   (fcom 0~>0 base) in S1
 by {
   auto

--- a/test/success/S1-fcom.prl
+++ b/test/success/S1-fcom.prl
@@ -1,45 +1,45 @@
-Thm Fcom/trans3 : [
+theorem Fcom/trans3 :
   (-> [a b c d : S1]
    (path [_] S1 a b)
    (path [_] S1 a c)
    (path [_] S1 b d)
    (path [_] S1 c d))
-] by [
+by
   lam a b c d pab pac pbd =>
     abs i => `(fcom 0~>1 (@ pab i) [i=0 [j] (@ pac j)] [i=1 [j] (@ pbd j)])
-].
+.
 
-Print Fcom/trans3.
+print Fcom/trans3.
 
-Thm Fcom/trans2 : [
+theorem Fcom/trans2 :
   (-> [a b c : S1]
    (path [_] S1 a b)
    (path [_] S1 b c)
    (path [_] S1 a c))
-] by [
+by
   lam a b c pab pbc =>
     abs i => `(fcom 0~>1 (@ pab i) [i=0 [_] a] [i=1 [j] (@ pbc j)])
-].
+.
 
-Thm Fcom/symm : [
+theorem Fcom/symm :
   (-> [a b : S1]
    (path [_] S1 a b)
    (path [_] S1 b a))
-] by [
+by
   lam a b pab =>
     abs i => `(fcom 0~>1 a [i=0 [j] (@ pab j)] [i=1 [_] a])
-].
+.
 
-Thm Tube : [
+theorem Tube :
   (->
    [x : S1]
    (= S1 (fcom 0~>1 x [1=1 [_] x] [0=0 [_] x]) x))
-] by [
+by
   lam x => auto
-].
+.
 
-Thm TrueByEvaluation : [
+theorem TrueByEvaluation :
   (fcom 0~>0 base) in S1
-] by [
+by
   auto
-].
+.

--- a/test/success/S1.prl
+++ b/test/success/S1.prl
@@ -1,25 +1,25 @@
-Thm Loop : [
+theorem Loop :
   (path [_] S1 base base)
-] by [
+by
   abs u => `(loop u)
-].
+.
 
-Thm LoopBetaEasiest(#i:lvl) : [
+theorem LoopBetaEasiest(#i:lvl) :
   (-> [u : dim] [a : (U #i)] [x : a]
       (= a (S1-rec [_] a (loop u) x [_] x) x))
-] by [
+by
   abs u => lam a x =>
     refine s1/beta/loop;
     auto
-].
+.
 
-Thm LoopBetaEasier(#i:lvl) : [
+theorem LoopBetaEasier(#i:lvl) :
   (-> [u : dim] [a : (-> S1 (U #i))]
       [b : ($ a base)] [l : (path [v] ($ a (loop v)) b b)]
       (= ($ a (loop u)) (S1-rec [x] a (loop u) b [v] (@ l v)) (@ l u)))
-] by [
+by
   abs u => lam a b l =>
     refine s1/beta/loop;
     auto
-].
+.
 

--- a/test/success/S1.prl
+++ b/test/success/S1.prl
@@ -1,25 +1,25 @@
-theorem Loop :
+theorem Loop : 
   (path [_] S1 base base)
-by
+by {
   abs u => `(loop u)
-.
+}.
 
-theorem LoopBetaEasiest(#i:lvl) :
+theorem LoopBetaEasiest(#i:lvl) : 
   (-> [u : dim] [a : (U #i)] [x : a]
       (= a (S1-rec [_] a (loop u) x [_] x) x))
-by
+by {
   abs u => lam a x =>
     refine s1/beta/loop;
     auto
-.
+}.
 
-theorem LoopBetaEasier(#i:lvl) :
+theorem LoopBetaEasier(#i:lvl) : 
   (-> [u : dim] [a : (-> S1 (U #i))]
       [b : ($ a base)] [l : (path [v] ($ a (loop v)) b b)]
       (= ($ a (loop u)) (S1-rec [x] a (loop u) b [v] (@ l v)) (@ l u)))
-by
+by {
   abs u => lam a b l =>
     refine s1/beta/loop;
     auto
-.
+}.
 

--- a/test/success/S1.prl
+++ b/test/success/S1.prl
@@ -1,10 +1,10 @@
-theorem Loop : 
+theorem Loop :
   (path [_] S1 base base)
 by {
   abs u => `(loop u)
 }.
 
-theorem LoopBetaEasiest(#i:lvl) : 
+theorem LoopBetaEasiest(#i:lvl) :
   (-> [u : dim] [a : (U #i)] [x : a]
       (= a (S1-rec [_] a (loop u) x [_] x) x))
 by {
@@ -13,7 +13,7 @@ by {
     auto
 }.
 
-theorem LoopBetaEasier(#i:lvl) : 
+theorem LoopBetaEasier(#i:lvl) :
   (-> [u : dim] [a : (-> S1 (U #i))]
       [b : ($ a base)] [l : (path [v] ($ a (loop v)) b b)]
       (= ($ a (loop u)) (S1-rec [x] a (loop u) b [v] (@ l v)) (@ l u)))

--- a/test/success/V-types.prl
+++ b/test/success/V-types.prl
@@ -95,7 +95,7 @@ tactic Bool/contra/inverse (#p:exp) = {
   query gl <- concl;
   match gl {
     [a b | #jdg{%a = %b in bool} =>
-      claim eq : [(= bool %b %a)] by [use Bool/reflect [`%b, `%a, `#p]; auto];
+      claim eq : (= bool %b %a) by {use Bool/reflect [`%b, `%a, `#p]; auto};
       symmetry; auto
     ]
     [a | %[a:jdg] => id]

--- a/test/success/V-types.prl
+++ b/test/success/V-types.prl
@@ -12,7 +12,7 @@ define Id = (lam [a] a).
 
 theorem IdIsEquiv(#l:lvl) :
   (-> [ty : (U #l hcom)] (IsEquiv ty ty Id))
-by
+by {
   lam ty a =>
   { {use a, abs _ => use a}
   , lam {_,c'} => abs i =>
@@ -25,14 +25,14 @@ by
             [i=1 [j] a])
        }
   }
-.
+}.
 
 theorem IdEquiv(#l:lvl) :
   (-> [ty : (U #l hcom)] (Equiv ty ty))
-by
+by {
   lam ty =>
     {`Id, use (IdIsEquiv #l) [use ty]}
-.
+}.
 
 print IdEquiv.
 
@@ -45,9 +45,9 @@ theorem IdV/Wf(#l:lvl) :
    [i : dim]
    [ty : (U #l hcom)]
    (mem (U #l) (IdV i #l ty)))
-by
+by {
   abs i => lam ty => auto
-.
+}.
 
 theorem IdV/Test0(#l:lvl) :
   (->
@@ -55,18 +55,18 @@ theorem IdV/Test0(#l:lvl) :
    [ty : (U #l hcom)]
    [a : ty]
    (mem (IdV i #l ty) (Vin i a a)))
-by
+by {
   abs i => lam ty a => auto
-.
+}.
 
 theorem IdV/Test1(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a : ty]
    (= ty (Vproj (dim 0) (Vin (dim 0) a a) Id) a))
-by
+by {
   lam ty a => auto
-.
+}.
 
 theorem IdV/Test2(#l:lvl) :
   (->
@@ -74,9 +74,9 @@ theorem IdV/Test2(#l:lvl) :
    [a : ty]
    (= ty (coe 0~>1 [x] (IdV x #l ty) a)
          (coe 0~>1 [_] ty a)))
-by
+by {
   lam ty a => auto
-.
+}.
 
 print IdV/Test2.
 
@@ -87,24 +87,24 @@ theorem Bool/reflect :
   [a b : bool]
   [p : (path [_] bool a b)]
   (= bool a b))
-by
+by {
   lam a b p => `(coe 0~>1 [x] (= bool a (@ p x)) ax)
-.
+}.
 
-tactic Bool/contra/inverse (#p:exp) =
+tactic Bool/contra/inverse (#p:exp) = {
   query gl <- concl;
   match gl {
     [a b | #jdg{%a = %b in bool} =>
-      claim eq : [ (= bool %b %a) ] by [ use Bool/reflect [`%b, `%a, `#p]; auto];
+      claim eq : [(= bool %b %a)] by [use Bool/reflect [`%b, `%a, `#p]; auto];
       symmetry; auto
     ]
     [a | %[a:jdg] => id]
   }
-.
+}.
 
 theorem NotIsEquiv :
   (IsEquiv bool bool Not)
-by
+by {
   lam b =>
   { {`($ Not b), abs _ => use b}
   , lam {_,p'} =>
@@ -119,43 +119,43 @@ by
         }
       ); auto; (Bool/contra/inverse p'); assumption
   }
-.
+}.
 
 theorem NotEquiv :
   (Equiv bool bool)
-by
+by {
   {`Not, `NotIsEquiv}
-.
+}.
 
 define NotV(#i:dim) = (V #i bool bool NotEquiv).
 
 theorem NotV/Wf :
   (-> [i : dim] (mem (U 0 kan) (NotV i)))
-by
+by {
   abs i => auto
-.
+}.
 
 theorem NotV/Test0 :
   (->
    [i : dim]
    [a : bool]
    (mem (NotV i) (Vin i ($ Not a) a)))
-by
+by {
   abs i => lam a => auto
-.
+}.
 
 theorem NotV/Test1 :
   (->
    [a : bool]
    (= bool (coe 0~>1 [x] (NotV x) a) ($ Not a)))
-by
+by {
   lam a => auto
-.
+}.
 
 theorem NotV/Test2 :
   (->
    [a : bool]
    (= bool (coe 1~>0 [x] (NotV x) a) ($ Not a)))
-by
+by {
   lam a => auto
-.
+}.

--- a/test/success/V-types.prl
+++ b/test/success/V-types.prl
@@ -1,18 +1,18 @@
-Def HasAllPathsTo (#C,#c) = [(-> [c' : #C] (path [_] #C c' #c))].
+define HasAllPathsTo (#C,#c) = (-> [c' : #C] (path [_] #C c' #c)).
 
-Def IsContr (#C) = [(* [c : #C] (HasAllPathsTo #C c))].
+define IsContr (#C) = (* [c : #C] (HasAllPathsTo #C c)).
 
-Def Fiber (#A,#B,#f,#b) = [(* [a : #A] (path [_] #B ($ #f a) #b))].
+define Fiber (#A,#B,#f,#b) = (* [a : #A] (path [_] #B ($ #f a) #b)).
 
-Def IsEquiv (#A,#B,#f) = [(-> [b : #B] (IsContr (Fiber #A #B #f b)))].
+define IsEquiv (#A,#B,#f) = (-> [b : #B] (IsContr (Fiber #A #B #f b))).
 
-Def Equiv (#A,#B) = [(* [f : (-> #A #B)] (IsEquiv #A #B f))].
+define Equiv (#A,#B) = (* [f : (-> #A #B)] (IsEquiv #A #B f)).
 
-Def Id = [(lam [a] a)].
+define Id = (lam [a] a).
 
-Thm IdIsEquiv(#l:lvl) : [
+theorem IdIsEquiv(#l:lvl) :
   (-> [ty : (U #l hcom)] (IsEquiv ty ty Id))
-] by [
+by
   lam ty a =>
   { {use a, abs _ => use a}
   , lam {_,c'} => abs i =>
@@ -25,86 +25,86 @@ Thm IdIsEquiv(#l:lvl) : [
             [i=1 [j] a])
        }
   }
-].
+.
 
-Thm IdEquiv(#l:lvl) : [
+theorem IdEquiv(#l:lvl) :
   (-> [ty : (U #l hcom)] (Equiv ty ty))
-] by [
+by
   lam ty =>
     {`Id, use (IdIsEquiv #l) [use ty]}
-].
+.
 
-Print IdEquiv.
+print IdEquiv.
 
-Def IdV(#i:dim, #l:lvl, #ty) = [
+define IdV(#i:dim, #l:lvl, #ty) =
   (V #i #ty #ty ($ (IdEquiv #l) #ty))
-].
+.
 
-Thm IdV/Wf(#l:lvl) : [
+theorem IdV/Wf(#l:lvl) :
   (->
    [i : dim]
    [ty : (U #l hcom)]
    (mem (U #l) (IdV i #l ty)))
-] by [
+by
   abs i => lam ty => auto
-].
+.
 
-Thm IdV/Test0(#l:lvl) : [
+theorem IdV/Test0(#l:lvl) :
   (->
    [i : dim]
    [ty : (U #l hcom)]
    [a : ty]
    (mem (IdV i #l ty) (Vin i a a)))
-] by [
+by
   abs i => lam ty a => auto
-].
+.
 
-Thm IdV/Test1(#l:lvl) : [
+theorem IdV/Test1(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a : ty]
    (= ty (Vproj (dim 0) (Vin (dim 0) a a) Id) a))
-] by [
+by
   lam ty a => auto
-].
+.
 
-Thm IdV/Test2(#l:lvl) : [
+theorem IdV/Test2(#l:lvl) :
   (->
    [ty : (U #l kan)]
    [a : ty]
    (= ty (coe 0~>1 [x] (IdV x #l ty) a)
          (coe 0~>1 [_] ty a)))
-] by [
+by
   lam ty a => auto
-].
+.
 
-Print IdV/Test2.
+print IdV/Test2.
 
-Def Not = [(lam [b] (if [_] bool b ff tt))].
+define Not = (lam [b] (if [_] bool b ff tt)).
 
-Thm Bool/reflect : [
+theorem Bool/reflect :
  (->
   [a b : bool]
   [p : (path [_] bool a b)]
   (= bool a b))
-] by [
+by
   lam a b p => `(coe 0~>1 [x] (= bool a (@ p x)) ax)
-].
+.
 
-Tac Bool/contra/inverse (#p:exp) = [
+tactic Bool/contra/inverse (#p:exp) =
   query gl <- concl;
   match gl {
     [a b | #jdg{%a = %b in bool} =>
-      claim eq : [(= bool %b %a)] by [use Bool/reflect [`%b, `%a, `#p]; auto];
+      claim eq : [ (= bool %b %a) ] by [ use Bool/reflect [`%b, `%a, `#p]; auto];
       symmetry; auto
     ]
     [a | %[a:jdg] => id]
   }
-].
+.
 
-Thm NotIsEquiv : [
+theorem NotIsEquiv :
   (IsEquiv bool bool Not)
-] by [
+by
   lam b =>
   { {`($ Not b), abs _ => use b}
   , lam {_,p'} =>
@@ -119,43 +119,43 @@ Thm NotIsEquiv : [
         }
       ); auto; (Bool/contra/inverse p'); assumption
   }
-].
+.
 
-Thm NotEquiv : [
+theorem NotEquiv :
   (Equiv bool bool)
-] by [
+by
   {`Not, `NotIsEquiv}
-].
+.
 
-Def NotV(#i:dim) = [(V #i bool bool NotEquiv)].
+define NotV(#i:dim) = (V #i bool bool NotEquiv).
 
-Thm NotV/Wf : [
+theorem NotV/Wf :
   (-> [i : dim] (mem (U 0 kan) (NotV i)))
-] by [
+by
   abs i => auto
-].
+.
 
-Thm NotV/Test0 : [
+theorem NotV/Test0 :
   (->
    [i : dim]
    [a : bool]
    (mem (NotV i) (Vin i ($ Not a) a)))
-] by [
+by
   abs i => lam a => auto
-].
+.
 
-Thm NotV/Test1 : [
+theorem NotV/Test1 :
   (->
    [a : bool]
    (= bool (coe 0~>1 [x] (NotV x) a) ($ Not a)))
-] by [
+by
   lam a => auto
-].
+.
 
-Thm NotV/Test2 : [
+theorem NotV/Test2 :
   (->
    [a : bool]
    (= bool (coe 1~>0 [x] (NotV x) a) ($ Not a)))
-] by [
+by
   lam a => auto
-].
+.

--- a/test/success/bool-pair-test.prl
+++ b/test/success/bool-pair-test.prl
@@ -1,5 +1,5 @@
-Thm Test : [ (* bool bool) = (* bool bool) type ] by [
+theorem Test : (* bool bool) = (* bool bool) type  by
   auto
-].
+.
 
-Print Test.
+print Test.

--- a/test/success/bool-pair-test.prl
+++ b/test/success/bool-pair-test.prl
@@ -1,5 +1,5 @@
-theorem Test : (* bool bool) = (* bool bool) type  by
+theorem Test :  (* bool bool) = (* bool bool) type by {
   auto
-.
+}.
 
 print Test.

--- a/test/success/dashes-n-slashes.prl
+++ b/test/success/dashes-n-slashes.prl
@@ -1,4 +1,4 @@
 // Identifiers can contain hyphens and slashes
-Thm Ident-test/ : [ bool ] by [
+theorem Ident-test/ : bool  by
   `tt
-].
+.

--- a/test/success/dashes-n-slashes.prl
+++ b/test/success/dashes-n-slashes.prl
@@ -1,4 +1,4 @@
 // Identifiers can contain hyphens and slashes
-theorem Ident-test/ : bool  by
+theorem Ident-test/ :  bool by {
   `tt
-.
+}.

--- a/test/success/decomposition.prl
+++ b/test/success/decomposition.prl
@@ -1,16 +1,16 @@
-Thm Decomposition : [
+theorem Decomposition :
   (->
    (record [rcd : (record [a : bool] [b : (* bool int)])] [circ : S1])
    bool)
-] by [
+by
   lam x =>
     let {rcd = {a = a, b = {welp}}, circ = circ} = x;
     use welp
-].
+.
 
-Extract Decomposition.
+do let val M = extract Decomposition; print M.
 
-Thm Apply : [
+theorem Apply :
   (-> 
    (->
     bool
@@ -20,29 +20,29 @@ Thm Apply : [
      (tuple [a base])
      (tuple [a base])))
    S1)
-] by [
+by
   lam f =>
     let {a = a} = f [`tt, `ff, `(dim 0)];
     use a
-].
+.
 
 
 
-Extract Apply.
+do let val M = extract Apply; print M.
 
-Thm UseHypTest : [
+theorem UseHypTest :
   (-> bool bool)
-] by [
+by
   lam x =>
   claim p : [(-> bool S1 bool)] by [lam b c => use b];
   use p [use x, `(loop 0)]
-].
+.
 
-Print UseHypTest.
+print UseHypTest.
 
-Thm UseLemmaTest : [
+theorem UseLemmaTest :
   (-> bool bool)
-] by [
+by
   lam x =>
   use UseHypTest [use x]
-].
+.

--- a/test/success/decomposition.prl
+++ b/test/success/decomposition.prl
@@ -1,16 +1,16 @@
-theorem Decomposition :
+theorem Decomposition : 
   (->
    (record [rcd : (record [a : bool] [b : (* bool int)])] [circ : S1])
    bool)
-by
+by {
   lam x =>
     let {rcd = {a = a, b = {welp}}, circ = circ} = x;
     use welp
-.
+}.
 
-do let val M = extract Decomposition; print M.
+print Decomposition.
 
-theorem Apply :
+theorem Apply : 
   (-> 
    (->
     bool
@@ -20,29 +20,29 @@ theorem Apply :
      (tuple [a base])
      (tuple [a base])))
    S1)
-by
+by {
   lam f =>
     let {a = a} = f [`tt, `ff, `(dim 0)];
     use a
-.
+}.
 
 
 
-do let val M = extract Apply; print M.
+print Apply.
 
-theorem UseHypTest :
+theorem UseHypTest : 
   (-> bool bool)
-by
+by {
   lam x =>
   claim p : [(-> bool S1 bool)] by [lam b c => use b];
   use p [use x, `(loop 0)]
-.
+}.
 
 print UseHypTest.
 
-theorem UseLemmaTest :
+theorem UseLemmaTest : 
   (-> bool bool)
-by
+by {
   lam x =>
   use UseHypTest [use x]
-.
+}.

--- a/test/success/decomposition.prl
+++ b/test/success/decomposition.prl
@@ -1,4 +1,4 @@
-theorem Decomposition : 
+theorem Decomposition :
   (->
    (record [rcd : (record [a : bool] [b : (* bool int)])] [circ : S1])
    bool)
@@ -10,8 +10,8 @@ by {
 
 print Decomposition.
 
-theorem Apply : 
-  (-> 
+theorem Apply :
+  (->
    (->
     bool
     bool
@@ -30,7 +30,7 @@ by {
 
 print Apply.
 
-theorem UseHypTest : 
+theorem UseHypTest :
   (-> bool bool)
 by {
   lam x =>
@@ -40,7 +40,7 @@ by {
 
 print UseHypTest.
 
-theorem UseLemmaTest : 
+theorem UseLemmaTest :
   (-> bool bool)
 by {
   lam x =>

--- a/test/success/decomposition.prl
+++ b/test/success/decomposition.prl
@@ -34,7 +34,7 @@ theorem UseHypTest :
   (-> bool bool)
 by {
   lam x =>
-  claim p : [(-> bool S1 bool)] by [lam b c => use b];
+  claim p : (-> bool S1 bool) by {lam b c => use b};
   use p [use x, `(loop 0)]
 }.
 

--- a/test/success/discrete-types.prl
+++ b/test/success/discrete-types.prl
@@ -1,9 +1,9 @@
-Thm Discrete/reflection(#l:lvl) : [
+theorem Discrete/reflection(#l:lvl) :
   (->
    [ty : (U #l discrete)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (= ty a b))
-] by [
+by
   lam ty a b p => `(coe 0~>1 [x] (= ty a (@ p x)) ax)
-].
+.

--- a/test/success/discrete-types.prl
+++ b/test/success/discrete-types.prl
@@ -1,4 +1,4 @@
-theorem Discrete/reflection(#l:lvl) : 
+theorem Discrete/reflection(#l:lvl) :
   (->
    [ty : (U #l discrete)]
    [a b : ty]

--- a/test/success/discrete-types.prl
+++ b/test/success/discrete-types.prl
@@ -1,9 +1,9 @@
-theorem Discrete/reflection(#l:lvl) :
+theorem Discrete/reflection(#l:lvl) : 
   (->
    [ty : (U #l discrete)]
    [a b : ty]
    [p : (path [_] ty a b)]
    (= ty a b))
-by
+by {
   lam ty a b p => `(coe 0~>1 [x] (= ty a (@ p x)) ax)
-.
+}.

--- a/test/success/equality-elim.prl
+++ b/test/success/equality-elim.prl
@@ -1,14 +1,14 @@
-Tac GetHole(#c : [exp].exp, #t : [exp].tac) = [
+tactic GetHole(#c : [exp].exp, #t : [exp].tac) = 
   query gl <- concl;
   match gl {
     [hole | #jdg{(#c %hole)} => (#t %hole)]
   }
-].
+.
 
 // We can write a cool user-defined tactic for claiming and then rewriting along an equality.
 // (Rewrite n a [x] c) matches the goal against the motive "[x] c" and rewrites along
-// the equality [_ = n in a].
-Tac Rewrite(#c : [exp].exp, #n, #a, #t : tac) = [
+// the equality [_ = n in a.
+tactic Rewrite(#c : [exp].exp, #n, #a, #t : tac) = 
   (GetHole [x] (#c x) [hole] #tac{
     claim p : [hole = #n in #a] by [#t];
     // Use the elimination rule for equality. We bind a new hypothesis which will represent the location
@@ -16,17 +16,17 @@ Tac Rewrite(#c : [exp].exp, #n, #a, #t : tac) = [
     rewrite p;
     [with x => `(#c x), id, auto, auto]
   })
-].
+.
 
-Thm EqualityElimTest : [
+theorem EqualityElimTest :
   (-> [b : bool] (path [_] bool tt (if [_] bool tt tt ff)))
-] by [
+by
   // We're going to prove this in a silly way to illustrate equality elimination.
-  // We'll rewrite the goal by claiming [(if tt tt ff) = tt in bool].
+  // We'll rewrite the goal by claiming [(if tt tt ff) = tt in bool.
   (Rewrite 
     [x] (-> bool (path [_] bool tt x))
     tt bool #tac{auto});
   // observe that the goal has now been rewritten!
   ?check-this-out;
   lam b => abs _ => `tt
-].
+.

--- a/test/success/equality-elim.prl
+++ b/test/success/equality-elim.prl
@@ -1,14 +1,14 @@
-tactic GetHole(#c : [exp].exp, #t : [exp].tac) = 
+tactic GetHole(#c : [exp].exp, #t : [exp].tac) = {
   query gl <- concl;
   match gl {
     [hole | #jdg{(#c %hole)} => (#t %hole)]
   }
-.
+}.
 
 // We can write a cool user-defined tactic for claiming and then rewriting along an equality.
 // (Rewrite n a [x] c) matches the goal against the motive "[x] c" and rewrites along
-// the equality [_ = n in a.
-tactic Rewrite(#c : [exp].exp, #n, #a, #t : tac) = 
+// the equality [_ = n in a].
+tactic Rewrite(#c : [exp].exp, #n, #a, #t : tac) = {
   (GetHole [x] (#c x) [hole] #tac{
     claim p : [hole = #n in #a] by [#t];
     // Use the elimination rule for equality. We bind a new hypothesis which will represent the location
@@ -16,17 +16,17 @@ tactic Rewrite(#c : [exp].exp, #n, #a, #t : tac) =
     rewrite p;
     [with x => `(#c x), id, auto, auto]
   })
-.
+}.
 
 theorem EqualityElimTest :
   (-> [b : bool] (path [_] bool tt (if [_] bool tt tt ff)))
-by
+by {
   // We're going to prove this in a silly way to illustrate equality elimination.
-  // We'll rewrite the goal by claiming [(if tt tt ff) = tt in bool.
-  (Rewrite 
+  // We'll rewrite the goal by claiming [(if tt tt ff) = tt in bool}.
+  (Rewrite
     [x] (-> bool (path [_] bool tt x))
     tt bool #tac{auto});
   // observe that the goal has now been rewritten!
   ?check-this-out;
   lam b => abs _ => `tt
-.
+}.

--- a/test/success/equality-elim.prl
+++ b/test/success/equality-elim.prl
@@ -10,7 +10,7 @@ tactic GetHole(#c : [exp].exp, #t : [exp].tac) = {
 // the equality [_ = n in a].
 tactic Rewrite(#c : [exp].exp, #n, #a, #t : tac) = {
   (GetHole [x] (#c x) [hole] #tac{
-    claim p : [hole = #n in #a] by [#t];
+    claim p : hole = #n in #a by {#t};
     // Use the elimination rule for equality. We bind a new hypothesis which will represent the location
     // in the goal #c which is being rewritten.
     rewrite p;
@@ -22,7 +22,7 @@ theorem EqualityElimTest :
   (-> [b : bool] (path [_] bool tt (if [_] bool tt tt ff)))
 by {
   // We're going to prove this in a silly way to illustrate equality elimination.
-  // We'll rewrite the goal by claiming [(if tt tt ff) = tt in bool}.
+  // We'll rewrite the goal by claiming (if tt tt ff) = tt in bool.
   (Rewrite
     [x] (-> bool (path [_] bool tt x))
     tt bool #tac{auto});

--- a/test/success/equality.prl
+++ b/test/success/equality.prl
@@ -1,17 +1,17 @@
-theorem EqualityKind0(#A) :
+theorem EqualityKind0(#A) : 
   (->
    [ty : (U 0 pre)]
    [a b : ty]
    (= (U 0 hcom) (= ty a b) (= ty a b)))
-by 
+by { 
   lam ty a b => auto
-.
+}.
 
-theorem EqualityKind1(#A) :
+theorem EqualityKind1(#A) : 
   (->
    [ty : (U 0 discrete)]
    [a b : ty]
    (= (U 0 kan) (= ty a b) (= ty a b)))
-by 
+by { 
   lam ty a b => auto
-.
+}.

--- a/test/success/equality.prl
+++ b/test/success/equality.prl
@@ -1,17 +1,17 @@
-theorem EqualityKind0(#A) : 
+theorem EqualityKind0(#A) :
   (->
    [ty : (U 0 pre)]
    [a b : ty]
    (= (U 0 hcom) (= ty a b) (= ty a b)))
-by { 
+by {
   lam ty a b => auto
 }.
 
-theorem EqualityKind1(#A) : 
+theorem EqualityKind1(#A) :
   (->
    [ty : (U 0 discrete)]
    [a b : ty]
    (= (U 0 kan) (= ty a b) (= ty a b)))
-by { 
+by {
   lam ty a b => auto
 }.

--- a/test/success/equality.prl
+++ b/test/success/equality.prl
@@ -1,17 +1,17 @@
-Thm EqualityKind0(#A) : [
+theorem EqualityKind0(#A) :
   (->
    [ty : (U 0 pre)]
    [a b : ty]
    (= (U 0 hcom) (= ty a b) (= ty a b)))
-] by [ 
+by 
   lam ty a b => auto
-].
+.
 
-Thm EqualityKind1(#A) : [
+theorem EqualityKind1(#A) :
   (->
    [ty : (U 0 discrete)]
    [a b : ty]
    (= (U 0 kan) (= ty a b) (= ty a b)))
-] by [ 
+by 
   lam ty a b => auto
-].
+.

--- a/test/success/fcom-types.prl
+++ b/test/success/fcom-types.prl
@@ -1,34 +1,34 @@
-Thm Fcom/bool(#i:dim) : [
+theorem Fcom/bool(#i:dim) :
   (fcom 0~>1 bool [#i=0 [j] bool] [#i=1 [j] bool]) type
-] by [
+by
   auto
-].
+.
 
-Print Fcom/bool.
+print Fcom/bool.
 
-Thm Fcom/Box(#i:dim) : [
+theorem Fcom/Box(#i:dim) :
   (box 0~>1 tt [#i=0 tt] [#i=1 tt]) in
   (fcom 0~>1 bool [#i=0 [j] bool] [#i=1 [j] bool])
-] by [
+by
   auto
-].
+.
 
-Print Fcom/Box.
+print Fcom/Box.
 
-Thm Fcom/Reduce : [
+theorem Fcom/Reduce :
   (fcom 0~>1 bool [0=0 [j] bool]) = bool type
-] by [
+by
   auto
-].
+.
 
-Thm Fcom/Cap1 : [
+theorem Fcom/Cap1 :
   tt in (fcom 0~>1 bool [0=0 [j] bool])
-] by [
+by
   auto
-].
+.
 
-Thm Fcom/Cap2 : [
+theorem Fcom/Cap2 :
   (cap 0<~1 (box 0~>1 tt [0=0 tt]) [0=0 [j] bool]) in bool
-] by [
+by
   auto
-].
+.

--- a/test/success/fcom-types.prl
+++ b/test/success/fcom-types.prl
@@ -1,34 +1,34 @@
-theorem Fcom/bool(#i:dim) :
+theorem Fcom/bool(#i:dim) : 
   (fcom 0~>1 bool [#i=0 [j] bool] [#i=1 [j] bool]) type
-by
+by {
   auto
-.
+}.
 
 print Fcom/bool.
 
-theorem Fcom/Box(#i:dim) :
+theorem Fcom/Box(#i:dim) : 
   (box 0~>1 tt [#i=0 tt] [#i=1 tt]) in
   (fcom 0~>1 bool [#i=0 [j] bool] [#i=1 [j] bool])
-by
+by {
   auto
-.
+}.
 
 print Fcom/Box.
 
-theorem Fcom/Reduce :
+theorem Fcom/Reduce : 
   (fcom 0~>1 bool [0=0 [j] bool]) = bool type
-by
+by {
   auto
-.
+}.
 
-theorem Fcom/Cap1 :
+theorem Fcom/Cap1 : 
   tt in (fcom 0~>1 bool [0=0 [j] bool])
-by
+by {
   auto
-.
+}.
 
-theorem Fcom/Cap2 :
+theorem Fcom/Cap2 : 
   (cap 0<~1 (box 0~>1 tt [0=0 tt]) [0=0 [j] bool]) in bool
-by
+by {
   auto
-.
+}.

--- a/test/success/fcom-types.prl
+++ b/test/success/fcom-types.prl
@@ -1,4 +1,4 @@
-theorem Fcom/bool(#i:dim) : 
+theorem Fcom/bool(#i:dim) :
   (fcom 0~>1 bool [#i=0 [j] bool] [#i=1 [j] bool]) type
 by {
   auto
@@ -6,7 +6,7 @@ by {
 
 print Fcom/bool.
 
-theorem Fcom/Box(#i:dim) : 
+theorem Fcom/Box(#i:dim) :
   (box 0~>1 tt [#i=0 tt] [#i=1 tt]) in
   (fcom 0~>1 bool [#i=0 [j] bool] [#i=1 [j] bool])
 by {
@@ -15,19 +15,19 @@ by {
 
 print Fcom/Box.
 
-theorem Fcom/Reduce : 
+theorem Fcom/Reduce :
   (fcom 0~>1 bool [0=0 [j] bool]) = bool type
 by {
   auto
 }.
 
-theorem Fcom/Cap1 : 
+theorem Fcom/Cap1 :
   tt in (fcom 0~>1 bool [0=0 [j] bool])
 by {
   auto
 }.
 
-theorem Fcom/Cap2 : 
+theorem Fcom/Cap2 :
   (cap 0<~1 (box 0~>1 tt [0=0 tt]) [0=0 [j] bool]) in bool
 by {
   auto

--- a/test/success/hcom.prl
+++ b/test/success/hcom.prl
@@ -1,4 +1,4 @@
-Thm Hcom/Poly(#l:lvl) : [
+theorem Hcom/Poly(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b c d : ty]
@@ -6,76 +6,76 @@ Thm Hcom/Poly(#l:lvl) : [
    (path [_] ty a c)
    (path [_] ty b d)
    (path [_] ty c d))
-] by [
+by
   lam ty a b c d pab pac pbd =>
     abs i =>
       `(hcom 0~>1 ty (@ pab i)
         [i=0 [j] (@ pac j)]
         [i=1 [j] (@ pbd j)])
-].
+.
 
-Extract Hcom/Poly.
+print Hcom/Poly.
 
-Thm Hcom/trans(#l:lvl) : [
+theorem Hcom/trans(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b c : ty]
    (path [_] ty a b)
    (path [_] ty b c)
    (path [_] ty a c))
-] by [
+by
   lam ty a b c pab pbc =>
     abs i =>
       `(hcom 0 ~> 1 ty (@ pab i)
         [i=0 [_] a]
         [i=1 [j] (@ pbc j)])
-].
+.
 
-Extract Hcom/trans.
+print Hcom/trans.
 
-Thm Hcom/symm(#l:lvl) : [
+theorem Hcom/symm(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    (path [_] ty a b)
    (path [_] ty b a))
-] by [
+by
   lam ty a b pab =>
     abs i =>
       `(hcom 0~>1 ty a
         [i=0 [j] (@ pab j)]
         [i=1 [_] a])
-].
+.
 
-Extract Hcom/symm.
+print Hcom/symm.
 
 // An example of using the internalized exact equality type.
-Thm Cap(#i:dim, #l:lvl) : [
+theorem Cap(#i:dim, #l:lvl) :
   (->
    [ty : (U #l hcom)]
    [x : ty]
    (= ty
       (hcom 0~>0 ty x [#i=0 [_] x] [#i=1 [_] x])
       x))
-] by [
+by
   lam ty x => auto
-].
+.
 
 
 
-Thm Tube(#l:lvl) : [
+theorem Tube(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [x : ty]
    (= ty
       (hcom 0~>1 ty x [1=1 [_] x] [0=0 [_] x])
       x))
-] by [
+by
   lam ty x => auto
-].
+.
 
-Thm TrueByEvaluation : [
+theorem TrueByEvaluation :
   (hcom 0~>0 bool tt) in bool
-] by [
+by
   auto
-].
+.

--- a/test/success/hcom.prl
+++ b/test/success/hcom.prl
@@ -1,4 +1,4 @@
-theorem Hcom/Poly(#l:lvl) :
+theorem Hcom/Poly(#l:lvl) : 
   (->
    [ty : (U #l hcom)]
    [a b c d : ty]
@@ -6,76 +6,76 @@ theorem Hcom/Poly(#l:lvl) :
    (path [_] ty a c)
    (path [_] ty b d)
    (path [_] ty c d))
-by
+by {
   lam ty a b c d pab pac pbd =>
     abs i =>
       `(hcom 0~>1 ty (@ pab i)
         [i=0 [j] (@ pac j)]
         [i=1 [j] (@ pbd j)])
-.
+}.
 
 print Hcom/Poly.
 
-theorem Hcom/trans(#l:lvl) :
+theorem Hcom/trans(#l:lvl) : 
   (->
    [ty : (U #l hcom)]
    [a b c : ty]
    (path [_] ty a b)
    (path [_] ty b c)
    (path [_] ty a c))
-by
+by {
   lam ty a b c pab pbc =>
     abs i =>
       `(hcom 0 ~> 1 ty (@ pab i)
         [i=0 [_] a]
         [i=1 [j] (@ pbc j)])
-.
+}.
 
 print Hcom/trans.
 
-theorem Hcom/symm(#l:lvl) :
+theorem Hcom/symm(#l:lvl) : 
   (->
    [ty : (U #l hcom)]
    [a b : ty]
    (path [_] ty a b)
    (path [_] ty b a))
-by
+by {
   lam ty a b pab =>
     abs i =>
       `(hcom 0~>1 ty a
         [i=0 [j] (@ pab j)]
         [i=1 [_] a])
-.
+}.
 
 print Hcom/symm.
 
 // An example of using the internalized exact equality type.
-theorem Cap(#i:dim, #l:lvl) :
+theorem Cap(#i:dim, #l:lvl) : 
   (->
    [ty : (U #l hcom)]
    [x : ty]
    (= ty
       (hcom 0~>0 ty x [#i=0 [_] x] [#i=1 [_] x])
       x))
-by
+by {
   lam ty x => auto
-.
+}.
 
 
 
-theorem Tube(#l:lvl) :
+theorem Tube(#l:lvl) : 
   (->
    [ty : (U #l hcom)]
    [x : ty]
    (= ty
       (hcom 0~>1 ty x [1=1 [_] x] [0=0 [_] x])
       x))
-by
+by {
   lam ty x => auto
-.
+}.
 
-theorem TrueByEvaluation :
+theorem TrueByEvaluation : 
   (hcom 0~>0 bool tt) in bool
-by
+by {
   auto
-.
+}.

--- a/test/success/hcom.prl
+++ b/test/success/hcom.prl
@@ -1,4 +1,4 @@
-theorem Hcom/Poly(#l:lvl) : 
+theorem Hcom/Poly(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b c d : ty]
@@ -16,7 +16,7 @@ by {
 
 print Hcom/Poly.
 
-theorem Hcom/trans(#l:lvl) : 
+theorem Hcom/trans(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b c : ty]
@@ -33,7 +33,7 @@ by {
 
 print Hcom/trans.
 
-theorem Hcom/symm(#l:lvl) : 
+theorem Hcom/symm(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [a b : ty]
@@ -50,7 +50,7 @@ by {
 print Hcom/symm.
 
 // An example of using the internalized exact equality type.
-theorem Cap(#i:dim, #l:lvl) : 
+theorem Cap(#i:dim, #l:lvl) :
   (->
    [ty : (U #l hcom)]
    [x : ty]
@@ -63,7 +63,7 @@ by {
 
 
 
-theorem Tube(#l:lvl) : 
+theorem Tube(#l:lvl) :
   (->
    [ty : (U #l hcom)]
    [x : ty]
@@ -74,7 +74,7 @@ by {
   lam ty x => auto
 }.
 
-theorem TrueByEvaluation : 
+theorem TrueByEvaluation :
   (hcom 0~>0 bool tt) in bool
 by {
   auto

--- a/test/success/lines.prl
+++ b/test/success/lines.prl
@@ -1,48 +1,48 @@
-Thm Line/Test0 : [
+theorem Line/Test0 :
   (->
    [a : (U 0 kan)]
    [l : (-> dim a)]
    (= a (coe 0~>1 [_] a (@ l 0)) (@ (coe 0~>1 [_] (-> dim a) l) 0)))
-] by [
+by
   lam a l => `ax
-].
+.
 
-Thm Line/Test1 : [
+theorem Line/Test1 :
   (->
    [ty : (U 0 kan)]
    [p : (line [_] ty)]
    (path [_] ty (@ p 0) (@ p 1)))
-] by [
+by
   lam ty p => abs x => `(@ p x)
-].
+.
 
 
-Thm Line/Trans : [
+theorem Line/Trans :
   (->
    [ty : (U 0 kan)]
    [p : (line [_] ty)]
    [q : (line [_] ty)]
    [eq : (= ty (@ p 1) (@ q 0))]
    (path [_] ty (@ p 0) (@ q 1)))
-] by [
+by
   (lam ty p q eq => abs x =>
   `(hcom 0~>1 ty (@ p x)
     [x=0 [_] (@ p 0)]
     [x=1 [y] (@ q y)])); 
   
   repeat {assumption || auto-step}
-].
+.
 
-Thm Line/Symm : [
+theorem Line/Symm :
   (->
    [ty : (U 0 kan)]
    [p : (line [_] ty)]
    (path [_] ty (@ p 1) (@ p 0)))
-] by [
+by
   lam ty p => abs x =>
   `(hcom 0~>1 ty (@ p 0)
     [x=0 [y] (@ p y)]
     [x=1 [_] (@ p 0)])
-].
+.
 
-Print Line/Trans.
+print Line/Trans.

--- a/test/success/lines.prl
+++ b/test/success/lines.prl
@@ -1,4 +1,4 @@
-theorem Line/Test0 : 
+theorem Line/Test0 :
   (->
    [a : (U 0 kan)]
    [l : (-> dim a)]
@@ -7,7 +7,7 @@ by {
   lam a l => `ax
 }.
 
-theorem Line/Test1 : 
+theorem Line/Test1 :
   (->
    [ty : (U 0 kan)]
    [p : (line [_] ty)]
@@ -17,7 +17,7 @@ by {
 }.
 
 
-theorem Line/Trans : 
+theorem Line/Trans :
   (->
    [ty : (U 0 kan)]
    [p : (line [_] ty)]
@@ -28,12 +28,12 @@ by {
   (lam ty p q eq => abs x =>
   `(hcom 0~>1 ty (@ p x)
     [x=0 [_] (@ p 0)]
-    [x=1 [y] (@ q y)])); 
-  
+    [x=1 [y] (@ q y)]));
+
   repeat {assumption || auto-step}
 }.
 
-theorem Line/Symm : 
+theorem Line/Symm :
   (->
    [ty : (U 0 kan)]
    [p : (line [_] ty)]

--- a/test/success/lines.prl
+++ b/test/success/lines.prl
@@ -1,48 +1,48 @@
-theorem Line/Test0 :
+theorem Line/Test0 : 
   (->
    [a : (U 0 kan)]
    [l : (-> dim a)]
    (= a (coe 0~>1 [_] a (@ l 0)) (@ (coe 0~>1 [_] (-> dim a) l) 0)))
-by
+by {
   lam a l => `ax
-.
+}.
 
-theorem Line/Test1 :
+theorem Line/Test1 : 
   (->
    [ty : (U 0 kan)]
    [p : (line [_] ty)]
    (path [_] ty (@ p 0) (@ p 1)))
-by
+by {
   lam ty p => abs x => `(@ p x)
-.
+}.
 
 
-theorem Line/Trans :
+theorem Line/Trans : 
   (->
    [ty : (U 0 kan)]
    [p : (line [_] ty)]
    [q : (line [_] ty)]
    [eq : (= ty (@ p 1) (@ q 0))]
    (path [_] ty (@ p 0) (@ q 1)))
-by
+by {
   (lam ty p q eq => abs x =>
   `(hcom 0~>1 ty (@ p x)
     [x=0 [_] (@ p 0)]
     [x=1 [y] (@ q y)])); 
   
   repeat {assumption || auto-step}
-.
+}.
 
-theorem Line/Symm :
+theorem Line/Symm : 
   (->
    [ty : (U 0 kan)]
    [p : (line [_] ty)]
    (path [_] ty (@ p 1) (@ p 0)))
-by
+by {
   lam ty p => abs x =>
   `(hcom 0~>1 ty (@ p 0)
     [x=0 [y] (@ p y)]
     [x=1 [_] (@ p 0)])
-.
+}.
 
 print Line/Trans.

--- a/test/success/logical-investigations.prl
+++ b/test/success/logical-investigations.prl
@@ -1,14 +1,14 @@
 // Some theorems from http://www.nuprl.org/MathLibrary/LogicalInvestigations/.
 
-theorem Thm1 : 
-  (-> 
+theorem Thm1 :
+  (->
    [p q : (U 0)]
    p q p)
 by {
   lam p q a b => use a
 }.
 
-theorem Thm2 : 
+theorem Thm2 :
   (->
    [p q r : (U 0)]
    (-> p q)
@@ -23,16 +23,16 @@ by {
 print Thm2.
 
 // here's a proof using lower-level scripting
-theorem Thm3/low-level : 
+theorem Thm3/low-level :
   (->
    [p q r : (U 0)]
    (-> p q)
    (-> q r)
    (-> p r))
 by {
-  // fresh p q r pq qr x -> 
+  // fresh p q r pq qr x ->
   repeat {refine fun/intro || id};
-  auto; with x qr pq r q p => 
+  auto; with x qr pq r q p =>
   elim qr; elim pq;
   [ use x
   , with _ y => use y
@@ -43,10 +43,10 @@ by {
 
 print Thm3/low-level.
 
-// here's a high-level version of the above proof. proofs using the high-level 
-// programming calculus may be longer, but they are often easier to engineer, 
+// here's a high-level version of the above proof. proofs using the high-level
+// programming calculus may be longer, but they are often easier to engineer,
 // and nicely segregate main goals from auxiliary goals.
-theorem Thm3/high-level : 
+theorem Thm3/high-level :
   (->
    [p q r : (U 0)]
    (-> p q)
@@ -61,7 +61,7 @@ print Thm3/high-level.
 
 define Not(#A) =  (-> #A void) .
 
-theorem Thm4 : 
+theorem Thm4 :
   (-> [p q : (U 0)] (Not p) p q)
 by {
   lam p q r a =>
@@ -70,7 +70,7 @@ by {
   elim boom
 }.
 
-theorem Thm5 : 
+theorem Thm5 :
   (-> [p : (U 0)] p (Not (Not p)))
 by {
   lam p a => unfold Not; lam r =>
@@ -81,7 +81,7 @@ print Thm4.
 print Thm5.
 
 
-theorem Thm6(#A,#B) : 
+theorem Thm6(#A,#B) :
   (-> [p q : (U 0)] (-> p q) (Not q) (Not p))
 by {
   lam p q f g => unfold Not; lam a =>

--- a/test/success/logical-investigations.prl
+++ b/test/success/logical-investigations.prl
@@ -1,35 +1,35 @@
 // Some theorems from http://www.nuprl.org/MathLibrary/LogicalInvestigations/.
 
-Thm Thm1 : [
+theorem Thm1 :
   (-> 
    [p q : (U 0)]
    p q p)
-] by [
+by
   lam p q a b => use a
-].
+.
 
-Thm Thm2 : [
+theorem Thm2 :
   (->
    [p q r : (U 0)]
    (-> p q)
    (-> p q r)
    p r)
-] by [
+by
   lam p q r f g a =>
   use g [use a, use f [use a]]
-].
+.
 
 // It is worthwhile to print out the extract program / evidence for Thm2.
-Extract Thm2.
+do let val M = extract Thm2; print M.
 
 // here's a proof using lower-level scripting
-Thm Thm3/low-level : [
+theorem Thm3/low-level :
   (->
    [p q r : (U 0)]
    (-> p q)
    (-> q r)
    (-> p r))
-] by [
+by
   // fresh p q r pq qr x -> 
   repeat {refine fun/intro || id};
   auto; with x qr pq r q p => 
@@ -39,53 +39,53 @@ Thm Thm3/low-level : [
   , use x
   , with _ _ _ z => use z
   ]
-].
+.
 
-Extract Thm3/low-level.
+do let val M = extract Thm3/low-level; print M.
 
 // here's a high-level version of the above proof. proofs using the high-level 
 // programming calculus may be longer, but they are often easier to engineer, 
 // and nicely segregate main goals from auxiliary goals.
-Thm Thm3/high-level : [
+theorem Thm3/high-level :
   (->
    [p q r : (U 0)]
    (-> p q)
    (-> q r)
    (-> p r))
-] by [
+by
   lam p q r f g x =>
   use g [use f [use x]]
-].
+.
 
-Extract Thm3/high-level.
+print Thm3/high-level.
 
-Def Not(#A) = [ (-> #A void) ].
+define Not(#A) =  (-> #A void) .
 
-Thm Thm4 : [
+theorem Thm4 :
   (-> [p q : (U 0)] (Not p) p q)
-] by [
+by
   lam p q r a =>
   unfold Not;
   let boom = r [use a];
   elim boom
-].
+.
 
-Thm Thm5 : [
+theorem Thm5 :
   (-> [p : (U 0)] p (Not (Not p)))
-] by [
+by
   lam p a => unfold Not; lam r =>
   use r [use a]
-].
+.
 
-Print Thm4.
-Print Thm5.
+print Thm4.
+print Thm5.
 
 
-Thm Thm6(#A,#B) : [
+theorem Thm6(#A,#B) :
   (-> [p q : (U 0)] (-> p q) (Not q) (Not p))
-] by [
+by
   lam p q f g => unfold Not; lam a =>
   use g [use f [use a]]
-].
+.
 
-Print Thm6.
+print Thm6.

--- a/test/success/logical-investigations.prl
+++ b/test/success/logical-investigations.prl
@@ -1,35 +1,35 @@
 // Some theorems from http://www.nuprl.org/MathLibrary/LogicalInvestigations/.
 
-theorem Thm1 :
+theorem Thm1 : 
   (-> 
    [p q : (U 0)]
    p q p)
-by
+by {
   lam p q a b => use a
-.
+}.
 
-theorem Thm2 :
+theorem Thm2 : 
   (->
    [p q r : (U 0)]
    (-> p q)
    (-> p q r)
    p r)
-by
+by {
   lam p q r f g a =>
   use g [use a, use f [use a]]
-.
+}.
 
 // It is worthwhile to print out the extract program / evidence for Thm2.
-do let val M = extract Thm2; print M.
+print Thm2.
 
 // here's a proof using lower-level scripting
-theorem Thm3/low-level :
+theorem Thm3/low-level : 
   (->
    [p q r : (U 0)]
    (-> p q)
    (-> q r)
    (-> p r))
-by
+by {
   // fresh p q r pq qr x -> 
   repeat {refine fun/intro || id};
   auto; with x qr pq r q p => 
@@ -39,53 +39,53 @@ by
   , use x
   , with _ _ _ z => use z
   ]
-.
+}.
 
-do let val M = extract Thm3/low-level; print M.
+print Thm3/low-level.
 
 // here's a high-level version of the above proof. proofs using the high-level 
 // programming calculus may be longer, but they are often easier to engineer, 
 // and nicely segregate main goals from auxiliary goals.
-theorem Thm3/high-level :
+theorem Thm3/high-level : 
   (->
    [p q r : (U 0)]
    (-> p q)
    (-> q r)
    (-> p r))
-by
+by {
   lam p q r f g x =>
   use g [use f [use x]]
-.
+}.
 
 print Thm3/high-level.
 
 define Not(#A) =  (-> #A void) .
 
-theorem Thm4 :
+theorem Thm4 : 
   (-> [p q : (U 0)] (Not p) p q)
-by
+by {
   lam p q r a =>
   unfold Not;
   let boom = r [use a];
   elim boom
-.
+}.
 
-theorem Thm5 :
+theorem Thm5 : 
   (-> [p : (U 0)] p (Not (Not p)))
-by
+by {
   lam p a => unfold Not; lam r =>
   use r [use a]
-.
+}.
 
 print Thm4.
 print Thm5.
 
 
-theorem Thm6(#A,#B) :
+theorem Thm6(#A,#B) : 
   (-> [p q : (U 0)] (-> p q) (Not q) (Not p))
-by
+by {
   lam p q f g => unfold Not; lam a =>
   use g [use f [use a]]
-.
+}.
 
 print Thm6.

--- a/test/success/match.prl
+++ b/test/success/match.prl
@@ -1,11 +1,11 @@
-tactic QueryGoalType(#t : [exp].tac) = 
+tactic QueryGoalType(#t : [exp].tac) = {
   query gl <- concl;
   match gl {
     [a | #jdg{%a true} => (#t %a)]
   }
-.
+}.
 
-theorem MatchGoal : (-> bool bool bool bool bool bool)  by
+theorem MatchGoal :  (-> bool bool bool bool bool bool) by {
   repeat {
     (QueryGoalType [ty] #tac{
       match ty {
@@ -15,6 +15,6 @@ theorem MatchGoal : (-> bool bool bool bool bool bool)  by
   };
   
   with _ _ y => use y
-.
+}.
 
 print MatchGoal.

--- a/test/success/match.prl
+++ b/test/success/match.prl
@@ -13,7 +13,7 @@ theorem MatchGoal :  (-> bool bool bool bool bool bool) by {
       }
     })
   };
-  
+
   with _ _ y => use y
 }.
 

--- a/test/success/match.prl
+++ b/test/success/match.prl
@@ -1,11 +1,11 @@
-Tac QueryGoalType(#t : [exp].tac) = [
+tactic QueryGoalType(#t : [exp].tac) = 
   query gl <- concl;
   match gl {
     [a | #jdg{%a true} => (#t %a)]
   }
-].
+.
 
-Thm MatchGoal : [ (-> bool bool bool bool bool bool) ] by [
+theorem MatchGoal : (-> bool bool bool bool bool bool)  by
   repeat {
     (QueryGoalType [ty] #tac{
       match ty {
@@ -15,6 +15,6 @@ Thm MatchGoal : [ (-> bool bool bool bool bool bool) ] by [
   };
   
   with _ _ y => use y
-].
+.
 
-Print MatchGoal.
+print MatchGoal.

--- a/test/success/num.prl
+++ b/test/success/num.prl
@@ -1,28 +1,28 @@
-theorem One : 
+theorem One :
   (int 1) in int
 by {
   auto
 }.
 
-theorem NegOne : 
+theorem NegOne :
   (int -1) in int
 by {
   auto
 }.
 
-theorem NatOne : 
+theorem NatOne :
   (nat 1) in nat
 by {
   auto
 }.
 
-theorem NatIsInt : 
+theorem NatIsInt :
   (-> [x : nat] (mem int (pos x)))
 by {
   lam x => auto
 }.
 
-theorem Pred : 
+theorem Pred :
   (-> nat nat)
 by {
   lam a =>
@@ -31,7 +31,7 @@ by {
   [ with a' ind => `a' ]
 }.
 
-theorem Plus : 
+theorem Plus :
   (-> nat nat nat)
 by {
   lam a =>
@@ -43,38 +43,38 @@ by {
   ]
 }.
 
-theorem Plus/wf : 
+theorem Plus/wf :
   Plus in (-> nat nat nat)
 by {
   auto
 }.
 
-theorem Plus/zeroL : 
+theorem Plus/zeroL :
   (-> [n : nat] (= nat ($ Plus (nat 0) n) n))
 by {
   lam n => auto
 }.
 
-theorem Plus/zero/R : 
+theorem Plus/zero/R :
   (-> [n : nat] (= nat ($ Plus n (nat 0)) n))
 by {
   lam n =>
     elim n;
     [ `ax
-    , with ind n' => 
+    , with ind n' =>
       rewrite ind at left;
       [ with x => `(succ x) ];
       auto
     ]
 }.
 
-theorem Plus/succ/L : 
+theorem Plus/succ/L :
   (-> [n m : nat] (= nat ($ Plus (succ n) m) (succ ($ Plus n m))))
 by {
   lam n m => auto
 }.
 
-theorem Plus/succ/R : 
+theorem Plus/succ/R :
   (-> [n m : nat] (= nat ($ Plus n (succ m)) (succ ($ Plus n m))))
 by {
   lam n m => elim n;
@@ -92,7 +92,7 @@ by {
     auto
 }.
 
-theorem Plus/test0 : 
+theorem Plus/test0 :
   (-> [n m : nat] [eq : (= nat ($ Plus n zero) m)] (= nat n m))
 by {
   lam n m eq =>
@@ -100,13 +100,13 @@ by {
     [ with x => `x ]; auto; use eq
 }.
 
-theorem Eq/sym : 
+theorem Eq/sym :
   (-> [ty : (U 0)] [a b : ty] (= ty a b) (= ty b a))
 by {
   lam ty a b eq => symmetry; use eq
 }.
 
-theorem Plus/comm : 
+theorem Plus/comm :
   (-> [n m : nat] (= nat ($ Plus n m) ($ Plus m n)))
 by {
   lam n m => elim n;
@@ -123,7 +123,7 @@ by {
     auto
 }.
 
-theorem NatSymm : 
+theorem NatSymm :
   (->
    [a b : nat]
    (path [_] nat a b)
@@ -136,7 +136,7 @@ by {
       [i=1 [_] a])
 }.
 
-theorem IntPred : 
+theorem IntPred :
   (-> int int)
 by {
   lam a => elim a;
@@ -148,7 +148,7 @@ by {
   ];
 }.
 
-theorem IntSucc : 
+theorem IntSucc :
   (-> int int)
 by {
   lam a => elim a;
@@ -160,7 +160,7 @@ by {
   ]
 }.
 
-theorem IntPlus : 
+theorem IntPlus :
   (-> int int int)
 by {
   lam a => elim a;
@@ -175,14 +175,14 @@ by {
   ]
 }.
 
-theorem Int4Plus3 : 
+theorem Int4Plus3 :
   ($ IntPlus (int 4) (int 3)) = (int 7) in int
 by { auto }.
 
-theorem Int-6Plus10 : 
+theorem Int-6Plus10 :
   ($ IntPlus (int -6) (int 10)) = (int 4) in int
 by { auto }.
 
-theorem Int-1Plus-9 : 
+theorem Int-1Plus-9 :
   ($ IntPlus (int -1) (int -9)) = (int -10) in int
 by { auto }.

--- a/test/success/num.prl
+++ b/test/success/num.prl
@@ -1,39 +1,39 @@
-theorem One :
+theorem One : 
   (int 1) in int
-by
+by {
   auto
-.
+}.
 
-theorem NegOne :
+theorem NegOne : 
   (int -1) in int
-by
+by {
   auto
-.
+}.
 
-theorem NatOne :
+theorem NatOne : 
   (nat 1) in nat
-by
+by {
   auto
-.
+}.
 
-theorem NatIsInt :
+theorem NatIsInt : 
   (-> [x : nat] (mem int (pos x)))
-by
+by {
   lam x => auto
-.
+}.
 
-theorem Pred :
+theorem Pred : 
   (-> nat nat)
-by
+by {
   lam a =>
   elim a;
   [ `zero ];
   [ with a' ind => `a' ]
-.
+}.
 
-theorem Plus :
+theorem Plus : 
   (-> nat nat nat)
-by
+by {
   lam a =>
   elim a;
   [ lam x => use x
@@ -41,23 +41,23 @@ by
     lam x =>
       let ih/x = ind [use x]; `(succ ih/x)
   ]
-.
+}.
 
-theorem Plus/wf :
+theorem Plus/wf : 
   Plus in (-> nat nat nat)
-by
+by {
   auto
-.
+}.
 
-theorem Plus/zeroL :
+theorem Plus/zeroL : 
   (-> [n : nat] (= nat ($ Plus (nat 0) n) n))
-by
+by {
   lam n => auto
-.
+}.
 
-theorem Plus/zero/R :
+theorem Plus/zero/R : 
   (-> [n : nat] (= nat ($ Plus n (nat 0)) n))
-by
+by {
   lam n =>
     elim n;
     [ `ax
@@ -66,17 +66,17 @@ by
       [ with x => `(succ x) ];
       auto
     ]
-.
+}.
 
-theorem Plus/succ/L :
+theorem Plus/succ/L : 
   (-> [n m : nat] (= nat ($ Plus (succ n) m) (succ ($ Plus n m))))
-by
+by {
   lam n m => auto
-.
+}.
 
-theorem Plus/succ/R :
+theorem Plus/succ/R : 
   (-> [n m : nat] (= nat ($ Plus n (succ m)) (succ ($ Plus n m))))
-by
+by {
   lam n m => elim n;
     [ auto
     , with n'/ih n' => rewrite ($ Plus/succ/L n' (succ m)) at left;
@@ -90,25 +90,25 @@ by
     ];
 
     auto
-.
+}.
 
-theorem Plus/test0 :
+theorem Plus/test0 : 
   (-> [n m : nat] [eq : (= nat ($ Plus n zero) m)] (= nat n m))
-by
+by {
   lam n m eq =>
     rewrite ($ Plus/zero/R n) in eq at left;
     [ with x => `x ]; auto; use eq
-.
+}.
 
-theorem Eq/sym :
+theorem Eq/sym : 
   (-> [ty : (U 0)] [a b : ty] (= ty a b) (= ty b a))
-by
+by {
   lam ty a b eq => symmetry; use eq
-.
+}.
 
-theorem Plus/comm :
+theorem Plus/comm : 
   (-> [n m : nat] (= nat ($ Plus n m) ($ Plus m n)))
-by
+by {
   lam n m => elim n;
     [ symmetry; `($ Plus/zero/R  m)
     , with n'/ih n' => rewrite ($ Plus/succ/L n' m) at left;
@@ -121,24 +121,24 @@ by
     ];
 
     auto
-.
+}.
 
-theorem NatSymm :
+theorem NatSymm : 
   (->
    [a b : nat]
    (path [_] nat a b)
    (path [_] nat b a))
-by
+by {
   lam a b pab =>
   abs i =>
     `(hcom 0~>1 nat a
       [i=0 [j] (@ pab j)]
       [i=1 [_] a])
-.
+}.
 
-theorem IntPred :
+theorem IntPred : 
   (-> int int)
-by
+by {
   lam a => elim a;
   [ with n => elim n;
     [ `(int -1)
@@ -146,11 +146,11 @@ by
     ]
   , with n => `(negsucc (succ n))
   ];
-.
+}.
 
-theorem IntSucc :
+theorem IntSucc : 
   (-> int int)
-by
+by {
   lam a => elim a;
   [ with n => `(pos (succ n))
   , with n => elim n;
@@ -158,11 +158,11 @@ by
     , with _ n' => `(negsucc n')
     ]
   ]
-.
+}.
 
-theorem IntPlus :
+theorem IntPlus : 
   (-> int int int)
-by
+by {
   lam a => elim a;
   [ with n => elim n;
     [ lam b => use b
@@ -173,16 +173,16 @@ by
     , with ind a' => lam b => `($ IntPred ($ ind b))
     ]
   ]
-.
+}.
 
-theorem Int4Plus3 :
+theorem Int4Plus3 : 
   ($ IntPlus (int 4) (int 3)) = (int 7) in int
-by auto .
+by { auto }.
 
-theorem Int-6Plus10 :
+theorem Int-6Plus10 : 
   ($ IntPlus (int -6) (int 10)) = (int 4) in int
-by auto .
+by { auto }.
 
-theorem Int-1Plus-9 :
+theorem Int-1Plus-9 : 
   ($ IntPlus (int -1) (int -9)) = (int -10) in int
-by auto .
+by { auto }.

--- a/test/success/num.prl
+++ b/test/success/num.prl
@@ -1,39 +1,39 @@
-Thm One : [
+theorem One :
   (int 1) in int
-] by [
+by
   auto
-].
+.
 
-Thm NegOne : [
+theorem NegOne :
   (int -1) in int
-] by [
+by
   auto
-].
+.
 
-Thm NatOne : [
+theorem NatOne :
   (nat 1) in nat
-] by [
+by
   auto
-].
+.
 
-Thm NatIsInt : [
+theorem NatIsInt :
   (-> [x : nat] (mem int (pos x)))
-] by [
+by
   lam x => auto
-].
+.
 
-Thm Pred : [
+theorem Pred :
   (-> nat nat)
-] by [
+by
   lam a =>
   elim a;
   [ `zero ];
   [ with a' ind => `a' ]
-].
+.
 
-Thm Plus : [
+theorem Plus :
   (-> nat nat nat)
-] by [
+by
   lam a =>
   elim a;
   [ lam x => use x
@@ -41,23 +41,23 @@ Thm Plus : [
     lam x =>
       let ih/x = ind [use x]; `(succ ih/x)
   ]
-].
+.
 
-Thm Plus/wf : [
+theorem Plus/wf :
   Plus in (-> nat nat nat)
-] by [
+by
   auto
-].
+.
 
-Thm Plus/zeroL : [
+theorem Plus/zeroL :
   (-> [n : nat] (= nat ($ Plus (nat 0) n) n))
-] by [
+by
   lam n => auto
-].
+.
 
-Thm Plus/zero/R : [
+theorem Plus/zero/R :
   (-> [n : nat] (= nat ($ Plus n (nat 0)) n))
-] by [
+by
   lam n =>
     elim n;
     [ `ax
@@ -66,17 +66,17 @@ Thm Plus/zero/R : [
       [ with x => `(succ x) ];
       auto
     ]
-].
+.
 
-Thm Plus/succ/L : [
+theorem Plus/succ/L :
   (-> [n m : nat] (= nat ($ Plus (succ n) m) (succ ($ Plus n m))))
-] by [
+by
   lam n m => auto
-].
+.
 
-Thm Plus/succ/R : [
+theorem Plus/succ/R :
   (-> [n m : nat] (= nat ($ Plus n (succ m)) (succ ($ Plus n m))))
-] by [
+by
   lam n m => elim n;
     [ auto
     , with n'/ih n' => rewrite ($ Plus/succ/L n' (succ m)) at left;
@@ -90,25 +90,25 @@ Thm Plus/succ/R : [
     ];
 
     auto
-].
+.
 
-Thm Plus/test0 : [
+theorem Plus/test0 :
   (-> [n m : nat] [eq : (= nat ($ Plus n zero) m)] (= nat n m))
-] by [
+by
   lam n m eq =>
     rewrite ($ Plus/zero/R n) in eq at left;
     [ with x => `x ]; auto; use eq
-].
+.
 
-Thm Eq/sym : [
+theorem Eq/sym :
   (-> [ty : (U 0)] [a b : ty] (= ty a b) (= ty b a))
-] by [
+by
   lam ty a b eq => symmetry; use eq
-].
+.
 
-Thm Plus/comm : [
+theorem Plus/comm :
   (-> [n m : nat] (= nat ($ Plus n m) ($ Plus m n)))
-] by [
+by
   lam n m => elim n;
     [ symmetry; `($ Plus/zero/R  m)
     , with n'/ih n' => rewrite ($ Plus/succ/L n' m) at left;
@@ -121,24 +121,24 @@ Thm Plus/comm : [
     ];
 
     auto
-].
+.
 
-Thm NatSymm : [
+theorem NatSymm :
   (->
    [a b : nat]
    (path [_] nat a b)
    (path [_] nat b a))
-] by [
+by
   lam a b pab =>
   abs i =>
     `(hcom 0~>1 nat a
       [i=0 [j] (@ pab j)]
       [i=1 [_] a])
-].
+.
 
-Thm IntPred : [
+theorem IntPred :
   (-> int int)
-] by [
+by
   lam a => elim a;
   [ with n => elim n;
     [ `(int -1)
@@ -146,11 +146,11 @@ Thm IntPred : [
     ]
   , with n => `(negsucc (succ n))
   ];
-].
+.
 
-Thm IntSucc : [
+theorem IntSucc :
   (-> int int)
-] by [
+by
   lam a => elim a;
   [ with n => `(pos (succ n))
   , with n => elim n;
@@ -158,11 +158,11 @@ Thm IntSucc : [
     , with _ n' => `(negsucc n')
     ]
   ]
-].
+.
 
-Thm IntPlus : [
+theorem IntPlus :
   (-> int int int)
-] by [
+by
   lam a => elim a;
   [ with n => elim n;
     [ lam b => use b
@@ -173,16 +173,16 @@ Thm IntPlus : [
     , with ind a' => lam b => `($ IntPred ($ ind b))
     ]
   ]
-].
+.
 
-Thm Int4Plus3 : [
+theorem Int4Plus3 :
   ($ IntPlus (int 4) (int 3)) = (int 7) in int
-] by [ auto ].
+by auto .
 
-Thm Int-6Plus10 : [
+theorem Int-6Plus10 :
   ($ IntPlus (int -6) (int 10)) = (int 4) in int
-] by [ auto ].
+by auto .
 
-Thm Int-1Plus-9 : [
+theorem Int-1Plus-9 :
   ($ IntPlus (int -1) (int -9)) = (int -10) in int
-] by [ auto ].
+by auto .

--- a/test/success/path-ap-const.prl
+++ b/test/success/path-ap-const.prl
@@ -1,4 +1,4 @@
-theorem PathApConst : 
+theorem PathApConst :
   (-> (path [_] bool tt tt) bool)
 by {
   lam p => use p [`(dim 0)]

--- a/test/success/path-ap-const.prl
+++ b/test/success/path-ap-const.prl
@@ -1,7 +1,7 @@
-Thm PathApConst : [
+theorem PathApConst :
   (-> (path [_] bool tt tt) bool)
-] by [
+by
   lam p => use p [`(dim 0)]
-].
+.
 
-Print PathApConst.
+print PathApConst.

--- a/test/success/path-ap-const.prl
+++ b/test/success/path-ap-const.prl
@@ -1,7 +1,7 @@
-theorem PathApConst :
+theorem PathApConst : 
   (-> (path [_] bool tt tt) bool)
-by
+by {
   lam p => use p [`(dim 0)]
-.
+}.
 
 print PathApConst.

--- a/test/success/primitive-sequencing.prl
+++ b/test/success/primitive-sequencing.prl
@@ -1,6 +1,6 @@
-Thm PrimitiveSequencingTest : [(-> bool bool bool bool)] by [
+theorem PrimitiveSequencingTest : (-> bool bool bool bool) by
   repeat {refine fun/intro || id}; auto;
   with z y x => use y
-].
+.
 
-Extract PrimitiveSequencingTest.
+print PrimitiveSequencingTest.

--- a/test/success/primitive-sequencing.prl
+++ b/test/success/primitive-sequencing.prl
@@ -1,6 +1,6 @@
-theorem PrimitiveSequencingTest : (-> bool bool bool bool) by
+theorem PrimitiveSequencingTest : (-> bool bool bool bool)by {
   repeat {refine fun/intro || id}; auto;
   with z y x => use y
-.
+}.
 
 print PrimitiveSequencingTest.

--- a/test/success/primitive-sequencing.prl
+++ b/test/success/primitive-sequencing.prl
@@ -1,4 +1,4 @@
-theorem PrimitiveSequencingTest : (-> bool bool bool bool)by {
+theorem PrimitiveSequencingTest : (-> bool bool bool bool) by {
   repeat {refine fun/intro || id}; auto;
   with z y x => use y
 }.

--- a/test/success/pushout.prl
+++ b/test/success/pushout.prl
@@ -1,27 +1,27 @@
-Thm Pushout/Test0 : [
+theorem Pushout/Test0 :
   (pushout record record bool [_] tuple [_] tuple)
-] by [
+by
   `(left tuple)
-].
+.
 
-Thm Pushout/Test1 : [
+theorem Pushout/Test1 :
   (pushout bool bool bool [x] x [x] x)
-] by [
+by
   `(right tt)
-].
+.
 
-Thm Pushout/Test2 : [
+theorem Pushout/Test2 :
   (-> dim (pushout bool bool bool [x] x [x] x))
-] by [
+by
   abs u => `(glue u tt tt tt)
-].
+.
 
-Def S1' = [(pushout record record bool [_] tuple [_] tuple)].
+define S1' = (pushout record record bool [_] tuple [_] tuple).
 
 // Someone told me the following is an equivalence
-Thm PushoutToS1 : [
+theorem PushoutToS1 :
   (-> S1' S1)
-] by [
+by
   lam p => elim p;
     [ `base
     , `base
@@ -32,30 +32,30 @@ Thm PushoutToS1 : [
       ]
     ];
     auto
-].
+.
 
 
-Thm PushoutToS1/Test0 : [
+theorem PushoutToS1/Test0 :
   (= (-> S1' S1) PushoutToS1 PushoutToS1)
-] by [
+by
   unfold PushoutToS1; // otherwise too easy
   refine fun/eq/lam;
   [ refine pushout/eq/pushout-rec; auto
   , auto
   ]
-].
+.
 
-Thm PushoutBetaEasiest(#i:lvl) : [
+theorem PushoutBetaEasiest(#i:lvl) :
   (-> [a b c d : (U #i)] [w : d]
       [u : dim] [x : a] [y : b] [z : c]
       (= d (pushout-rec [_] d (glue u z x y) [_] w [_] w [_ _] w) w))
-] by [
+by
   lam a b c d w => abs u => lam x y z =>
     refine pushout/beta/glue;
     auto
-].
+.
 
-Thm PushoutBetaEasier(#i:lvl) : [
+theorem PushoutBetaEasier(#i:lvl) :
   (-> [a b c : (U #i)] [f : (-> c a)] [g : (-> c b)]
       [d : (-> (pushout a b c [z] ($ f z) [z] ($ g z)) (U #i))]
       [wl : (-> [x : a] ($ d (left x)))] [wr : (-> [y : b] ($ d (right y)))]
@@ -64,8 +64,8 @@ Thm PushoutBetaEasier(#i:lvl) : [
       (= ($ d (glue u m ($ f m) ($ g m)))
       	 (pushout-rec [p] ($ d p) (glue u m ($ f m) ($ g m)) [x] ($ wl x) [y] ($ wr y) [v z] (@ ($ wg z) v))
 	 (@ ($ wg m) u)))
-] by [
+by
   lam a b c f g d wl wr wg => abs u => lam m =>
     refine pushout/beta/glue;
     auto
-].
+.

--- a/test/success/pushout.prl
+++ b/test/success/pushout.prl
@@ -1,27 +1,27 @@
-theorem Pushout/Test0 :
+theorem Pushout/Test0 : 
   (pushout record record bool [_] tuple [_] tuple)
-by
+by {
   `(left tuple)
-.
+}.
 
-theorem Pushout/Test1 :
+theorem Pushout/Test1 : 
   (pushout bool bool bool [x] x [x] x)
-by
+by {
   `(right tt)
-.
+}.
 
-theorem Pushout/Test2 :
+theorem Pushout/Test2 : 
   (-> dim (pushout bool bool bool [x] x [x] x))
-by
+by {
   abs u => `(glue u tt tt tt)
-.
+}.
 
 define S1' = (pushout record record bool [_] tuple [_] tuple).
 
 // Someone told me the following is an equivalence
-theorem PushoutToS1 :
+theorem PushoutToS1 : 
   (-> S1' S1)
-by
+by {
   lam p => elim p;
     [ `base
     , `base
@@ -32,30 +32,30 @@ by
       ]
     ];
     auto
-.
+}.
 
 
-theorem PushoutToS1/Test0 :
+theorem PushoutToS1/Test0 : 
   (= (-> S1' S1) PushoutToS1 PushoutToS1)
-by
+by {
   unfold PushoutToS1; // otherwise too easy
   refine fun/eq/lam;
   [ refine pushout/eq/pushout-rec; auto
   , auto
   ]
-.
+}.
 
-theorem PushoutBetaEasiest(#i:lvl) :
+theorem PushoutBetaEasiest(#i:lvl) : 
   (-> [a b c d : (U #i)] [w : d]
       [u : dim] [x : a] [y : b] [z : c]
       (= d (pushout-rec [_] d (glue u z x y) [_] w [_] w [_ _] w) w))
-by
+by {
   lam a b c d w => abs u => lam x y z =>
     refine pushout/beta/glue;
     auto
-.
+}.
 
-theorem PushoutBetaEasier(#i:lvl) :
+theorem PushoutBetaEasier(#i:lvl) : 
   (-> [a b c : (U #i)] [f : (-> c a)] [g : (-> c b)]
       [d : (-> (pushout a b c [z] ($ f z) [z] ($ g z)) (U #i))]
       [wl : (-> [x : a] ($ d (left x)))] [wr : (-> [y : b] ($ d (right y)))]
@@ -64,8 +64,8 @@ theorem PushoutBetaEasier(#i:lvl) :
       (= ($ d (glue u m ($ f m) ($ g m)))
       	 (pushout-rec [p] ($ d p) (glue u m ($ f m) ($ g m)) [x] ($ wl x) [y] ($ wr y) [v z] (@ ($ wg z) v))
 	 (@ ($ wg m) u)))
-by
+by {
   lam a b c f g d wl wr wg => abs u => lam m =>
     refine pushout/beta/glue;
     auto
-.
+}.

--- a/test/success/pushout.prl
+++ b/test/success/pushout.prl
@@ -1,16 +1,16 @@
-theorem Pushout/Test0 : 
+theorem Pushout/Test0 :
   (pushout record record bool [_] tuple [_] tuple)
 by {
   `(left tuple)
 }.
 
-theorem Pushout/Test1 : 
+theorem Pushout/Test1 :
   (pushout bool bool bool [x] x [x] x)
 by {
   `(right tt)
 }.
 
-theorem Pushout/Test2 : 
+theorem Pushout/Test2 :
   (-> dim (pushout bool bool bool [x] x [x] x))
 by {
   abs u => `(glue u tt tt tt)
@@ -19,14 +19,14 @@ by {
 define S1' = (pushout record record bool [_] tuple [_] tuple).
 
 // Someone told me the following is an equivalence
-theorem PushoutToS1 : 
+theorem PushoutToS1 :
   (-> S1' S1)
 by {
   lam p => elim p;
     [ `base
     , `base
     , with c u:dim =>
-      elim c; 
+      elim c;
       [ `(loop u)
       , `base
       ]
@@ -35,7 +35,7 @@ by {
 }.
 
 
-theorem PushoutToS1/Test0 : 
+theorem PushoutToS1/Test0 :
   (= (-> S1' S1) PushoutToS1 PushoutToS1)
 by {
   unfold PushoutToS1; // otherwise too easy
@@ -45,7 +45,7 @@ by {
   ]
 }.
 
-theorem PushoutBetaEasiest(#i:lvl) : 
+theorem PushoutBetaEasiest(#i:lvl) :
   (-> [a b c d : (U #i)] [w : d]
       [u : dim] [x : a] [y : b] [z : c]
       (= d (pushout-rec [_] d (glue u z x y) [_] w [_] w [_ _] w) w))
@@ -55,7 +55,7 @@ by {
     auto
 }.
 
-theorem PushoutBetaEasier(#i:lvl) : 
+theorem PushoutBetaEasier(#i:lvl) :
   (-> [a b c : (U #i)] [f : (-> c a)] [g : (-> c b)]
       [d : (-> (pushout a b c [z] ($ f z) [z] ($ g z)) (U #i))]
       [wl : (-> [x : a] ($ d (left x)))] [wr : (-> [y : b] ($ d (right y)))]

--- a/test/success/record.prl
+++ b/test/success/record.prl
@@ -1,4 +1,4 @@
-theorem RecordTypeTest : 
+theorem RecordTypeTest :
   (record [a : bool] [b : (path [_] bool a a)] [c : bool] [d : S1]) type
 by {
   auto
@@ -6,43 +6,43 @@ by {
 
 print RecordTypeTest.
 
-theorem RecordTest0 : 
+theorem RecordTest0 :
   tuple in record
 by {
   auto
 }.
 
-theorem RecordTest1 : 
+theorem RecordTest1 :
   (tuple [a tt]) in (record [a : bool])
 by {
   auto
 }.
 
-theorem RecordTest2 : 
+theorem RecordTest2 :
   (tuple [a tt] [b tuple]) in (record [b : record] [a : bool])
 by {
   auto
 }.
 
-theorem RecordTest3 : 
+theorem RecordTest3 :
   (tuple [a tt] [b ff]) in (record [b a : bool])
 by {
   auto
 }.
 
-theorem RecordTest4 : 
+theorem RecordTest4 :
   (! a (tuple [a tt] [b ff])) = tt in bool
 by {
   auto
 }.
 
-theorem RecordTest5(#p) : 
+theorem RecordTest5(#p) :
   (-> [p : record] (= record p tuple))
 by {
   lam _ => auto
 }.
 
-theorem RecordTest6 : 
+theorem RecordTest6 :
   (->
     [p : (record [a : bool] [b c : record])]
     bool)
@@ -50,7 +50,7 @@ by {
   lam {a = a} => use a
 }.
 
-theorem RecordTest7 : 
+theorem RecordTest7 :
   (record
    [a : S1]
    [b : (path [_] S1 a a)])
@@ -58,8 +58,8 @@ by {
   {a = `base, b = abs i => `(loop i)}
 }.
 
-theorem RecordElimTest : 
-  (-> 
+theorem RecordElimTest :
+  (->
    (record
     [b : bool]
     [c : S1]

--- a/test/success/record.prl
+++ b/test/success/record.prl
@@ -1,73 +1,73 @@
-theorem RecordTypeTest :
+theorem RecordTypeTest : 
   (record [a : bool] [b : (path [_] bool a a)] [c : bool] [d : S1]) type
-by
+by {
   auto
-.
+}.
 
 print RecordTypeTest.
 
-theorem RecordTest0 :
+theorem RecordTest0 : 
   tuple in record
-by
+by {
   auto
-.
+}.
 
-theorem RecordTest1 :
+theorem RecordTest1 : 
   (tuple [a tt]) in (record [a : bool])
-by
+by {
   auto
-.
+}.
 
-theorem RecordTest2 :
+theorem RecordTest2 : 
   (tuple [a tt] [b tuple]) in (record [b : record] [a : bool])
-by
+by {
   auto
-.
+}.
 
-theorem RecordTest3 :
+theorem RecordTest3 : 
   (tuple [a tt] [b ff]) in (record [b a : bool])
-by
+by {
   auto
-.
+}.
 
-theorem RecordTest4 :
+theorem RecordTest4 : 
   (! a (tuple [a tt] [b ff])) = tt in bool
-by
+by {
   auto
-.
+}.
 
-theorem RecordTest5(#p) :
+theorem RecordTest5(#p) : 
   (-> [p : record] (= record p tuple))
-by
+by {
   lam _ => auto
-.
+}.
 
-theorem RecordTest6 :
+theorem RecordTest6 : 
   (->
     [p : (record [a : bool] [b c : record])]
     bool)
-by
+by {
   lam {a = a} => use a
-.
+}.
 
-theorem RecordTest7 :
+theorem RecordTest7 : 
   (record
    [a : S1]
    [b : (path [_] S1 a a)])
-by
+by {
   {a = `base, b = abs i => `(loop i)}
-.
+}.
 
-theorem RecordElimTest :
+theorem RecordElimTest : 
   (-> 
    (record
     [b : bool]
     [c : S1]
     [p : (path [_] bool b b)])
    (* [b : bool] (path [_] bool b b)))
-by
+by {
   lam {b = welp, p = hello} =>
     {use welp, use hello}
-.
+}.
 
 print RecordElimTest.

--- a/test/success/record.prl
+++ b/test/success/record.prl
@@ -1,73 +1,73 @@
-Thm RecordTypeTest : [
+theorem RecordTypeTest :
   (record [a : bool] [b : (path [_] bool a a)] [c : bool] [d : S1]) type
-] by [
+by
   auto
-].
+.
 
-Print RecordTypeTest.
+print RecordTypeTest.
 
-Thm RecordTest0 : [
+theorem RecordTest0 :
   tuple in record
-] by [
+by
   auto
-].
+.
 
-Thm RecordTest1 : [
+theorem RecordTest1 :
   (tuple [a tt]) in (record [a : bool])
-] by [
+by
   auto
-].
+.
 
-Thm RecordTest2 : [
+theorem RecordTest2 :
   (tuple [a tt] [b tuple]) in (record [b : record] [a : bool])
-] by [
+by
   auto
-].
+.
 
-Thm RecordTest3 : [
+theorem RecordTest3 :
   (tuple [a tt] [b ff]) in (record [b a : bool])
-] by [
+by
   auto
-].
+.
 
-Thm RecordTest4 : [
+theorem RecordTest4 :
   (! a (tuple [a tt] [b ff])) = tt in bool
-] by [
+by
   auto
-].
+.
 
-Thm RecordTest5(#p) : [
+theorem RecordTest5(#p) :
   (-> [p : record] (= record p tuple))
-] by [
+by
   lam _ => auto
-].
+.
 
-Thm RecordTest6 : [
+theorem RecordTest6 :
   (->
     [p : (record [a : bool] [b c : record])]
     bool)
-] by [
+by
   lam {a = a} => use a
-].
+.
 
-Thm RecordTest7 : [
+theorem RecordTest7 :
   (record
    [a : S1]
    [b : (path [_] S1 a a)])
-] by [
+by
   {a = `base, b = abs i => `(loop i)}
-].
+.
 
-Thm RecordElimTest : [
+theorem RecordElimTest :
   (-> 
    (record
     [b : bool]
     [c : S1]
     [p : (path [_] bool b b)])
    (* [b : bool] (path [_] bool b b)))
-] by [
+by
   lam {b = welp, p = hello} =>
     {use welp, use hello}
-].
+.
 
-Print RecordElimTest.
+print RecordElimTest.

--- a/test/success/strict-bool.prl
+++ b/test/success/strict-bool.prl
@@ -6,19 +6,19 @@ define Bool/Not =
   (lam [x] (if [_] bool x ff tt))
 .
 
-theorem Bool/Not-Not-Id :
+theorem Bool/Not-Not-Id : 
   (Cmp Bool/Not Bool/Not) = (lam [x] x) in (-> bool bool)
-by
+by {
   auto
-.
+}.
 
-theorem SBool/Not-Not-Id-Path :
+theorem SBool/Not-Not-Id-Path : 
   (path
     [_] (-> bool bool)
     (Cmp Bool/Not Bool/Not)
     (lam [x] x))
-by
+by {
   abs i => lam x => use x
-.
+}.
 
 print SBool/Not-Not-Id-Path.

--- a/test/success/strict-bool.prl
+++ b/test/success/strict-bool.prl
@@ -1,18 +1,18 @@
-define Cmp(#m, #n) = 
+define Cmp(#m, #n) =
   (lam [x] ($ #m ($ #n x)))
 .
 
-define Bool/Not = 
+define Bool/Not =
   (lam [x] (if [_] bool x ff tt))
 .
 
-theorem Bool/Not-Not-Id : 
+theorem Bool/Not-Not-Id :
   (Cmp Bool/Not Bool/Not) = (lam [x] x) in (-> bool bool)
 by {
   auto
 }.
 
-theorem SBool/Not-Not-Id-Path : 
+theorem SBool/Not-Not-Id-Path :
   (path
     [_] (-> bool bool)
     (Cmp Bool/Not Bool/Not)

--- a/test/success/strict-bool.prl
+++ b/test/success/strict-bool.prl
@@ -1,24 +1,24 @@
-Def Cmp(#m, #n) = [
+define Cmp(#m, #n) = 
   (lam [x] ($ #m ($ #n x)))
-].
+.
 
-Def Bool/Not = [
+define Bool/Not = 
   (lam [x] (if [_] bool x ff tt))
-].
+.
 
-Thm Bool/Not-Not-Id : [
+theorem Bool/Not-Not-Id :
   (Cmp Bool/Not Bool/Not) = (lam [x] x) in (-> bool bool)
-] by [
+by
   auto
-].
+.
 
-Thm SBool/Not-Not-Id-Path : [
+theorem SBool/Not-Not-Id-Path :
   (path
     [_] (-> bool bool)
     (Cmp Bool/Not Bool/Not)
     (lam [x] x))
-] by [
+by
   abs i => lam x => use x
-].
+.
 
-Extract SBool/Not-Not-Id-Path.
+print SBool/Not-Not-Id-Path.

--- a/test/success/unfold.prl
+++ b/test/success/unfold.prl
@@ -2,20 +2,20 @@ define Times(#A, #B) =
   (* #A #B)
 .
 
-tactic Proj1(#z) = 
+tactic Proj1(#z) = {
   let {x} = #z;
   use x
-.
+}.
 
-tactic Proj2(#z) = 
+tactic Proj2(#z) = {
   let {welp, x} = #z;
   use x
-.
+}.
 
-theorem Times/Proj :
+theorem Times/Proj : 
   (-> [ty : (U 0)] (Times bool ty) ty)
-by
+by {
   lam ty x => (Proj2 x)
-.
+}.
 
 print Times/Proj.

--- a/test/success/unfold.prl
+++ b/test/success/unfold.prl
@@ -1,21 +1,21 @@
-Def Times(#A, #B) = [
+define Times(#A, #B) = 
   (* #A #B)
-].
+.
 
-Tac Proj1(#z) = [
+tactic Proj1(#z) = 
   let {x} = #z;
   use x
-].
+.
 
-Tac Proj2(#z) = [
+tactic Proj2(#z) = 
   let {welp, x} = #z;
   use x
-].
+.
 
-Thm Times/Proj : [
+theorem Times/Proj :
   (-> [ty : (U 0)] (Times bool ty) ty)
-] by [
+by
   lam ty x => (Proj2 x)
-].
+.
 
-Extract Times/Proj.
+print Times/Proj.

--- a/test/success/unfold.prl
+++ b/test/success/unfold.prl
@@ -1,4 +1,4 @@
-define Times(#A, #B) = 
+define Times(#A, #B) =
   (* #A #B)
 .
 
@@ -12,7 +12,7 @@ tactic Proj2(#z) = {
   use x
 }.
 
-theorem Times/Proj : 
+theorem Times/Proj :
   (-> [ty : (U 0)] (Times bool ty) ty)
 by {
   lam ty x => (Proj2 x)

--- a/test/success/universes.prl
+++ b/test/success/universes.prl
@@ -1,16 +1,16 @@
-theorem Univ0(#i:lvl, #j:lvl) : 
+theorem Univ0(#i:lvl, #j:lvl) :
   (U #i) in (U (++ (lmax #i #j)))
 by {
   auto
 }.
 
-theorem Univ1(#i:lvl) : 
+theorem Univ1(#i:lvl) :
   nat in (U #i discrete)
 by {
   auto
 }.
 
-theorem Univ2 : 
+theorem Univ2 :
   (->
    [a : (U 0 discrete)]
    (= (U 1 kan) a a))

--- a/test/success/universes.prl
+++ b/test/success/universes.prl
@@ -1,24 +1,24 @@
-theorem Univ0(#i:lvl, #j:lvl) :
+theorem Univ0(#i:lvl, #j:lvl) : 
   (U #i) in (U (++ (lmax #i #j)))
-by
+by {
   auto
-.
+}.
 
-theorem Univ1(#i:lvl) :
+theorem Univ1(#i:lvl) : 
   nat in (U #i discrete)
-by
+by {
   auto
-.
+}.
 
-theorem Univ2 :
+theorem Univ2 : 
   (->
    [a : (U 0 discrete)]
    (= (U 1 kan) a a))
-by
+by {
   lam a => auto
-.
+}.
 
-theorem Monoid(#i:lvl) : (U (++ #i))  by
+theorem Monoid(#i:lvl) :  (U (++ #i)) by {
   `(record
     [ob : (U #i)]
     [one : ob]
@@ -31,6 +31,6 @@ theorem Monoid(#i:lvl) : (U (++ #i))  by
       (= ob
          ($ mul l ($ mul m n))
          ($ mul ($ mul m n) l)))])
-.
+}.
 
 print Monoid.

--- a/test/success/universes.prl
+++ b/test/success/universes.prl
@@ -1,24 +1,24 @@
-Thm Univ0(#i:lvl, #j:lvl) : [
+theorem Univ0(#i:lvl, #j:lvl) :
   (U #i) in (U (++ (lmax #i #j)))
-] by [
+by
   auto
-].
+.
 
-Thm Univ1(#i:lvl) : [
+theorem Univ1(#i:lvl) :
   nat in (U #i discrete)
-] by [
+by
   auto
-].
+.
 
-Thm Univ2 : [
+theorem Univ2 :
   (->
    [a : (U 0 discrete)]
    (= (U 1 kan) a a))
-] by [
+by
   lam a => auto
-].
+.
 
-Thm Monoid(#i:lvl) : [ (U (++ #i)) ] by [
+theorem Monoid(#i:lvl) : (U (++ #i))  by
   `(record
     [ob : (U #i)]
     [one : ob]
@@ -31,6 +31,6 @@ Thm Monoid(#i:lvl) : [ (U (++ #i)) ] by [
       (= ob
          ($ mul l ($ mul m n))
          ($ mul ($ mul m n) l)))])
-].
+.
 
-Print Monoid.
+print Monoid.

--- a/test/wip/adjointify.prl
+++ b/test/wip/adjointify.prl
@@ -1,63 +1,63 @@
-Def HasAllPaths(#C) = [
+define HasAllPaths(#C) = 
   (->
    [c c' : #C]
    (path [_] #C c c'))
-].
+.
 
-Def IsContr(#C) = [
+define IsContr(#C) = 
   (record
    [point : #C]
    [rays : (HasAllPaths #C)])
-].
+.
 
-Def Fiber(#A,#B,#f,#b) = [
+define Fiber(#A,#B,#f,#b) = 
   (record
    [point : #A]
    [ray : (path [_] #B ($ #f point) #b)])
-].
+.
 
-Def IsEquiv(#A,#B,#f) = [
+define IsEquiv(#A,#B,#f) = 
   (->
    [b : #B]
    (IsContr (Fiber #A #B #f b)))
-].
+.
 
-Def Equiv(#A,#B) = [
+define Equiv(#A,#B) = 
   (record
    [to : (-> #A #B)]
    [to/equiv : (IsEquiv #A #B to)])
-].
+.
 
 
-Def Iso(#A, #B) = [
+define Iso(#A, #B) = 
   (record
    [to : (-> #A #B)]
    [from : (-> #B #A)]
    [coh1 : (-> [b : #B] (path [_] #B ($ to ($ from b)) b))]
    [coh2 : (-> [a : #A] (path [_] #A ($ from ($ to a)) a))])
-].
+.
 
-Thm Path/Symm(#l:lvl) : [
+theorem Path/Symm(#l:lvl) :
  (->
   [ty : (U #l kan)]
   [a b : ty]
   (path [_] ty a b)
   (path [_] ty b a))
-] by [
+by
  lam ty, a, b, pab.
    <i>
      `(hcom 0~>1 ty a
        [i=0 [j] (@ pab j)]
        [i=1 [_] a])
-].
+.
 
-Thm Adointify(#l:lvl) : [
+theorem Adointify(#l:lvl) :
   (->
    [ty1 : (U #l kan)]
    [ty2 : (U #l kan)]
    (Iso ty1 ty2)
    (Equiv ty1 ty2))
-] by [
+by
   lam ty1, ty2, {to=to, from=from, coh1=coh1, coh2=coh2}.
     {to = use to,
      to/equiv =
@@ -68,28 +68,28 @@ Thm Adointify(#l:lvl) : [
           rays =
             lam {point = point1, ray = r1}, {point = point2, ray = r2}.
 
-              let alpha : [ (path [_] ty1 ($ from b) ($ from ($ to point1))) ] =
+              let alpha : (path [_] ty1 ($ from b) ($ from ($ to point1))) ] =
                 use (Path/Symm #l)
                   [use ty1,
                    use from [use to [use point1]],
                    use from [use b],
-                   <i> use from [use r1 [`i]]].
+                   <i> use from [use r1 [`i]].
 
-              let beta : [ (path [_] ty1 ($ from b) ($ from ($ to point2))) ] =
+              let beta : (path [_] ty1 ($ from b) ($ from ($ to point2))) ] =
                 use (Path/Symm #l)
                   [use ty1,
                    use from [use to [use point2]],
                    use from [use b],
-                   <i> use from [use r2 [`i]]].
+                   <i> use from [use r2 [`i]].
 
 
-              let gamma : [ (path [_] ty1 ($ from ($ to point1)) ($ from ($ to point2))) ] =
+              let gamma : (path [_] ty1 ($ from ($ to point1)) ($ from ($ to point2))) ] =
                 <i>
                   `(hcom 0~>1 ty1 ($ from b)
                     [i=0 [j] (@ alpha j)]
                     [i=1 [j] (@ beta j)]).
 
-              let point12 : [ (path [_] ty1 point1 point2) ] =
+              let point12 : (path [_] ty1 point1 point2) ] =
                 <i>
                   `(hcom 0~>1 ty1 (@ gamma i)
                     [i=0 [j] (@ ($ coh2 point1) j)]
@@ -98,9 +98,9 @@ Thm Adointify(#l:lvl) : [
 
               <i>
 
-               let welp : [ (path [_] ty1 (@ point12 i) point1) ] =
+               let welp : (path [_] ty1 (@ point12 i) point1) ] =
                  id.
 
                {point = use point12 [`i],
                 ray = ?}}}
-].
+.

--- a/test/wip/adjointify.prl
+++ b/test/wip/adjointify.prl
@@ -37,27 +37,27 @@ define Iso(#A, #B) =
    [coh2 : (-> [a : #A] (path [_] #A ($ from ($ to a)) a))])
 .
 
-theorem Path/Symm(#l:lvl) :
+theorem Path/Symm(#l:lvl) : 
  (->
   [ty : (U #l kan)]
   [a b : ty]
   (path [_] ty a b)
   (path [_] ty b a))
-by
+by {
  lam ty, a, b, pab.
    <i>
      `(hcom 0~>1 ty a
        [i=0 [j] (@ pab j)]
        [i=1 [_] a])
-.
+}.
 
-theorem Adointify(#l:lvl) :
+theorem Adointify(#l:lvl) : 
   (->
    [ty1 : (U #l kan)]
    [ty2 : (U #l kan)]
    (Iso ty1 ty2)
    (Equiv ty1 ty2))
-by
+by {
   lam ty1, ty2, {to=to, from=from, coh1=coh1, coh2=coh2}.
     {to = use to,
      to/equiv =
@@ -68,28 +68,28 @@ by
           rays =
             lam {point = point1, ray = r1}, {point = point2, ray = r2}.
 
-              let alpha : (path [_] ty1 ($ from b) ($ from ($ to point1))) ] =
+              let alpha : [ (path [_] ty1 ($ from b) ($ from ($ to point1))) ] =
                 use (Path/Symm #l)
                   [use ty1,
                    use from [use to [use point1]],
                    use from [use b],
-                   <i> use from [use r1 [`i]].
+                   <i> use from [use r1 [`i]]}.
 
-              let beta : (path [_] ty1 ($ from b) ($ from ($ to point2))) ] =
+              let beta : [ (path [_] ty1 ($ from b) ($ from ($ to point2))) ] =
                 use (Path/Symm #l)
                   [use ty1,
                    use from [use to [use point2]],
                    use from [use b],
-                   <i> use from [use r2 [`i]].
+                   <i> use from [use r2 [`i]]].
 
 
-              let gamma : (path [_] ty1 ($ from ($ to point1)) ($ from ($ to point2))) ] =
+              let gamma : [ (path [_] ty1 ($ from ($ to point1)) ($ from ($ to point2))) ] =
                 <i>
                   `(hcom 0~>1 ty1 ($ from b)
                     [i=0 [j] (@ alpha j)]
                     [i=1 [j] (@ beta j)]).
 
-              let point12 : (path [_] ty1 point1 point2) ] =
+              let point12 : [ (path [_] ty1 point1 point2) ] =
                 <i>
                   `(hcom 0~>1 ty1 (@ gamma i)
                     [i=0 [j] (@ ($ coh2 point1) j)]
@@ -98,9 +98,9 @@ by
 
               <i>
 
-               let welp : (path [_] ty1 (@ point12 i) point1) ] =
+               let welp : [ (path [_] ty1 (@ point12 i) point1) ] =
                  id.
 
                {point = use point12 [`i],
                 ray = ?}}}
-.
+].

--- a/test/wip/adjointify.prl
+++ b/test/wip/adjointify.prl
@@ -1,35 +1,35 @@
-define HasAllPaths(#C) = 
+define HasAllPaths(#C) =
   (->
    [c c' : #C]
    (path [_] #C c c'))
 .
 
-define IsContr(#C) = 
+define IsContr(#C) =
   (record
    [point : #C]
    [rays : (HasAllPaths #C)])
 .
 
-define Fiber(#A,#B,#f,#b) = 
+define Fiber(#A,#B,#f,#b) =
   (record
    [point : #A]
    [ray : (path [_] #B ($ #f point) #b)])
 .
 
-define IsEquiv(#A,#B,#f) = 
+define IsEquiv(#A,#B,#f) =
   (->
    [b : #B]
    (IsContr (Fiber #A #B #f b)))
 .
 
-define Equiv(#A,#B) = 
+define Equiv(#A,#B) =
   (record
    [to : (-> #A #B)]
    [to/equiv : (IsEquiv #A #B to)])
 .
 
 
-define Iso(#A, #B) = 
+define Iso(#A, #B) =
   (record
    [to : (-> #A #B)]
    [from : (-> #B #A)]
@@ -37,7 +37,7 @@ define Iso(#A, #B) =
    [coh2 : (-> [a : #A] (path [_] #A ($ from ($ to a)) a))])
 .
 
-theorem Path/Symm(#l:lvl) : 
+theorem Path/Symm(#l:lvl) :
  (->
   [ty : (U #l kan)]
   [a b : ty]
@@ -51,7 +51,7 @@ by {
        [i=1 [_] a])
 }.
 
-theorem Adointify(#l:lvl) : 
+theorem Adointify(#l:lvl) :
   (->
    [ty1 : (U #l kan)]
    [ty2 : (U #l kan)]

--- a/test/wip/contractibility.prl
+++ b/test/wip/contractibility.prl
@@ -1,20 +1,20 @@
-Def IsProp(#A) = [
+define IsProp(#A) = 
   (-> [x y : #A] (path [_] #A x y))
-].
+.
 
-Def IsContr(#A) = [
+define IsContr(#A) = 
   (* [x : #A] (-> [y : #A] (path [_] #A x y)))
-].
+.
 
 
-Thm Prop/IsContr : [
+theorem Prop/IsContr :
   (-> [ty : (U 0 kan)] (IsProp (IsContr ty)))
-] by [
+by
   lam ty, {b1,r1}, {b2,r2}.
 
-  let r1r2 : [(path [i] (-> [y:ty] (path [_] ty (@ ($ r1 b2) i) y)) r1 r2)] =
+  let r1r2 :(path [i] (-> [y:ty] (path [_] ty (@ ($ r1 b2) i) y)) r1 r2)] =
     <i> lam y. ?what-do-i-do.
 
   <i> {use r1 [use b2, use i],
        lam x. use r1r2 [use i, use x]}
-].
+.

--- a/test/wip/contractibility.prl
+++ b/test/wip/contractibility.prl
@@ -1,13 +1,13 @@
-define IsProp(#A) = 
+define IsProp(#A) =
   (-> [x y : #A] (path [_] #A x y))
 .
 
-define IsContr(#A) = 
+define IsContr(#A) =
   (* [x : #A] (-> [y : #A] (path [_] #A x y)))
 .
 
 
-theorem Prop/IsContr : 
+theorem Prop/IsContr :
   (-> [ty : (U 0 kan)] (IsProp (IsContr ty)))
 by {
   lam ty, {b1,r1}, {b2,r2}.

--- a/test/wip/contractibility.prl
+++ b/test/wip/contractibility.prl
@@ -7,14 +7,14 @@ define IsContr(#A) =
 .
 
 
-theorem Prop/IsContr :
+theorem Prop/IsContr : 
   (-> [ty : (U 0 kan)] (IsProp (IsContr ty)))
-by
+by {
   lam ty, {b1,r1}, {b2,r2}.
 
-  let r1r2 :(path [i] (-> [y:ty] (path [_] ty (@ ($ r1 b2) i) y)) r1 r2)] =
+  let r1r2 : [(path [i] (-> [y:ty] (path [_] ty (@ ($ r1 b2) i) y)) r1 r2)] =
     <i> lam y. ?what-do-i-do.
 
   <i> {use r1 [use b2, use i],
        lam x. use r1r2 [use i, use x]}
-.
+}.

--- a/vim/syntax/redprl.vim
+++ b/vim/syntax/redprl.vim
@@ -10,7 +10,7 @@ endif
 setlocal iskeyword+=-
 setlocal iskeyword+=/
 
-syn keyword redDecl Def Extract Print Rule Tac Thm Quit
+syn keyword redDecl define print theorem tactic quit extract
 syn keyword redSort dim hyp exp lvl tac jdg knd
 syn match   redHole '?\(\a\|\d\|\'\|\/\|\-\)*'
 syn match   redMeta '#'


### PR DESCRIPTION
Resolves #645 

1. polish metalanguage elaborator
2. new concrete notation for RedPRL signatures
3. start parsing RedML code in RedPRL signatures directly; see `example/metalanguage.prl`


TODO:

- [x] update vim mode
- [x] update docs
- [x] update pygments lexer