### PR TITLE
Fix bugs in Pygments lexer.

### DIFF
--- a/doc/src/redprl.py
+++ b/doc/src/redprl.py
@@ -11,13 +11,13 @@ class RedPRLLexer(RegexLexer):
     aliases = ['redprl']
     filenames = ['*.prl']
 
-    exprs = ['ax', 'fcom', 'bool', 'tt', 'ff', 'if', 'nat-rec', 'nat', 'zero', 'succ',
-             'nat-rec', 'int', 'negsucc', 'int-rec', 'void', 'S1', 'base',
-             'loop', 'S1-rec', 'lam', 'record', 'tuple', 'path', 'line',
-             'pushout', 'left', 'right', 'glue', 'pushout-rec', 'coeq', 'cecod',
-             'cedom', 'coeq-rec', 'mem', 'ni', 'box', 'cap', 'V', 'VV', 'WU',
-             'Vin', 'Vproj', 'U', 'abs', 'hcom', 'com', 'ghcom', 'gcom', 'coe',
-             'lmax', 'omega']
+    exprs = ['ax', 'fcom', 'bool', 'tt', 'ff', 'if', 'nat-rec', 'nat', 'zero',
+             'succ', 'int-rec', 'int', 'negsucc', 'void', 'S1-rec', 'S1',
+             'base', 'loop', 'lam', 'record', 'tuple', 'path', 'line',
+             'pushout-rec', 'pushout', 'left', 'right', 'glue', 'coeq-rec',
+             'coeq', 'cecod', 'cedom', 'mem', 'ni', 'box', 'cap', 'V', 'VV',
+             'WU', 'Vin', 'Vproj', 'U', 'abs', 'hcom', 'com', 'ghcom', 'gcom',
+             'coe', 'lmax', 'omega']
     tacs = ['auto', 'auto-step', 'case', 'cut-lemma', 'elim', 'else', 'exact',
             'goal', 'hyp', 'id', 'lemma', 'let', 'claim', 'match', 'of',
             'print', 'trace', 'progress', 'query', 'reduce', 'refine', 'repeat',
@@ -49,7 +49,7 @@ class RedPRLLexer(RegexLexer):
 
             ('|\\b'.join(misc), Name.Builtin),
 
-            (r'\#', Comment), # hack
+            (r'\#[a-zA-Z0-9\'/-]*', Name.Variable),
 
             (r'\(|\)|\[|\]|\.|:|,|\{|\}|_', Punctuation),
             (r'\b\d+', Number),


### PR DESCRIPTION
Fixing some bugs in the Pygments lexer that I noticed while looking through #656. Namely, `foo-rec` operators and metavariables whose names start with keywords were not being highlighted correctly.