### PR TITLE
Rename refinement rules for V types.

### DIFF
--- a/doc/src/refine.rst
+++ b/doc/src/refine.rst
@@ -756,7 +756,7 @@ Composite types
 V types
 -------
 
-:index:`V/eqtype`
+:index:`v/eqtype`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
@@ -781,7 +781,7 @@ where ``Equiv`` is defined by
   define IsEquiv (#A,#B,#f) = (-> [b : #B] (IsContr (Fiber #A #B #f b))).
   define Equiv (#A,#B) = (* [f : (-> #A #B)] (IsEquiv #A #B f)).
 
-:index:`V/eq/uain`
+:index:`v/eq/vin`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
@@ -791,7 +791,7 @@ where ``Equiv`` is defined by
   | H, #r=0 >> ($ (! proj1 #e) #m0) = #n0 in #b
   | H, #r=0 >> #e in (Equiv #a #b)
 
-:index:`V/intro`
+:index:`v/intro`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
@@ -801,7 +801,7 @@ where ``Equiv`` is defined by
   | H, #r=0 >> ($ (! proj1 #e) #m) = #n in #b
   | H, #r=0 >> #e in (Equiv #a #b)
 
-:index:`V/eq/proj`
+:index:`v/eq/proj`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 

--- a/src/redprl/refiner.fun
+++ b/src/redprl/refiner.fun
@@ -272,10 +272,10 @@ struct
      | "fcom/eq/box" => Lcf.rule FormalComposition.Eq
      | "fcom/intro" => Lcf.rule FormalComposition.True
      | "ecom/eqtype" => Lcf.rule EmptyComposition.EqType
-     | "V/eqtype" => Lcf.rule V.EqType
-     | "V/eq/uain" => Lcf.rule V.Eq
-     | "V/intro" => Lcf.rule V.True
-     | "V/eq/proj" => Lcf.rule @@ V.EqProj sign
+     | "v/eqtype" => Lcf.rule V.EqType
+     | "v/eq/vin" => Lcf.rule V.Eq
+     | "v/intro" => Lcf.rule V.True
+     | "v/eq/proj" => Lcf.rule @@ V.EqProj sign
      | "universe/eqtype" => Lcf.rule Universe.EqType
      | "hcom/eq" => Lcf.rule HCom.Eq
      | "hcom/eq/cap" => Lcf.rule HCom.EqCapL


### PR DESCRIPTION
It turns out nobody had ever tried to invoke a refinement rule for V types before today, because they were impossible to invoke. Let's see if you can spot the issue:

in the lexer:
```
<INITIAL>{lower}{identChr}* => (Tokens.VARNAME (posTupleWith (size yytext) yytext));
```
in the parser:
```
atomicRawTac
  : REFINE VARNAME (Ast.$$ (O.RULE_PRIM VARNAME, []))
```
in the refinement rule lookup:
```
     | "V/eqtype" => Lcf.rule V.EqType
```